### PR TITLE
fix go e2e consistency test failed

### DIFF
--- a/tests/consistency_test.go
+++ b/tests/consistency_test.go
@@ -29,7 +29,7 @@ var (
 	leader    *redis.Client
 )
 
-var _ = XDescribe("Consistency [Skipped]", Ordered, func() {
+var _ = Describe("Consistency", Ordered, func() {
 	var (
 		ctx     = context.TODO()
 		servers []*util.Server

--- a/tests/key_test.go
+++ b/tests/key_test.go
@@ -429,7 +429,7 @@ var _ = Describe("Keyspace", Ordered, func() {
 		Expect(client.Do(ctx, "pexpire", DefaultKey, "err").Err()).To(MatchError("ERR value is not an integer or out of range"))
 	})
 
-	PIt("should Rename", func() {
+	It("should Rename", func() {
 		client.Set(ctx, "mykey", "hello", 0)
 		client.Rename(ctx, "mykey", "mykey1")
 		client.Rename(ctx, "mykey1", "mykey2")
@@ -450,7 +450,7 @@ var _ = Describe("Keyspace", Ordered, func() {
 		Expect(client.TTL(ctx, "mykey2").Val()).To(Equal(-1 * time.Nanosecond))
 	})
 
-	PIt("should RenameNX", func() {
+	It("should RenameNX", func() {
 		client.Del(ctx, "mykey", "mykey1", "mykey2")
 		client.Set(ctx, "mykey", "hello", 0)
 		client.RenameNX(ctx, "mykey", "mykey1")


### PR DESCRIPTION
#181 
At present, both consistency test and keyspace test can be completely passed, that is, all go e2e tests can be passed. The local test results are as follows:
![image](https://github.com/user-attachments/assets/7ca2eeee-f58a-4923-9a1c-13cc4bbb52ba)
