### PR TITLE
fix: lru ci error

### DIFF
--- a/src/storage/lru_cache.rs
+++ b/src/storage/lru_cache.rs
@@ -105,6 +105,10 @@ where
         }
     }
 
+    fn default() -> Self {
+        Self::new()
+    }
+
     /// Create a LRUCache with capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         let origin = Box::leak(Box::new(Chain::new())).into();

--- a/src/storage/lru_cache.rs
+++ b/src/storage/lru_cache.rs
@@ -85,6 +85,16 @@ fn cut_out(cache: NonNull<Chain>) {
     unsafe { connect(cache.as_ref().prev, cache.as_ref().next) }
 }
 
+impl<K, V> Default for LRUCache<K, V>
+where
+    K: std::hash::Hash + Eq + Clone,
+    V: Clone,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<K, V> LRUCache<K, V>
 where
     K: std::hash::Hash + Eq + Clone,
@@ -103,10 +113,6 @@ where
             size: 0,
             origin,
         }
-    }
-
-    fn default() -> Self {
-        Self::new()
     }
 
     /// Create a LRUCache with capacity.


### PR DESCRIPTION
ci警告，要求lru_cache实现default trait

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a default configuration option for the caching mechanism, allowing users to quickly instantiate it without specifying parameters for improved ease-of-use while maintaining all existing behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->