### PR TITLE
feat: StringValueFormat & BaseMetaFilter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,9 +245,11 @@ dependencies = [
 name = "kiwi-rs"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "chrono",
  "log",
  "rocksdb",
+ "thiserror",
 ]
 
 [[package]]
@@ -453,6 +461,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,7 @@ edition = "2024"
 
 [dependencies]
 rocksdb = "0.23.0"
-chrono = "0.4.40"
 log = "0.4"
+bytes = "1"
+chrono = "0.4.40"
+thiserror = "1.0"

--- a/src/storage/base_filter.rs
+++ b/src/storage/base_filter.rs
@@ -108,7 +108,7 @@ mod tests {
 
         let string_val: &'static [u8] = b"filter_val";
         let mut string_val = crate::storage::strings_value_format::StringValue::new(string_val);
-        let ttl = 1_000_000; 
+        let ttl = 1_000_000;
         crate::storage::base_value_format::InternalValue::set_relative_timestamp(
             &mut string_val,
             ttl,

--- a/src/storage/base_filter.rs
+++ b/src/storage/base_filter.rs
@@ -54,7 +54,7 @@ impl CompactionFilter for BaseMetaFilter {
             Ok(dt) => dt,
             Err(_) => {
                 debug!(
-                    "BaseMetaFilter: Invalid data type byte {} for key {:?}, remove",
+                    "BaseMetaFilter: Invalid data type byte {} for key {:?}, remove.",
                     value[0],
                     parsed_key.key()
                 );

--- a/src/storage/base_filter.rs
+++ b/src/storage/base_filter.rs
@@ -1,0 +1,133 @@
+// Copyright 2024 The Kiwi-rs Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+use chrono::Utc;
+use log::debug;
+use rocksdb::{
+    CompactionDecision, compaction_filter::CompactionFilter,
+    compaction_filter_factory::CompactionFilterFactory,
+};
+
+use crate::storage::{
+    base_key_format::ParsedBaseKey,
+    base_value_format::{DataType, ParsedInternalValue},
+    strings_value_format::ParsedStringsValue,
+};
+
+#[derive(Debug, Default)]
+pub struct BaseMetaFilter;
+
+#[derive(Debug, Default)]
+pub struct BaseMetaFilterFactory;
+
+impl CompactionFilter for BaseMetaFilter {
+    fn name(&self) -> &std::ffi::CStr {
+        c"BaseMetaFilter"
+    }
+
+    fn filter(&mut self, _level: u32, key: &[u8], value: &[u8]) -> CompactionDecision {
+        let current_time = Utc::now().timestamp_micros() as u64;
+
+        let parsed_key = ParsedBaseKey::new(key);
+
+        if value.is_empty() {
+            debug!(
+                "BaseMetaFilter: Value for key {:?} is empty, remove.",
+                parsed_key.key()
+            );
+            return CompactionDecision::Remove;
+        }
+
+        let data_type = match DataType::try_from(value[0]) {
+            Ok(dt) => dt,
+            Err(_) => {
+                debug!(
+                    "BaseMetaFilter: Invalid data type byte {} for key {:?}, remove",
+                    value[0],
+                    parsed_key.key()
+                );
+                return CompactionDecision::Remove;
+            }
+        };
+        match data_type {
+            DataType::String => match ParsedStringsValue::new(value) {
+                Ok(pv) => pv.filter_decision(current_time),
+                Err(e) => {
+                    debug!(
+                        "BaseMetaFilter: Failed to parse Strings value for key {:?}: {}, remove.",
+                        parsed_key.key(),
+                        e
+                    );
+                    CompactionDecision::Remove
+                }
+            },
+            DataType::List => {
+                todo!()
+            }
+            _ => {
+                todo!()
+            }
+        }
+    }
+}
+
+impl CompactionFilterFactory for BaseMetaFilterFactory {
+    type Filter = BaseMetaFilter;
+
+    fn create(
+        &mut self,
+        _context: rocksdb::compaction_filter_factory::CompactionFilterContext,
+    ) -> Self::Filter {
+        BaseMetaFilter
+    }
+
+    fn name(&self) -> &std::ffi::CStr {
+        c"BaseMetaFilterFactory"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strings_filter() {
+        let mut filter = BaseMetaFilter::default();
+
+        let string_val: &'static [u8] = b"filter_val";
+        let mut string_val = crate::storage::strings_value_format::StringValue::new(string_val);
+        let ttl = 1_000_000;
+        crate::storage::base_value_format::InternalValue::set_relative_timestamp(
+            &mut string_val,
+            ttl,
+        );
+
+        let decision = filter.filter(
+            0,
+            b"filter_key",
+            &crate::storage::base_value_format::InternalValue::encode(&string_val),
+        );
+        assert!(matches!(decision, CompactionDecision::Keep));
+
+        std::thread::sleep(std::time::Duration::from_secs(2));
+
+        let decision = filter.filter(
+            0,
+            b"filter_key",
+            &crate::storage::base_value_format::InternalValue::encode(&string_val),
+        );
+        assert!(matches!(decision, CompactionDecision::Remove));
+    }
+}

--- a/src/storage/base_filter.rs
+++ b/src/storage/base_filter.rs
@@ -108,7 +108,7 @@ mod tests {
 
         let string_val: &'static [u8] = b"filter_val";
         let mut string_val = crate::storage::strings_value_format::StringValue::new(string_val);
-        let ttl = 1_000_000; // 1 秒 = 1,000,000 微秒
+        let ttl = 1_000_000; 
         crate::storage::base_value_format::InternalValue::set_relative_timestamp(
             &mut string_val,
             ttl,

--- a/src/storage/base_filter.rs
+++ b/src/storage/base_filter.rs
@@ -108,7 +108,7 @@ mod tests {
 
         let string_val: &'static [u8] = b"filter_val";
         let mut string_val = crate::storage::strings_value_format::StringValue::new(string_val);
-        let ttl = 1_000_000;
+        let ttl = 1_000_000; // 1 秒 = 1,000,000 微秒
         crate::storage::base_value_format::InternalValue::set_relative_timestamp(
             &mut string_val,
             ttl,

--- a/src/storage/coding.rs
+++ b/src/storage/coding.rs
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+/// TODO: remove allow dead code
+#[allow(dead_code)]
 pub trait FixedInt: Copy {
     /// convert self to little-endian bytes
     fn to_le_bytes(self) -> Vec<u8>;
@@ -61,6 +63,8 @@ impl_fixed_int_32!(i32, u32);
 impl_fixed_int_64!(i64, u64);
 
 /// encode a fixed-width int into a byte buffer
+/// TODO: remove allow dead code
+#[allow(dead_code)]
 #[inline]
 pub fn encode_fixed<T: FixedInt>(buf: *mut u8, value: T) {
     let size = T::byte_size();
@@ -70,6 +74,8 @@ pub fn encode_fixed<T: FixedInt>(buf: *mut u8, value: T) {
 }
 
 /// decode a fixed-width int from a byte buffer
+/// TODO: remove allow dead code
+#[allow(dead_code)]
 #[inline]
 pub fn decode_fixed<T: FixedInt>(buf: *mut u8) -> T {
     let size = T::byte_size();

--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -17,6 +17,8 @@
 use std::io;
 use thiserror::Error;
 
+/// TODO: remove allow dead code
+#[allow(dead_code)]
 #[derive(Error, Debug)]
 pub enum StorageError {
     #[error("IO error: {0}")]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -12,14 +12,17 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-mod base_data_value_format;
+// mod base_data_value_format;
+mod base_filter;
 mod base_key_format;
 mod base_value_format;
 mod coding;
+mod error;
 mod lru_cache;
 mod options;
 mod slot_indexer;
 mod storage_define;
 mod storage_murmur3;
+mod strings_value_format;
 
 // pub mod storage;

--- a/src/storage/storage_define.rs
+++ b/src/storage/storage_define.rs
@@ -21,7 +21,7 @@ pub const SUFFIX_RESERVE_LENGTH: usize = 16;
 // const LIST_VALUE_INDEX_LENGTH: usize = 16;
 
 // used to store a fixed-size value for the Type field.
-// const TYPE_LENGTH: usize = 1;
+pub const TYPE_LENGTH: usize = 1;
 pub const TIMESTAMP_LENGTH: usize = 8;
 
 // TODO: maybe we can change \u{0000} to \0,
@@ -30,6 +30,8 @@ pub const NEED_TRANSFORM_CHARACTER: char = '\u{0000}';
 const ENCODED_TRANSFORM_CHARACTER: &str = "\u{0000}\u{0001}";
 const ENCODED_KEY_DELIM: &str = "\u{0000}\u{0000}";
 pub const ENCODED_KEY_DELIM_SIZE: usize = 2;
+
+pub const STRING_VALUE_SUFFIXLENGTH: usize = 2 * TIMESTAMP_LENGTH + SUFFIX_RESERVE_LENGTH;
 
 /// Encode user key
 ///

--- a/src/storage/strings_value_format.rs
+++ b/src/storage/strings_value_format.rs
@@ -1,0 +1,152 @@
+// Copyright 2024 The Kiwi-rs Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+use super::base_value_format::DataType;
+use super::base_value_format::InternalValue;
+use super::base_value_format::ParsedInternalValue;
+use super::error::Result;
+use super::storage_define::{
+    STRING_VALUE_SUFFIXLENGTH, SUFFIX_RESERVE_LENGTH, TIMESTAMP_LENGTH, TYPE_LENGTH,
+};
+use bytes::Buf;
+use bytes::BufMut;
+use bytes::Bytes;
+use bytes::BytesMut;
+use chrono::Utc;
+use std::ops::Range;
+
+/*
+ * | type | value | reserve | cdate | timestamp |
+ * |  1B  |       |   16B   |   8B  |     8B    |
+ */
+
+#[derive(Debug, Clone)]
+pub struct StringValue {
+    user_value: Bytes,
+    etime: u64,
+    ctime: u64,
+}
+
+impl StringValue {
+    /// TODO: remove allow dead code
+    #[allow(dead_code)]
+    pub fn new<T>(user_value: T) -> Self
+    where
+        T: Into<Bytes>,
+    {
+        Self {
+            user_value: user_value.into(),
+            etime: 0,
+            ctime: Utc::now().timestamp_micros() as u64,
+        }
+    }
+}
+
+impl InternalValue for StringValue {
+    fn encode(&self) -> BytesMut {
+        let needed =
+            TYPE_LENGTH + self.user_value.len() + SUFFIX_RESERVE_LENGTH + 2 * TIMESTAMP_LENGTH;
+
+        let mut buf = BytesMut::with_capacity(needed);
+        buf.put_u8(DataType::String as u8);
+        buf.put_slice(&self.user_value);
+        buf.put_bytes(0, SUFFIX_RESERVE_LENGTH);
+        buf.put_u64_le(self.ctime);
+        buf.put_u64_le(self.etime);
+
+        buf
+    }
+
+    fn set_etime(&mut self, etime: u64) {
+        self.etime = etime;
+    }
+
+    fn set_ctime(&mut self, ctime: u64) {
+        self.ctime = ctime;
+    }
+
+    fn set_relative_timestamp(&mut self, ttl: u64) {
+        self.etime = Utc::now().timestamp_micros() as u64 + ttl;
+    }
+}
+
+pub struct ParsedStringsValue {
+    data: Bytes,
+    user_value_range: Range<usize>,
+    reserve_range: Range<usize>,
+    data_type: DataType,
+    ctime: u64,
+    etime: u64,
+}
+
+impl<'a> ParsedInternalValue<'a> for ParsedStringsValue {
+    fn new(input_data: &'a [u8]) -> Result<Self> {
+        debug_assert!(input_data.len() >= STRING_VALUE_SUFFIXLENGTH);
+
+        let data = Bytes::copy_from_slice(input_data);
+        let data_type = DataType::try_from(data[0])?;
+
+        let user_value_len = data.len() - TYPE_LENGTH - STRING_VALUE_SUFFIXLENGTH;
+        let user_value_start = TYPE_LENGTH;
+        let user_value_end = user_value_start + user_value_len;
+        let user_value_range = user_value_start..user_value_end;
+
+        let suffix_start = user_value_end;
+        let reserve_start = suffix_start;
+        let reserve_end = reserve_start + SUFFIX_RESERVE_LENGTH;
+        let reserve_range = reserve_start..reserve_end;
+
+        let mut time_reader = &data[reserve_end..];
+        debug_assert!(time_reader.len() >= 2 * TIMESTAMP_LENGTH);
+        let ctime = time_reader.get_u64_le();
+        let etime = time_reader.get_u64_le();
+
+        Ok(ParsedStringsValue {
+            data,
+            data_type,
+            user_value_range,
+            reserve_range,
+            ctime,
+            etime,
+        })
+    }
+
+    fn data_type(&self) -> DataType {
+        self.data_type
+    }
+
+    fn user_value(&self) -> &[u8] {
+        &self.data[self.user_value_range.clone()]
+    }
+
+    fn ctime(&self) -> u64 {
+        self.ctime
+    }
+
+    fn etime(&self) -> u64 {
+        self.etime
+    }
+
+    fn reserve(&self) -> &[u8] {
+        &self.data[self.reserve_range.clone()]
+    }
+
+    fn filter_decision(&self, current_time: u64) -> rocksdb::CompactionDecision {
+        if self.etime != 0 && self.etime < current_time {
+            return rocksdb::CompactionDecision::Remove;
+        }
+        rocksdb::CompactionDecision::Keep
+    }
+}

--- a/src/storage/strings_value_format.rs
+++ b/src/storage/strings_value_format.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 //  of patent rights can be found in the PATENTS file in the same directory.
 
+use crate::storage::error::StorageError;
+
 use super::base_value_format::DataType;
 use super::base_value_format::InternalValue;
 use super::base_value_format::ParsedInternalValue;
@@ -94,6 +96,13 @@ pub struct ParsedStringsValue {
 impl<'a> ParsedInternalValue<'a> for ParsedStringsValue {
     fn new(input_data: &'a [u8]) -> Result<Self> {
         debug_assert!(input_data.len() >= STRING_VALUE_SUFFIXLENGTH);
+        if input_data.len() < STRING_VALUE_SUFFIXLENGTH {
+            return Err(StorageError::InvalidFormat(format!(
+                "invalid string value length: {} < {}",
+                input_data.len(),
+                STRING_VALUE_SUFFIXLENGTH,
+            )));
+        }
 
         let data = Bytes::copy_from_slice(input_data);
         let data_type = DataType::try_from(data[0])?;
@@ -110,6 +119,13 @@ impl<'a> ParsedInternalValue<'a> for ParsedStringsValue {
 
         let mut time_reader = &data[reserve_end..];
         debug_assert!(time_reader.len() >= 2 * TIMESTAMP_LENGTH);
+        if time_reader.len() < 2 * TIMESTAMP_LENGTH {
+            return Err(StorageError::InvalidFormat(format!(
+                "invalid string value length: {} < {}",
+                time_reader.len(),
+                2 * TIMESTAMP_LENGTH,
+            )));
+        }
         let ctime = time_reader.get_u64_le();
         let etime = time_reader.get_u64_le();
 

--- a/src/storage/strings_value_format.rs
+++ b/src/storage/strings_value_format.rs
@@ -13,19 +13,15 @@
 // limitations under the License.
 //  of patent rights can be found in the PATENTS file in the same directory.
 
-use crate::storage::error::StorageError;
-
-use super::base_value_format::DataType;
-use super::base_value_format::InternalValue;
-use super::base_value_format::ParsedInternalValue;
-use super::error::Result;
-use super::storage_define::{
-    STRING_VALUE_SUFFIXLENGTH, SUFFIX_RESERVE_LENGTH, TIMESTAMP_LENGTH, TYPE_LENGTH,
+use crate::storage::{
+    base_value_format::{DataType, InternalValue, ParsedInternalValue},
+    error::{Result, StorageError},
+    storage_define::{
+        STRING_VALUE_SUFFIXLENGTH, SUFFIX_RESERVE_LENGTH, TIMESTAMP_LENGTH, TYPE_LENGTH,
+    },
 };
-use bytes::Buf;
-use bytes::BufMut;
-use bytes::Bytes;
-use bytes::BytesMut;
+
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use chrono::Utc;
 use std::ops::Range;
 


### PR DESCRIPTION
1. Change interval and parsedInterval to traits
2. Implement string_value_format and the BaseMetaFilter part of base_filter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced advanced compaction filtering for database entries, improving automatic cleanup of expired data.
  - Added new internal value format for string data, supporting precise encoding, timestamps, and efficient expiry handling.

- **Refactor**
  - Replaced concrete value structures with trait-based abstractions for greater flexibility and maintainability in storage handling.

- **Chores**
  - Added new dependencies to enhance buffer and timestamp management.
  - Updated and clarified public constants for storage value formatting.
  - Suppressed compiler warnings for unused code in storage error handling and encoding utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->