### PR TITLE
fix: fix window cli 

### DIFF
--- a/src/net/src/unix.rs
+++ b/src/net/src/unix.rs
@@ -18,18 +18,23 @@ use async_trait::async_trait;
 use log::info;
 use std::error::Error;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
 
+#[cfg(unix)]
 pub struct UnixStreamWrapper {
     stream: UnixStream,
 }
 
+#[cfg(unix)]
 impl UnixStreamWrapper {
     pub fn new(stream: UnixStream) -> Self {
         Self { stream }
     }
 }
 
+#[cfg(unix)]
 #[async_trait]
 impl StreamTrait for UnixStreamWrapper {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error> {
@@ -51,6 +56,7 @@ impl UnixServer {
     }
 }
 
+#[cfg(unix)]
 #[async_trait]
 impl ServerTrait for UnixServer {
     async fn start(&self) -> Result<(), Box<dyn Error>> {
@@ -67,5 +73,13 @@ impl ServerTrait for UnixServer {
 
             tokio::spawn(async move { process_connection(&mut client).await.unwrap() });
         }
+    }
+}
+
+#[cfg(not(unix))]
+#[async_trait]
+impl ServerTrait for UnixServer {
+    async fn start(&self) -> Result<(), Box<dyn Error>> {
+        Err("Unix sockets are not supported on this platform".into())
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform compatibility by ensuring Unix socket features are only available on Unix systems.
  * On non-Unix platforms, attempting to use Unix socket features now results in a clear error message indicating lack of support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->