### PR TITLE
chore: reducing the unsafe usage of coding.rs

### DIFF
--- a/src/storage/src/coding.rs
+++ b/src/storage/src/coding.rs
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-use std::mem::size_of;
-
 /// TODO: remove allow dead code
 #[allow(dead_code)]
 pub trait FixedInt: Copy {

--- a/src/storage/src/coding.rs
+++ b/src/storage/src/coding.rs
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+use std::mem::size_of;
+
 /// TODO: remove allow dead code
 #[allow(dead_code)]
 pub trait FixedInt: Copy {
@@ -71,22 +73,20 @@ impl_fixed_int_64!(i64, u64);
 /// TODO: remove allow dead code
 #[allow(dead_code)]
 #[inline]
-pub fn encode_fixed<T: FixedInt>(buf: *mut u8, value: T) {
+pub fn encode_fixed<T: FixedInt>(buf: &mut [u8], value: T) {
     let size = T::byte_size();
-    let buffer: &mut [u8] = unsafe { std::slice::from_raw_parts_mut(buf, size) };
-    assert!(buffer.len() >= size, "buffer too small for fixed int");
-    buffer.copy_from_slice(&value.to_le_bytes());
+    assert!(buf.len() >= size, "buffer too small for fixed int");
+    buf[..size].copy_from_slice(&value.to_le_bytes());
 }
 
 /// decode a fixed-width int from a byte buffer
 /// TODO: remove allow dead code
 #[allow(dead_code)]
 #[inline]
-pub fn decode_fixed<T: FixedInt>(buf: *mut u8) -> T {
+pub fn decode_fixed<T: FixedInt>(buf: &[u8]) -> T {
     let size = T::byte_size();
-    let buffer: &mut [u8] = unsafe { std::slice::from_raw_parts_mut(buf, size) };
-    assert!(buffer.len() >= size, "buffer too small for fixed int");
-    T::from_le_bytes(&buffer[..size])
+    assert!(buf.len() >= size, "buffer too small for fixed int");
+    T::from_le_bytes(&buf[..size])
 }
 
 #[cfg(test)]
@@ -100,8 +100,8 @@ mod tests {
         let mut buf = [0u8; 4];
         let original = 0x12345678u32;
 
-        encode_fixed(buf.as_mut_ptr(), original);
-        let decoded = decode_fixed(buf.as_mut_ptr());
+        encode_fixed(&mut buf, original);
+        let decoded = decode_fixed(&buf);
 
         assert_eq!(
             original, decoded,
@@ -114,8 +114,8 @@ mod tests {
         let mut buf = [0u8; 8];
         let original = 0x1234567890ABCDEFu64;
 
-        encode_fixed(buf.as_mut_ptr(), original);
-        let decoded = decode_fixed(buf.as_mut_ptr());
+        encode_fixed(&mut buf, original);
+        let decoded = decode_fixed(&buf);
 
         assert_eq!(
             original, decoded,
@@ -127,41 +127,41 @@ mod tests {
     fn test_edge_cases_fixed32() {
         let mut buf = [0u8; 4];
 
-        encode_fixed(buf.as_mut_ptr(), 0);
+        encode_fixed(&mut buf, 0);
         assert_eq!(
-            decode_fixed::<u32>(buf.as_mut_ptr()),
+            decode_fixed::<u32>(&buf),
             0,
             "Minimum u32 value should encode/decode correctly"
         );
 
-        encode_fixed(buf.as_mut_ptr(), u32::MAX);
+        encode_fixed(&mut buf, u32::MAX);
         assert_eq!(
-            decode_fixed::<u32>(buf.as_mut_ptr()),
+            decode_fixed::<u32>(&buf),
             u32::MAX,
             "Maximum u32 value should encode/decode correctly"
         );
 
         let powers = [1u32, 2, 4, 16, 256, 65536, 16777216];
         for &power in &powers {
-            encode_fixed(buf.as_mut_ptr(), power);
+            encode_fixed(&mut buf, power);
             assert_eq!(
-                decode_fixed::<u32>(buf.as_mut_ptr()),
+                decode_fixed::<u32>(&buf),
                 power,
                 "Power of 2 value {} should encode/decode correctly",
                 power
             );
         }
 
-        encode_fixed::<u32>(buf.as_mut_ptr(), 0xAAAAAAAA);
+        encode_fixed::<u32>(&mut buf, 0xAAAAAAAA);
         assert_eq!(
-            decode_fixed::<u32>(buf.as_mut_ptr()),
+            decode_fixed::<u32>(&buf),
             0xAAAAAAAA,
             "Alternating bits should encode/decode correctly"
         );
 
-        encode_fixed(buf.as_mut_ptr(), 0x55555555);
+        encode_fixed(&mut buf, 0x55555555);
         assert_eq!(
-            decode_fixed::<u32>(buf.as_mut_ptr()),
+            decode_fixed::<u32>(&buf),
             0x55555555,
             "Alternating bits should encode/decode correctly"
         );
@@ -171,16 +171,16 @@ mod tests {
     fn test_edge_cases_fixed64() {
         let mut buf = [0u8; 8];
 
-        encode_fixed(buf.as_mut_ptr(), 0);
+        encode_fixed(&mut buf, 0);
         assert_eq!(
-            decode_fixed::<u64>(buf.as_mut_ptr()),
+            decode_fixed::<u64>(&buf),
             0,
             "Minimum u64 value should encode/decode correctly"
         );
 
-        encode_fixed(buf.as_mut_ptr(), u64::MAX);
+        encode_fixed(&mut buf, u64::MAX);
         assert_eq!(
-            decode_fixed::<u64>(buf.as_mut_ptr()),
+            decode_fixed::<u64>(&buf),
             u64::MAX,
             "Maximum u64 value should encode/decode correctly"
         );
@@ -197,25 +197,25 @@ mod tests {
             1u64 << 63,
         ];
         for &power in &powers {
-            encode_fixed(buf.as_mut_ptr(), power);
+            encode_fixed(&mut buf, power);
             assert_eq!(
-                decode_fixed::<u64>(buf.as_mut_ptr()),
+                decode_fixed::<u64>(&buf),
                 power,
                 "Power of 2 value {} should encode/decode correctly",
                 power
             );
         }
 
-        encode_fixed::<u64>(buf.as_mut_ptr(), 0xAAAAAAAAAAAAAAAA);
+        encode_fixed::<u64>(&mut buf, 0xAAAAAAAAAAAAAAAA);
         assert_eq!(
-            decode_fixed::<u64>(buf.as_mut_ptr()),
+            decode_fixed::<u64>(&buf),
             0xAAAAAAAAAAAAAAAA,
             "Alternating bits should encode/decode correctly"
         );
 
-        encode_fixed::<u64>(buf.as_mut_ptr(), 0x5555555555555555);
+        encode_fixed::<u64>(&mut buf, 0x5555555555555555);
         assert_eq!(
-            decode_fixed::<u64>(buf.as_mut_ptr()),
+            decode_fixed::<u64>(&buf),
             0x5555555555555555,
             "Alternating bits should encode/decode correctly"
         );
@@ -228,9 +228,9 @@ mod tests {
         ];
 
         for &pattern in &patterns {
-            encode_fixed(buf.as_mut_ptr(), pattern);
+            encode_fixed(&mut buf, pattern);
             assert_eq!(
-                decode_fixed::<u64>(buf.as_mut_ptr()),
+                decode_fixed::<u64>(&buf),
                 pattern,
                 "Byte pattern {:X} should encode/decode correctly",
                 pattern
@@ -243,7 +243,7 @@ mod tests {
         let value = 0x01020304u32;
         let mut buf = [0u8; 4];
 
-        encode_fixed(buf.as_mut_ptr(), value);
+        encode_fixed(&mut buf, value);
 
         if cfg!(target_endian = "little") {
             assert_eq!(buf[0], 0x04);
@@ -257,7 +257,7 @@ mod tests {
             assert_eq!(buf[3], 0x04);
         }
 
-        assert_eq!(decode_fixed::<u32>(buf.as_mut_ptr()), value);
+        assert_eq!(decode_fixed::<u32>(&buf), value);
     }
 
     #[test]
@@ -265,7 +265,7 @@ mod tests {
         let value = 0x0102030405060708u64;
         let mut buf = [0u8; 8];
 
-        encode_fixed(buf.as_mut_ptr(), value);
+        encode_fixed(&mut buf, value);
 
         if cfg!(target_endian = "little") {
             assert_eq!(buf[0], 0x08);
@@ -287,7 +287,7 @@ mod tests {
             assert_eq!(buf[7], 0x08);
         }
 
-        assert_eq!(decode_fixed::<u64>(buf.as_mut_ptr()), value);
+        assert_eq!(decode_fixed::<u64>(&buf), value);
     }
 
     #[test]
@@ -300,8 +300,8 @@ mod tests {
         ];
 
         for &value in &values {
-            encode_fixed(buf.as_mut_ptr(), value);
-            let decoded = decode_fixed::<u32>(buf.as_mut_ptr());
+            encode_fixed(&mut buf, value);
+            let decoded = decode_fixed::<u32>(&buf);
             assert_eq!(value, decoded, "Round trip of 0x{:X} failed", value);
         }
     }
@@ -324,8 +324,8 @@ mod tests {
         ];
 
         for &value in &values {
-            encode_fixed::<u64>(buf.as_mut_ptr(), value);
-            let decoded = decode_fixed(buf.as_mut_ptr());
+            encode_fixed::<u64>(&mut buf, value);
+            let decoded = decode_fixed(&buf);
             assert_eq!(value, decoded, "Round trip of 0x{:X} failed", value);
         }
     }


### PR DESCRIPTION
this pr made a small change to reduce the usage of unsafe for parsing fixed int values in `coding.rs`.

this pr might risks having conflicts with #73, please merge #73 first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved safety and readability by updating buffer handling in encoding and decoding functions to use Rust slices instead of raw pointers.

* **Tests**
  * Updated test cases to use slices for buffer parameters, ensuring consistency with the new function signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->