### PR TITLE
feat(makefile): add makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           components: rustfmt
 
       - name: Run fmt
-        run: cargo fmt --manifest-path ./Cargo.toml --all -- --check --unstable-features
+        run: make fmt
 
   cargo-clippy:
     strategy:
@@ -55,7 +55,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - run: cargo clippy --manifest-path ./Cargo.toml --all-features --workspace -- -D warnings
+      - run: make lint
 
   cargo-miri:
     strategy:
@@ -84,4 +84,4 @@ jobs:
       - name: Install Miri
         run: rustup component add miri --toolchain nightly
 
-      - run: cargo miri test --manifest-path ./Cargo.toml --all-features --workspace
+      - run: make miri

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ lint:
 	@echo "Linting code..."
 	@cargo clippy --manifest-path ./Cargo.toml --all-features --workspace -- -D warnings
 
+miri:
+	@echo "Running miri..."
+	@cargo miri test --manifest-path ./Cargo.toml --all-features --workspace
+
 help:
 	@echo "Available commands:"
 	@echo "  build         - Build the project"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,20 @@
+# Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 SHELL := bash
 .DELETE_ON_ERROR:
 .SHELLFLAGS := -eu -o pipefail -c

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ help:
 	@echo "  clean         - Clean the project"
 	@echo "  fmt           - Format the code"
 	@echo "  lint          - Lint the code"
+	@echo "  miri          - Run tests under Miri"
 	@echo "  help          - Show this help message"
 
 .PHONY: build run test clean fmt lint help

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+SHELL := bash
+.DELETE_ON_ERROR:
+.SHELLFLAGS := -eu -o pipefail -c
+.DEFAULT_GOAL := help
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rules
+MAKEFLAGS += --no-print-directory
+
+build:
+	@echo "Building project..."
+	@cargo build
+
+run:
+	@echo "Running project..."
+	@cargo run --bin server
+
+test:
+	@echo "Running tests..."
+	@cargo test
+
+clean:
+	@echo "Cleaning project..."
+	@cargo clean
+
+fmt:
+	@echo "Formatting code..."
+	@cargo fmt --manifest-path ./Cargo.toml --all -- --check --unstable-features
+
+lint:
+	@echo "Linting code..."
+	@cargo clippy --manifest-path ./Cargo.toml --all-features --workspace -- -D warnings
+
+help:
+	@echo "Available commands:"
+	@echo "  build         - Build the project"
+	@echo "  run           - Run the project"
+	@echo "  test          - Run tests"
+	@echo "  clean         - Clean the project"
+	@echo "  fmt           - Format the code"
+	@echo "  lint          - Lint the code"
+	@echo "  help          - Show this help message"
+
+.PHONY: build run test clean fmt lint help


### PR DESCRIPTION
### **feat: 添加 Makefile 以简化常用开发任务**

#### 这个 PR 做了什么？ (What does this PR do?)

这个 PR 在项目根目录中添加了一个 `Makefile` 文件，旨在标准化和简化常见的开发工作流程，例如构建、测试、格式化和代码检查。

#### 为什么需要这个 PR？ (Why is this PR needed?)

目前，开发者需要手动输入并记忆各种 `cargo` 命令（如 `cargo build`, `cargo test`, `cargo clippy ...` 等）。特别是 `lint` 命令通常带有较多参数，不方便记忆和使用。

通过引入 `Makefile`，我们可以为这些常用操作提供简短、易于记忆的别名。这能够：

  * **提升开发效率**：使用 `make lint` 代替冗长的 `cargo clippy` 命令。
  * **保证团队一致性**：确保团队所有成员都使用相同的参数进行构建和代码检查。
  * **方便新成员上手**：新成员只需查看 `make help` 即可了解项目的主要操作。

#### 主要变更 (Key changes)

新增的 `Makefile` 提供了以下命令：

  * `make` 或 `make help`：显示所有可用命令的帮助信息 (默认操作)。
  * `make build`：编译项目。
  * `make run`：运行项目二进制文件 `kiwi-server`。
  * `make test`：运行所有测试。
  * `make fmt`：使用 `cargo fmt` 格式化代码。
  * `make lint`：使用 `cargo clippy` 对代码进行静态检查。
  * `make clean`：清理构建产物。

#### 如何使用？ (How to use?)

在项目根目录下，直接运行 `make <command>` 即可。例如：

```bash
# 显示帮助信息
make

# 格式化代码
make fmt

# 执行代码检查
make lint
```

-----

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Makefile to simplify common project tasks such as building, running, testing, cleaning, formatting, linting, and displaying help instructions.
* **Chores**
  * Updated continuous integration workflow to use Makefile commands for formatting, linting, and testing steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->