### PR TITLE
fix: change the return type for set command

### DIFF
--- a/src/net/src/handle.rs
+++ b/src/net/src/handle.rs
@@ -47,12 +47,12 @@ pub async fn process_connection(
 
                                 client.set_cmd_name(&params[0]);
                                 client.set_argv(&params);
-
+                                let cmd_name = String::from_utf8(params[0].clone()).unwrap();
                                 handle_command(client, storage.clone(), commands.clone()).await;
 
                                 // Extract the reply from the connection and send it
                                 let response = client.take_reply();
-                                match client.write(&response.serialize()).await {
+                                match client.write(&response.serialize(cmd_name.as_str())).await {
                                     Ok(_) => (),
                                     Err(e) => error!("Write error: {e}"),
                                 }


### PR DESCRIPTION
Aim to fix: https://github.com/arana-db/kiwi/issues/95
According to protocol of redis，set command should use simple string: https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved response formatting: The output format now varies based on the command used. For example, the "set" command returns a simple string reply, while other commands return bulk string replies.

* **Bug Fixes**
  * Enhanced handling of command names to ensure correct response formatting for each command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->