### PR TITLE
refactor(lock_mgr): panic when mutex poison

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,5 @@ storage = { path = "src/storage" }
 kstd = { path = "src/kstd" }
 common-macro = { path = "src/common/macro" }
 net = { path = "src/net" }
+
+


### PR DESCRIPTION
fix #108 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated lock manager behavior: unlocking now notifies all waiting tasks (previously notified one), which may affect concurrency wake-ups.
  * Stricter error handling: locking and condition waits now panic on poisoning instead of attempting recovery. No public API changes.

* **Style**
  * Minor whitespace adjustments in configuration file; no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->