### PR TITLE
feat(storage): enhance bg task worker

### DIFF
--- a/src/storage/src/redis.rs
+++ b/src/storage/src/redis.rs
@@ -343,11 +343,7 @@ impl Redis {
         let bg_task_handler = self.bg_task_handler.clone();
         tokio::spawn(async move {
             let _ = bg_task_handler
-                .send(crate::storage::BgTask::CompactRange {
-                    dtype,
-                    start: key.clone(),
-                    end: key,
-                })
+                .send(crate::storage::BgTask::CompactSpecificKey { dtype, key })
                 .await;
         });
 

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -27,9 +27,31 @@ use kstd::lock_mgr::LockMgr;
 use snafu::ResultExt;
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 use tokio::sync::mpsc;
+
+pub enum TaskType {
+    None = 0,
+    CleanAll = 1,
+    CompactRange = 2,
+}
+
+impl From<u8> for TaskType {
+    fn from(value: u8) -> Self {
+        match value {
+            1 => TaskType::CleanAll,
+            2 => TaskType::CompactRange,
+            _ => TaskType::None,
+        }
+    }
+}
+
+impl From<TaskType> for u8 {
+    fn from(value: TaskType) -> Self {
+        value as u8
+    }
+}
 
 #[derive(Debug, Clone)]
 pub enum BgTask {
@@ -41,8 +63,11 @@ pub enum BgTask {
         start: String,
         end: String,
     },
-    // For shutdown bg task
-    Shutdown,
+    CompactSpecificKey {
+        dtype: DataType,
+        key: String,
+    },
+    Shutdown, // For shutdown bg task
 }
 
 pub struct BgTaskHandler {
@@ -71,6 +96,8 @@ pub struct Storage {
     // For bg task
     pub bg_task_handler: Option<Arc<BgTaskHandler>>,
     pub bg_task: Option<tokio::task::JoinHandle<()>>,
+    pub current_task_type: AtomicU8,
+    pub ignore_tasks: AtomicBool,
 
     pub cursors_store: Arc<Cache<String, String>>,
 
@@ -93,7 +120,9 @@ impl Storage {
             db_id,
             bg_task_handler: None,
             bg_task: None,
+            current_task_type: AtomicU8::new(TaskType::None.into()),
             scan_keynum_exit: AtomicBool::new(false),
+            ignore_tasks: AtomicBool::new(false),
         }
     }
 
@@ -149,6 +178,33 @@ impl Storage {
         }
     }
 
+    pub fn get_current_task_type(&self) -> String {
+        let task_type = self.current_task_type.load(Ordering::Relaxed);
+        match task_type.into() {
+            TaskType::None => "None".to_string(),
+            TaskType::CleanAll => "CleanAll".to_string(),
+            TaskType::CompactRange => "CompactRange".to_string(),
+        }
+    }
+
+    fn set_current_task_type(&self, task_type: TaskType) {
+        self.current_task_type
+            .store(task_type.into(), Ordering::Relaxed);
+    }
+
+    fn clear_current_task_type(&self) {
+        self.current_task_type
+            .store(TaskType::None.into(), Ordering::Relaxed);
+    }
+
+    fn set_ignore_tasks(&self, ignore: bool) {
+        self.ignore_tasks.store(ignore, Ordering::SeqCst);
+    }
+
+    fn is_ignoring_tasks(&self) -> bool {
+        self.ignore_tasks.load(Ordering::SeqCst)
+    }
+
     /// usage:
     /// let mut storage = Storage::new(...);
     /// let receiver = storage.open(...)?;
@@ -158,15 +214,37 @@ impl Storage {
         while let Some(event) = receiver.recv().await {
             match event {
                 BgTask::CleanAll { dtype } => {
-                    log::info!("Cleaning all for type: {dtype:?}");
+                    log::info!("BgTaskWorker received CleanAll {dtype:?}");
+                    storage.set_ignore_tasks(false);
+                    storage.set_current_task_type(TaskType::CleanAll);
+                    if let Err(e) = storage.do_compact_range(dtype, "", "") {
+                        log::error!("BgTaskWorker CleanAll failed: {e:?}");
+                    }
+                    storage.clear_current_task_type();
                 }
                 BgTask::CompactRange { dtype, start, end } => {
-                    log::info!("Compacting range: {start} - {end} for type: {dtype:?}");
-                    if let Some(redis) = storage.insts.first() {
-                        if let Some(db) = &redis.db {
-                            db.compact_range(Some(start), Some(end));
-                        }
+                    if storage.is_ignoring_tasks() {
+                        log::info!("Ignoring compact range task due to ignore tasks");
+                        continue;
                     }
+                    log::info!("BgTaskWorker received CompactRange {dtype:?} {start} {end}");
+                    storage.set_current_task_type(TaskType::CompactRange);
+                    if let Err(e) = storage.do_compact_range(dtype, &start, &end) {
+                        log::error!("BgTaskWorker CompactRange failed: {e:?}");
+                    }
+                    storage.clear_current_task_type();
+                }
+                BgTask::CompactSpecificKey { dtype, key } => {
+                    if storage.is_ignoring_tasks() {
+                        log::info!("Ignoring compact specific key task due to ignore tasks");
+                        continue;
+                    }
+                    log::info!("BgTaskWorker received CompactSpecificKey {dtype:?} {key}");
+                    storage.set_current_task_type(TaskType::CompactRange);
+                    if let Err(e) = storage.do_compact_specific_key(dtype, &key) {
+                        log::error!("BgTaskWorker CompactSpecificKey failed: {e:?}");
+                    }
+                    storage.clear_current_task_type();
                 }
                 BgTask::Shutdown => {
                     log::info!("BgTaskWorker received Shutdown, exiting...");
@@ -174,6 +252,59 @@ impl Storage {
                 }
             }
         }
+    }
+
+    // use for admin command and cron job
+    pub async fn compact_all(&self, sync: bool) -> Result<()> {
+        if sync {
+            log::info!("Executing compact ALL synchronously");
+            self.do_compact_range(DataType::All, "", "")?;
+        } else {
+            log::info!("Adding compact ALL to background queue, setting ignore flag");
+            self.set_ignore_tasks(true);
+            if let Some(handler) = &self.bg_task_handler {
+                handler
+                    .send(BgTask::CleanAll {
+                        dtype: DataType::All,
+                    })
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    // use for admin command
+    pub async fn compact_range(
+        &self,
+        dtype: DataType,
+        start: &str,
+        end: &str,
+        sync: bool,
+    ) -> Result<()> {
+        if sync {
+            log::info!("Executing compact range synchronously: start={start}, end={end}",);
+            self.do_compact_range(dtype, start, end)?;
+        } else {
+            log::info!("Adding compact range to background queue: start={start}, end={end}",);
+            if let Some(handler) = &self.bg_task_handler {
+                handler
+                    .send(BgTask::CompactRange {
+                        dtype,
+                        start: start.to_string(),
+                        end: end.to_string(),
+                    })
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    fn do_compact_range(&self, _dtype: DataType, _start: &str, _end: &str) -> Result<()> {
+        unimplemented!("This function is not implemented yet");
+    }
+
+    fn do_compact_specific_key(&self, _dtype: DataType, _key: &str) -> Result<()> {
+        unimplemented!("This function is not implemented yet");
     }
 
     fn set_option(&self, option_type: OptionType, options: &HashMap<String, String>) -> Result<()> {

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -215,12 +215,13 @@ impl Storage {
             match event {
                 BgTask::CleanAll { dtype } => {
                     log::info!("BgTaskWorker received CleanAll {dtype:?}");
-                    storage.set_ignore_tasks(false);
                     storage.set_current_task_type(TaskType::CleanAll);
-                    if let Err(e) = storage.do_compact_range(dtype, "", "") {
+                    let ret = storage.do_compact_range(dtype, "", "");
+                    storage.set_ignore_tasks(false);
+                    storage.clear_current_task_type();
+                    if let Err(e) = ret {
                         log::error!("BgTaskWorker CleanAll failed: {e:?}");
                     }
-                    storage.clear_current_task_type();
                 }
                 BgTask::CompactRange { dtype, start, end } => {
                     if storage.is_ignoring_tasks() {

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -300,11 +300,13 @@ impl Storage {
     }
 
     fn do_compact_range(&self, _dtype: DataType, _start: &str, _end: &str) -> Result<()> {
-        unimplemented!("This function is not implemented yet");
+        log::info!("do_compact_range {_dtype:?} {_start} {_end}");
+        Ok(())
     }
 
     fn do_compact_specific_key(&self, _dtype: DataType, _key: &str) -> Result<()> {
-        unimplemented!("This function is not implemented yet");
+        log::info!("do_compact_specific_key {_dtype:?} {_key}");
+        Ok(())
     }
 
     // Used to modify rocksdb dynamic options

--- a/src/storage/tests/storage_basic_test.rs
+++ b/src/storage/tests/storage_basic_test.rs
@@ -24,7 +24,6 @@ use storage::{BgTask, BgTaskHandler, DataType};
 // This test ensures:
 // - All tasks are sent successfully (no panic)
 // - The worker can process tasks and exit cleanly (no deadlock)
-#[cfg(not(miri))]
 #[tokio::test]
 async fn test_bg_task_worker_concurrent() {
     let mut storage = Storage::new(1, 0);


### PR DESCRIPTION
**enhance bg task worker :** 
- Set a separate `ignore_task` variable. Since the compaction performed by the client and scheduled tasks has the highest priority and covers the logic of other tasks, mark `ignore_task` as `true` when sending the compact all task to skip other tasks.
- Correctly set the current compaction state：`current_task_type`， to improve observability
- Expose `fn compac`t and `fn compact_range` to upper layers

**TODO:**  enhance in next PR
- Supplement the implementation of `do_compact_range` and `do_compact_specific_key` functions, which need to rely on `calculate_start_and_end_key` functions to calculate the start and end keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-key compaction added alongside full and range compaction.
  * Asynchronous background maintenance tasks with optional synchronous execution and visible task-type/status reporting.
  * Logging and ignore/backpressure controls to better manage background task processing.

* **Tests**
  * Background-task concurrency test enabled to run on all targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->