### PR TITLE
feat(storage): add BaseMetaKey and ParsedBaseMetaKey types to key format

### DIFF
--- a/src/storage/src/base_key_format.rs
+++ b/src/storage/src/base_key_format.rs
@@ -25,6 +25,12 @@ use crate::{
         encode_user_key,
     },
 };
+
+#[allow(dead_code)]
+pub type BaseMetaKey = BaseKey;
+#[allow(dead_code)]
+pub type ParsedBaseMetaKey = ParsedBaseKey;
+
 // used for string data key or hash/zset/set/list's meta key. format:
 // | reserve1 | key | reserve2 |
 // |    8B    |     |   16B    |

--- a/src/storage/src/base_value_format.rs
+++ b/src/storage/src/base_value_format.rs
@@ -223,6 +223,10 @@ impl ParsedInternalValue {
     pub fn is_valid(&self) -> bool {
         !self.is_stale()
     }
+
+    pub fn data_type(&self) -> DataType {
+        self.data_type
+    }
 }
 
 /// This macro is used to forward the base function to the structure
@@ -259,6 +263,10 @@ macro_rules! delegate_parsed_value {
             #[allow(dead_code)]
             pub fn version(&self) -> u64 {
                 self.inner.version()
+            }
+
+            pub fn data_type(&self) -> DataType {
+                self.inner.data_type()
             }
         }
     };

--- a/src/storage/src/base_value_format.rs
+++ b/src/storage/src/base_value_format.rs
@@ -265,6 +265,7 @@ macro_rules! delegate_parsed_value {
                 self.inner.version()
             }
 
+            #[allow(dead_code)]
             pub fn data_type(&self) -> DataType {
                 self.inner.data_type()
             }


### PR DESCRIPTION
1. set `BaseMetaKey` and `ParsedBaseMetaKey` to pub
2. Provides `data_type` function to confirm the type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Exposes a public data-type accessor on parsed values and their wrappers, letting clients read value types directly.
- Chores
  - Adds alternative public names for meta-key types to improve naming clarity; no behavioral change and fully backward-compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->