### PR TITLE
feat(storage): redis set implement

### DIFF
--- a/src/storage/src/base_data_key_format.rs
+++ b/src/storage/src/base_data_key_format.rs
@@ -1,0 +1,221 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(dead_code)]
+// TODO: remove allow dead_code
+
+use bytes::{BufMut, Bytes, BytesMut};
+
+use crate::{
+    error::Result,
+    storage_define::{
+        ENCODED_KEY_DELIM_SIZE, PREFIX_RESERVE_LENGTH, SUFFIX_RESERVE_LENGTH, decode_user_key,
+        encode_user_key,
+    },
+};
+
+// used for Hash/Set/Zset's member data key. format:
+// | reserve1 | key | version | data | reserve2 |
+// |    8B    |     |    8B   |      |   16B    |
+
+#[derive(Debug, Clone)]
+pub struct MemberDataKey {
+    pub reserve1: [u8; 8],
+    pub key: Bytes,
+    pub version: u64,
+    pub data: Bytes,
+    pub reserve2: [u8; 16],
+}
+
+impl MemberDataKey {
+    pub fn new(key: &[u8], version: u64, data: &[u8]) -> Self {
+        MemberDataKey {
+            reserve1: [0; PREFIX_RESERVE_LENGTH],
+            key: Bytes::copy_from_slice(key),
+            version,
+            data: Bytes::copy_from_slice(data),
+            reserve2: [0; SUFFIX_RESERVE_LENGTH],
+        }
+    }
+
+    pub fn encode(&self) -> Result<BytesMut> {
+        // TODO(marsevilspirit): allocate right memory size
+        let estimated_cap = PREFIX_RESERVE_LENGTH
+            + self.key.len() * 2
+            + size_of::<u64>()
+            + self.data.len()
+            + ENCODED_KEY_DELIM_SIZE
+            + SUFFIX_RESERVE_LENGTH;
+        let mut dst = BytesMut::with_capacity(estimated_cap);
+
+        dst.put_slice(&self.reserve1);
+        dst.put_u64(self.version);
+        encode_user_key(&self.key, &mut dst)?;
+        dst.put_slice(&self.data);
+        dst.put_slice(&self.reserve2);
+        Ok(dst)
+    }
+}
+
+pub struct ParsedMemberDataKey {
+    key_str: BytesMut,
+    reserve: [u8; 8],
+    version: u64,
+    data: Bytes,
+}
+
+impl ParsedMemberDataKey {
+    pub fn new(encoded_key: &[u8]) -> Result<Self> {
+        let mut key_str = BytesMut::new();
+
+        let start_idx = PREFIX_RESERVE_LENGTH;
+        let end_idx = encoded_key.len() - SUFFIX_RESERVE_LENGTH;
+
+        // reserve
+        let reserve_slice = &encoded_key[0..PREFIX_RESERVE_LENGTH];
+        let mut reserve = [0u8; PREFIX_RESERVE_LENGTH];
+        reserve.copy_from_slice(reserve_slice);
+
+        // version is 8 bytes right after reserve
+        let version_slice = &encoded_key[start_idx..start_idx + size_of::<u64>()];
+        let version = u64::from_be_bytes(version_slice.try_into().unwrap());
+
+        // encoded key part starts after version and ends at delimiter before suffix
+        let encoded_key_part = &encoded_key[start_idx + size_of::<u64>()..end_idx];
+
+        // find delimiter (0x00 0x00) to know the encoded length of key
+        let mut delim_pos = None;
+        for i in 0..encoded_key_part.len().saturating_sub(1) {
+            if encoded_key_part[i] == 0x00 && encoded_key_part[i + 1] == 0x00 {
+                delim_pos = Some(i + 2);
+                break;
+            }
+        }
+        let key_encoded_len = delim_pos.expect("encoded key delimiter not found");
+
+        // decode only the key part (including delimiter) into key_str
+        decode_user_key(&encoded_key_part[..key_encoded_len], &mut key_str)?;
+
+        // data is whatever remains before suffix
+        let data_slice = &encoded_key[start_idx + size_of::<u64>() + key_encoded_len..end_idx];
+        let data = Bytes::copy_from_slice(data_slice);
+
+        Ok(ParsedMemberDataKey {
+            key_str,
+            reserve,
+            version,
+            data,
+        })
+    }
+
+    pub fn key(&self) -> &[u8] {
+        self.key_str.as_ref()
+    }
+
+    pub fn version(&self) -> u64 {
+        self.version
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mv_test_member_data_key_encode_and_decode() {
+        let test_key = b"hash_key\x00with_zero";
+        let test_version: u64 = 42;
+        let test_data = b"member_field";
+
+        let data_key = MemberDataKey::new(test_key, test_version, test_data);
+        let encoded_result = data_key.encode();
+        assert!(
+            encoded_result.is_ok(),
+            "Encoding failed: {:?}",
+            encoded_result.err()
+        );
+        let encoded = encoded_result.unwrap();
+
+        // computed total length using actual encoded key length
+        let mut encoded_key_buf = BytesMut::new();
+        crate::storage_define::encode_user_key(test_key, &mut encoded_key_buf)
+            .expect("encode key part failed");
+        let expected_len = PREFIX_RESERVE_LENGTH
+            + size_of::<u64>()
+            + encoded_key_buf.len()
+            + test_data.len()
+            + SUFFIX_RESERVE_LENGTH;
+        assert_eq!(encoded.len(), expected_len);
+
+        // parse back
+        let parsed_result = ParsedMemberDataKey::new(&encoded);
+        assert!(
+            parsed_result.is_ok(),
+            "Decoding failed: {:?}",
+            parsed_result.err()
+        );
+        let parsed = parsed_result.unwrap();
+        assert_eq!(parsed.key(), test_key);
+        assert_eq!(parsed.version(), test_version);
+
+        // verify data region by slicing the encoded buffer directly
+        let start_idx = PREFIX_RESERVE_LENGTH + size_of::<u64>();
+        let end_idx = encoded.len() - SUFFIX_RESERVE_LENGTH;
+        let encoded_key_part = &encoded[start_idx..end_idx];
+        // find the position of delimiter in encoded key part ("\x00\x00")
+        let mut pos = None;
+        for i in 0..encoded_key_part.len().saturating_sub(1) {
+            if encoded_key_part[i] == 0x00 && encoded_key_part[i + 1] == 0x00 {
+                pos = Some(i + 2);
+                break;
+            }
+        }
+        let key_encoded_len = pos.expect("encoded key delimiter not found");
+        let data_begin = PREFIX_RESERVE_LENGTH + size_of::<u64>() + key_encoded_len;
+        let data_end = encoded.len() - SUFFIX_RESERVE_LENGTH;
+        assert_eq!(&encoded[data_begin..data_end], test_data);
+    }
+
+    #[test]
+    fn mv_test_member_data_key_with_empty_key_and_data() {
+        let test_key = b"";
+        let test_version: u64 = 0;
+        let test_data = b"";
+
+        let data_key = MemberDataKey::new(test_key, test_version, test_data);
+        let encoded = data_key.encode().expect("encode failed");
+
+        // length should be reserves + version(8) + encoded(empty key) + suffix
+        let mut encoded_key_buf = BytesMut::new();
+        crate::storage_define::encode_user_key(test_key, &mut encoded_key_buf)
+            .expect("encode key part failed");
+        let expected_len = PREFIX_RESERVE_LENGTH
+            + size_of::<u64>()
+            + encoded_key_buf.len()
+            + SUFFIX_RESERVE_LENGTH;
+        assert_eq!(encoded.len(), expected_len);
+
+        let parsed = ParsedMemberDataKey::new(&encoded).expect("decode failed");
+        assert_eq!(parsed.key(), test_key);
+        assert_eq!(parsed.version(), test_version);
+
+        // data is empty: verify indices collapse
+        let data_begin = PREFIX_RESERVE_LENGTH + size_of::<u64>() + ENCODED_KEY_DELIM_SIZE;
+        let data_end = encoded.len() - SUFFIX_RESERVE_LENGTH;
+        assert!(data_begin == data_end);
+    }
+}

--- a/src/storage/src/base_key_format.rs
+++ b/src/storage/src/base_key_format.rs
@@ -29,6 +29,8 @@ use crate::{
     },
 };
 
+pub type BaseMetaKey = BaseKey;
+
 // used for string data key or hash/zset/set/list's meta key. format:
 // | reserve1 | key | reserve2 |
 // |    8B    |     |   16B    |

--- a/src/storage/src/base_key_format.rs
+++ b/src/storage/src/base_key_format.rs
@@ -15,6 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+// TODO: remove allow dead_code
+
 use bytes::{BufMut, Bytes, BytesMut};
 use snafu::ensure;
 
@@ -25,21 +28,17 @@ use crate::{
         encode_user_key,
     },
 };
+
 // used for string data key or hash/zset/set/list's meta key. format:
 // | reserve1 | key | reserve2 |
 // |    8B    |     |   16B    |
 //
-
-/// TODO: remove allow dead code
-#[allow(dead_code)]
 pub struct BaseKey {
     reserve1: [u8; 8],
     key: Bytes,
     reserve2: [u8; 16],
 }
 
-/// TODO: remove allow dead code
-#[allow(dead_code)]
 impl BaseKey {
     pub fn new(key: &[u8]) -> Self {
         BaseKey {

--- a/src/storage/src/base_meta_value_format.rs
+++ b/src/storage/src/base_meta_value_format.rs
@@ -38,7 +38,7 @@ type ParsedHashesMetaValue = ParsedBaseMetaValue;
 #[allow(dead_code)]
 type SetsMetaValue = BaseMetaValue;
 #[allow(dead_code)]
-type ParsedSetsMetaValue = ParsedBaseMetaValue;
+pub type ParsedSetsMetaValue = ParsedBaseMetaValue;
 #[allow(dead_code)]
 type ZSetsMetaValue = BaseMetaValue;
 #[allow(dead_code)]
@@ -92,7 +92,7 @@ impl BaseMetaValue {
 
 #[allow(dead_code)]
 pub struct ParsedBaseMetaValue {
-    inner: ParsedInternalValue,
+    pub(crate) inner: ParsedInternalValue,
     count: u64,
 }
 
@@ -221,6 +221,11 @@ impl ParsedBaseMetaValue {
 
         self.set_version_to_value();
         self.inner.version
+    }
+
+    /// Get encoded bytes of the meta value
+    pub fn encoded(&self) -> &[u8] {
+        &self.inner.value
     }
 }
 

--- a/src/storage/src/base_value_format.rs
+++ b/src/storage/src/base_value_format.rs
@@ -15,6 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+// TODO(marsevilspirit): remove allow dead_code
+
 use std::ops::Range;
 
 use bytes::{BufMut, Bytes, BytesMut};
@@ -23,7 +26,6 @@ use snafu::OptionExt;
 
 use crate::error::{Error, InvalidFormatSnafu, Result};
 
-/// TODO: remove allow dead code
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DataType {
@@ -57,27 +59,17 @@ impl TryFrom<u8> for DataType {
     }
 }
 
-/// TODO: remove allow dead code
-#[allow(dead_code)]
 pub const DATA_TYPE_STRINGS: [&str; 7] = ["string", "hash", "set", "list", "zset", "none", "all"];
-/// TODO: remove allow dead code
-#[allow(dead_code)]
 pub const DATA_TYPE_TAG: [char; 7] = ['k', 'h', 's', 'l', 'z', 'n', 'a'];
 
-/// TODO: remove allow dead code
-#[allow(dead_code)]
 pub fn data_type_to_string(data_type: DataType) -> &'static str {
     DATA_TYPE_STRINGS[data_type as usize]
 }
 
-/// TODO: remove allow dead code
-#[allow(dead_code)]
 pub fn data_type_to_tag(data_type: DataType) -> char {
     DATA_TYPE_TAG[data_type as usize]
 }
 
-/// TODO: remove allow dead code
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct InternalValue {
     pub data_type: DataType,
@@ -130,22 +122,18 @@ impl InternalValue {
 macro_rules! delegate_internal_value {
     ($struct_name:ident) => {
         impl $struct_name {
-            #[allow(dead_code)]
             pub fn set_etime(&mut self, etime: u64) {
                 self.inner.set_etime(etime);
             }
 
-            #[allow(dead_code)]
             pub fn set_ctime(&mut self, ctime: u64) {
                 self.inner.set_ctime(ctime);
             }
 
-            #[allow(dead_code)]
             pub fn set_version(&mut self, version: u64) {
                 self.inner.set_version(version);
             }
 
-            #[allow(dead_code)]
             pub fn set_relative_etime(&mut self, ttl: u64) -> Result<()> {
                 self.inner.set_relative_etime(ttl)
             }
@@ -153,8 +141,6 @@ macro_rules! delegate_internal_value {
     };
 }
 
-/// TODO: remove allow dead code
-#[allow(dead_code)]
 pub struct ParsedInternalValue {
     pub value: BytesMut,
     pub data_type: DataType,
@@ -166,7 +152,6 @@ pub struct ParsedInternalValue {
     pub etime: u64,
 }
 
-#[allow(dead_code)]
 impl ParsedInternalValue {
     pub fn new(
         value: BytesMut,
@@ -231,32 +216,26 @@ impl ParsedInternalValue {
 macro_rules! delegate_parsed_value {
     ($struct_name:ident) => {
         impl $struct_name {
-            #[allow(dead_code)]
             pub fn etime(&self) -> u64 {
                 self.inner.etime()
             }
 
-            #[allow(dead_code)]
             pub fn ctime(&self) -> u64 {
                 self.inner.ctime()
             }
 
-            #[allow(dead_code)]
             pub fn is_stale(&self) -> bool {
                 self.inner.is_stale()
             }
 
-            #[allow(dead_code)]
             pub fn is_permanent_survival(&self) -> bool {
                 self.inner.is_permanent_survival()
             }
 
-            #[allow(dead_code)]
             pub fn user_value(&self) -> BytesMut {
                 self.inner.user_value()
             }
 
-            #[allow(dead_code)]
             pub fn version(&self) -> u64 {
                 self.inner.version()
             }

--- a/src/storage/src/base_value_format.rs
+++ b/src/storage/src/base_value_format.rs
@@ -122,18 +122,22 @@ impl InternalValue {
 macro_rules! delegate_internal_value {
     ($struct_name:ident) => {
         impl $struct_name {
+            #[allow(dead_code)]
             pub fn set_etime(&mut self, etime: u64) {
                 self.inner.set_etime(etime);
             }
 
+            #[allow(dead_code)]
             pub fn set_ctime(&mut self, ctime: u64) {
                 self.inner.set_ctime(ctime);
             }
 
+            #[allow(dead_code)]
             pub fn set_version(&mut self, version: u64) {
                 self.inner.set_version(version);
             }
 
+            #[allow(dead_code)]
             pub fn set_relative_etime(&mut self, ttl: u64) -> Result<()> {
                 self.inner.set_relative_etime(ttl)
             }
@@ -216,26 +220,32 @@ impl ParsedInternalValue {
 macro_rules! delegate_parsed_value {
     ($struct_name:ident) => {
         impl $struct_name {
+            #[allow(dead_code)]
             pub fn etime(&self) -> u64 {
                 self.inner.etime()
             }
 
+            #[allow(dead_code)]
             pub fn ctime(&self) -> u64 {
                 self.inner.ctime()
             }
 
+            #[allow(dead_code)]
             pub fn is_stale(&self) -> bool {
                 self.inner.is_stale()
             }
 
+            #[allow(dead_code)]
             pub fn is_permanent_survival(&self) -> bool {
                 self.inner.is_permanent_survival()
             }
 
+            #[allow(dead_code)]
             pub fn user_value(&self) -> BytesMut {
                 self.inner.user_value()
             }
 
+            #[allow(dead_code)]
             pub fn version(&self) -> u64 {
                 self.inner.version()
             }

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -131,4 +131,11 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Invalid argument: {}", message))]
+    InvalidArgument {
+        message: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -46,6 +46,7 @@ pub mod error;
 pub mod options;
 pub mod storage;
 
+pub use base_key_format::BaseMetaKey;
 pub use base_value_format::*;
 pub use error::Result;
 pub use options::StorageOptions;

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -15,29 +15,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod base_data_key_format;
 mod base_data_value_format;
-// mod base_data_key_format;
+
 mod base_filter;
 mod base_key_format;
 mod base_meta_value_format;
 mod base_value_format;
-mod coding;
-pub mod error;
+
+mod strings_value_format;
+
 mod list_meta_value_format;
 mod lists_data_key_format;
-pub mod options;
-mod redis;
+
+mod coding;
 mod slot_indexer;
 mod statistics;
-pub mod storage;
+mod util;
+
+mod redis;
 mod storage_define;
 mod storage_impl;
 mod storage_murmur3;
-mod strings_value_format;
-mod util;
 
 // commands
+mod redis_sets;
 mod redis_strings;
+
+pub mod error;
+pub mod options;
+pub mod storage;
 
 pub use base_value_format::*;
 pub use error::Result;

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -15,8 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod base_data_key_format;
 mod base_data_value_format;
+mod member_data_key_format;
 
 mod base_filter;
 mod base_key_format;

--- a/src/storage/src/member_data_key_format.rs
+++ b/src/storage/src/member_data_key_format.rs
@@ -129,6 +129,10 @@ impl ParsedMemberDataKey {
     pub fn version(&self) -> u64 {
         self.version
     }
+
+    pub fn data(&self) -> &[u8] {
+        self.data.as_ref()
+    }
 }
 
 #[cfg(test)]

--- a/src/storage/src/redis_sets.rs
+++ b/src/storage/src/redis_sets.rs
@@ -1,113 +1,118 @@
-/*
- * Copyright (c) 2024-present, arana-db Community.  All rights reserved.
- *
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(dead_code)]
+// TODO(marsevilspirit): remove allow dead_code
 
 //! Redis sets operations implementation
 //! This module provides set operations for Redis storage
 
-use rocksdb::{Direction, IteratorMode, ReadOptions, WriteBatch, WriteOptions};
 use std::collections::HashSet;
-use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::format::{DataType, InternalValue, ParsedInternalValue};
-use crate::lock::ScopeRecordLock;
-use crate::redis::Redis;
-use crate::types::KeyVersion;
-use crate::{Result, StorageError};
+use kstd::lock_mgr::ScopeRecordLock;
+use rocksdb::WriteBatch;
+use snafu::{OptionExt, ResultExt};
+
+use crate::{
+    ColumnFamilyIndex, Redis, Result,
+    base_data_key_format::MemberDataKey,
+    base_data_value_format::BaseDataValue,
+    base_meta_value_format::ParsedSetsMetaValue,
+    error::{InvalidArgumentSnafu, KeyNotFoundSnafu, OptionNoneSnafu, RocksSnafu},
+};
 
 impl Redis {
-    /// Scan sets key number
-    pub fn scan_sets_key_num(&self, key_info: &mut crate::types::KeyInfo) -> Result<()> {
-        let db = self
-            .db
-            .as_ref()
-            .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-
-        let mut keys = 0;
-        let mut expires = 0;
-        let mut ttl_sum = 0;
-        let mut invalid_keys = 0;
-
-        // Get current time
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-
-        // Create iterator options
-        let mut iterator_options = ReadOptions::default();
-        iterator_options.fill_cache(false);
-
-        // Create snapshot
-        let snapshot = db.snapshot();
-        iterator_options.set_snapshot(&snapshot);
-
-        // Iterate through all keys in meta column family
-        let iter = db.iterator_cf_opt(
-            self.get_handle(crate::redis::ColumnFamilyIndex::MetaCF),
-            iterator_options,
-            IteratorMode::Start,
-        );
-
-        for (_, value) in iter {
-            // Parse the meta value
-            let parsed_value = ParsedInternalValue::new(&value);
-
-            // Check if it's a sets type
-            if parsed_value.data_type() != DataType::Sets {
-                continue;
-            }
-
-            // Check if it's stale or empty
-            if parsed_value.is_expired(now) || parsed_value.size() == 0 {
-                invalid_keys += 1;
-            } else {
-                keys += 1;
-
-                // Check if it has expiration
-                let etime = parsed_value.etime();
-                if etime > 0 {
-                    expires += 1;
-                    ttl_sum += etime - now;
-                }
-            }
-        }
-
-        // Set key info
-        key_info.keys = keys;
-        key_info.expires = expires;
-        key_info.avg_ttl = if expires > 0 { ttl_sum / expires } else { 0 };
-        key_info.invalid_keys = invalid_keys;
-
-        Ok(())
-    }
+    // /// Scan sets key number
+    // pub fn scan_sets_key_num(&self, key_info: &mut crate::types::KeyInfo) -> Result<()> {
+    //     let db = self
+    //         .db
+    //         .as_ref()
+    //         .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
+    //
+    //     let mut keys = 0;
+    //     let mut expires = 0;
+    //     let mut ttl_sum = 0;
+    //     let mut invalid_keys = 0;
+    //
+    //     // Get current time
+    //     let now = SystemTime::now()
+    //         .duration_since(UNIX_EPOCH)
+    //         .unwrap()
+    //         .as_secs();
+    //
+    //     // Create iterator options
+    //     let mut iterator_options = ReadOptions::default();
+    //     iterator_options.fill_cache(false);
+    //
+    //     // Create snapshot
+    //     let snapshot = db.snapshot();
+    //     iterator_options.set_snapshot(&snapshot);
+    //
+    //     // Iterate through all keys in meta column family
+    //     let iter = db.iterator_cf_opt(
+    //         self.get_handle(crate::redis::ColumnFamilyIndex::MetaCF),
+    //         iterator_options,
+    //         IteratorMode::Start,
+    //     );
+    //
+    //     for (_, value) in iter {
+    //         // Parse the meta value
+    //         let parsed_value = ParsedInternalValue::new(&value);
+    //
+    //         // Check if it's a sets type
+    //         if parsed_value.data_type() != DataType::Sets {
+    //             continue;
+    //         }
+    //
+    //         // Check if it's stale or empty
+    //         if parsed_value.is_expired(now) || parsed_value.size() == 0 {
+    //             invalid_keys += 1;
+    //         } else {
+    //             keys += 1;
+    //
+    //             // Check if it has expiration
+    //             let etime = parsed_value.etime();
+    //             if etime > 0 {
+    //                 expires += 1;
+    //                 ttl_sum += etime - now;
+    //             }
+    //         }
+    //     }
+    //
+    //     // Set key info
+    //     key_info.keys = keys;
+    //     key_info.expires = expires;
+    //     key_info.avg_ttl = if expires > 0 { ttl_sum / expires } else { 0 };
+    //     key_info.invalid_keys = invalid_keys;
+    //
+    //     Ok(())
+    // }
 
     /// Add one or more members to a set
     pub fn sadd(&self, key: &[u8], members: &[&[u8]], ret: &mut i32) -> Result<()> {
-        let db = self
-            .db
-            .as_ref()
-            .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
+        let db = self.db.as_ref().context(OptionNoneSnafu {
+            message: "db is not initialized".to_string(),
+        })?;
 
         // Filter duplicate members
         let mut unique = HashSet::new();
         let mut filtered_members = Vec::new();
 
+        // Deduplicate members
         for &member in members {
             let member_str = String::from_utf8_lossy(member).to_string();
             if !unique.contains(&member_str) {
@@ -121,1366 +126,1284 @@ impl Redis {
             return Ok(());
         }
 
+        let key_str = String::from_utf8_lossy(key).to_string();
         // Create lock for the key
-        let _lock = ScopeRecordLock::new(self.lock_mgr.as_ref(), key);
+        let _lock = ScopeRecordLock::new(self.lock_mgr.as_ref(), &key_str);
 
         let mut version = 0;
         let mut batch = WriteBatch::default();
 
-        // Try to get the existing meta value
-        let read_options = ReadOptions::default();
-        match db.get_opt(key, &read_options)? {
-            Some(meta_value) => {
-                // Parse the meta value
-                let mut parsed_meta = ParsedInternalValue::new(&meta_value);
+        let cf = self
+            .get_cf_handle(ColumnFamilyIndex::MetaCF)
+            .context(OptionNoneSnafu {
+                message: "cf is not initialized".to_string(),
+            })?;
 
-                // Check if it's the right type
-                if parsed_meta.data_type() != DataType::Sets {
-                    if parsed_meta.is_expired(
-                        SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs(),
-                    ) {
-                        // Treat as not found if expired
-                        let mut sets_meta = InternalValue::new(DataType::Sets, &[]);
-                        sets_meta.set_size(filtered_members.len() as u64);
-                        version = sets_meta.update_version();
+        // Try to get the existing set meta value
+        let meta_get = db.get_cf(&cf, key).context(RocksSnafu)?;
+        match meta_get {
+            Some(val) => {
+                let mut set_meta_value = ParsedSetsMetaValue::new(&val[..])?;
+                version = set_meta_value.initial_meta_value();
 
-                        batch.put(key, &sets_meta.encode());
-
-                        // Add all members
-                        for &member in &filtered_members {
-                            let member_key = self.encode_sets_member_key(key, version, member);
-                            let empty_value = InternalValue::new(DataType::None, &[]).encode();
-                            batch.put_cf(
-                                self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                                &member_key,
-                                &empty_value,
-                            );
-                        }
-
-                        *ret = filtered_members.len() as i32;
-                    } else {
-                        return Err(StorageError::InvalidFormat(format!(
-                            "Wrong type for key: {}",
-                            String::from_utf8_lossy(key)
-                        )));
+                // check add member size
+                if !set_meta_value.check_set_count(filtered_members.len()) {
+                    return InvalidArgumentSnafu {
+                        message: "set size overflow".to_string(),
                     }
-                } else if parsed_meta.is_expired(
-                    SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs(),
-                ) || parsed_meta.size() == 0
-                {
-                    // Initialize meta value if expired or empty
-                    version = parsed_meta.update_version();
-                    parsed_meta.set_size(filtered_members.len() as u64);
-
-                    batch.put(key, &parsed_meta.encode());
-
-                    // Add all members
-                    for &member in &filtered_members {
-                        let member_key = self.encode_sets_member_key(key, version, member);
-                        let empty_value = InternalValue::new(DataType::None, &[]).encode();
-                        batch.put_cf(
-                            self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                            &member_key,
-                            &empty_value,
-                        );
-                    }
-
-                    *ret = filtered_members.len() as i32;
-                } else {
-                    // Add new members to existing set
-                    let mut count = 0;
-                    version = parsed_meta.version();
-
-                    for &member in &filtered_members {
-                        let member_key = self.encode_sets_member_key(key, version, member);
-
-                        // Check if member already exists
-                        match db.get_cf_opt(
-                            self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                            &member_key,
-                            &read_options,
-                        )? {
-                            Some(_) => {
-                                // Member already exists, skip
-                            }
-                            None => {
-                                // Add new member
-                                count += 1;
-                                let empty_value = InternalValue::new(DataType::None, &[]).encode();
-                                batch.put_cf(
-                                    self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                                    &member_key,
-                                    &empty_value,
-                                );
-                            }
-                        }
-                    }
-
-                    *ret = count;
-
-                    if count > 0 {
-                        // Update meta value with new count
-                        parsed_meta.set_size(parsed_meta.size() + count as u64);
-                        batch.put(key, &parsed_meta.encode());
-                    }
+                    .fail();
                 }
-            }
-            None => {
-                // Create new set
-                let mut sets_meta = InternalValue::new(DataType::Sets, &[]);
-                sets_meta.set_size(filtered_members.len() as u64);
-                version = sets_meta.update_version();
 
-                batch.put(key, &sets_meta.encode());
+                set_meta_value.set_count(filtered_members.len() as u64);
 
-                // Add all members
-                for &member in &filtered_members {
-                    let member_key = self.encode_sets_member_key(key, version, member);
-                    let empty_value = InternalValue::new(DataType::None, &[]).encode();
-                    batch.put_cf(
-                        self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                        &member_key,
-                        &empty_value,
-                    );
+                batch.put_cf(&cf, key, set_meta_value.encoded());
+
+                for member in &filtered_members {
+                    let set_member_key = MemberDataKey::new(key, version, member);
+                    let iter_value = BaseDataValue::new("");
+                    let key_encoded = set_member_key.encode()?;
+                    let val_encoded = iter_value.encode();
+                    batch.put_cf(&cf, key_encoded.as_ref(), val_encoded.as_ref());
                 }
 
                 *ret = filtered_members.len() as i32;
+
+                Ok(())
             }
-        }
+            None => KeyNotFoundSnafu {
+                key: String::from_utf8_lossy(key).to_string(),
+            }
+            .fail(),
+        };
 
         // Write batch to DB
-        db.write_opt(batch, &self.default_write_options)?;
+        db.write_opt(batch, &self.write_options)
+            .context(RocksSnafu)?;
 
         Ok(())
     }
 
-    /// Get the number of members in a set
-    pub fn scard(&self, key: &[u8], ret: &mut i32) -> Result<()> {
-        let db = self
-            .db
-            .as_ref()
-            .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-
-        *ret = 0;
-
-        // Try to get the meta value
-        let read_options = ReadOptions::default();
-        match db.get_opt(key, &read_options)? {
-            Some(meta_value) => {
-                // Parse the meta value
-                let parsed_meta = ParsedInternalValue::new(&meta_value);
-
-                // Check if it's the right type
-                if parsed_meta.data_type() != DataType::Sets {
-                    return Err(StorageError::InvalidFormat(format!(
-                        "Wrong type for key: {}",
-                        String::from_utf8_lossy(key)
-                    )));
-                }
-
-                // Check if expired
-                if parsed_meta.is_expired(
-                    SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs(),
-                ) {
-                    return Err(StorageError::KeyNotFound("Stale".to_string()));
-                }
-
-                // Get the count
-                *ret = parsed_meta.size() as i32;
-
-                if *ret == 0 {
-                    return Err(StorageError::KeyNotFound("Deleted".to_string()));
-                }
-            }
-            None => {
-                // Key not found
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Returns the members of the set resulting from the difference between the first set and all the successive sets
-    pub fn sdiff(&self, keys: &[&[u8]], members: &mut Vec<String>) -> Result<()> {
-        if keys.is_empty() {
-            return Err(StorageError::InvalidFormat(
-                "SDiff invalid parameter, no keys".to_string(),
-            ));
-        }
-
-        let db = self
-            .db
-            .as_ref()
-            .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-
-        // Create snapshot and read options
-        let snapshot = db.snapshot();
-        let mut read_options = ReadOptions::default();
-        read_options.set_snapshot(&snapshot);
-
-        // Store valid sets (key, version)
-        let mut valid_sets = Vec::new();
-
-        // Process all keys except the first one
-        for &key in &keys[1..] {
-            match db.get_opt(key, &read_options)? {
-                Some(meta_value) => {
-                    let parsed_meta = ParsedInternalValue::new(&meta_value);
-
-                    // Check if it's the right type
-                    if parsed_meta.data_type() != DataType::Sets {
-                        return Err(StorageError::InvalidFormat(format!(
-                            "Wrong type for key: {}",
-                            String::from_utf8_lossy(key)
-                        )));
-                    }
-
-                    // Skip if expired
-                    if parsed_meta.is_expired(
-                        SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs(),
-                    ) {
-                        continue;
-                    }
-
-                    // Add to valid sets
-                    valid_sets.push((key, parsed_meta.version()));
-                }
-                None => {
-                    // Key not found, skip
-                }
-            }
-        }
-
-        // Process the first key
-        match db.get_opt(keys[0], &read_options)? {
-            Some(meta_value) => {
-                let parsed_meta = ParsedInternalValue::new(&meta_value);
-
-                // Check if it's the right type
-                if parsed_meta.data_type() != DataType::Sets {
-                    return Err(StorageError::InvalidFormat(format!(
-                        "Wrong type for key: {}",
-                        String::from_utf8_lossy(keys[0])
-                    )));
-                }
-
-                // Skip if expired
-                if parsed_meta.is_expired(
-                    SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs(),
-                ) {
-                    return Ok(());
-                }
-
-                // Get the version
-                let version = parsed_meta.version();
-
-                // Create prefix for iteration
-                let prefix = self.encode_sets_member_prefix(keys[0], version);
-
-                // Iterate through all members of the first set
-                let iter = db.iterator_cf_opt(
-                    self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                    read_options.clone(),
-                    IteratorMode::From(&prefix, Direction::Forward),
-                );
-
-                for (key_bytes, _) in iter {
-                    // Check if key starts with prefix
-                    if !key_bytes.starts_with(&prefix) {
-                        break;
-                    }
-
-                    // Extract member from key
-                    let member = self.decode_sets_member_from_key(&key_bytes);
-
-                    // Check if member exists in any other set
-                    let mut found = false;
-                    for &(other_key, other_version) in &valid_sets {
-                        let member_key =
-                            self.encode_sets_member_key(other_key, other_version, &member);
-
-                        match db.get_cf_opt(
-                            self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                            &member_key,
-                            &read_options,
-                        )? {
-                            Some(_) => {
-                                found = true;
-                                break;
-                            }
-                            None => {
-                                // Not found in this set
-                            }
-                        }
-                    }
-
-                    // Add to result if not found in any other set
-                    if !found {
-                        members.push(String::from_utf8_lossy(&member).to_string());
-                    }
-                }
-            }
-            None => {
-                // First key not found, return empty result
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Helper method to encode sets member key
-    fn encode_sets_member_key(&self, key: &[u8], version: u64, member: &[u8]) -> Vec<u8> {
-        // In a real implementation, this would encode the key in the format expected by the C++ code
-        // For simplicity, we'll use a basic format here
-        let mut result = Vec::with_capacity(key.len() + 8 + member.len() + 2);
-        result.extend_from_slice(key);
-        result.push(0); // separator
-
-        // Add version (8 bytes)
-        result.extend_from_slice(&version.to_be_bytes());
-
-        result.push(0); // separator
-        result.extend_from_slice(member);
-
-        result
-    }
-
-    /// Helper method to encode sets member prefix for iteration
-    fn encode_sets_member_prefix(&self, key: &[u8], version: u64) -> Vec<u8> {
-        let mut result = Vec::with_capacity(key.len() + 9);
-        result.extend_from_slice(key);
-        result.push(0); // separator
-
-        // Add version (8 bytes)
-        result.extend_from_slice(&version.to_be_bytes());
-
-        result.push(0); // separator
-
-        result
-    }
-
-    /// Helper method to decode member from sets member key
-    fn decode_sets_member_from_key(&self, key: &[u8]) -> Vec<u8> {
-        // Find the second separator
-        let mut separator_count = 0;
-        let mut pos = 0;
-
-        for (i, &byte) in key.iter().enumerate() {
-            if byte == 0 {
-                separator_count += 1;
-                if separator_count == 2 {
-                    pos = i + 1;
-                    break;
-                }
-            }
-        }
-
-        if pos > 0 && pos < key.len() {
-            key[pos..].to_vec()
-        } else {
-            Vec::new()
-        }
-    }
-
-    /// Store the difference between the first set and all the successive sets into a destination key
-    pub fn sdiffstore(
-        &self,
-        destination: &[u8],
-        keys: &[&[u8]],
-        value_to_dest: &mut Vec<String>,
-        ret: &mut i32,
-    ) -> Result<()> {
-        if keys.is_empty() {
-            return Err(StorageError::InvalidFormat(
-                "SDiffstore invalid parameter, no keys".to_string(),
-            ));
-        }
-
-        let db = self
-            .db
-            .as_ref()
-            .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-
-        // Create lock for the destination key
-        let _lock = ScopeRecordLock::new(self.lock_mgr.as_ref(), destination);
-
-        // Create snapshot and read options
-        let snapshot = db.snapshot();
-        let mut read_options = ReadOptions::default();
-        read_options.set_snapshot(&snapshot);
-
-        // Store valid sets (key, version)
-        let mut valid_sets = Vec::new();
-        let mut members = Vec::new();
-
-        // Process all keys except the first one
-        for &key in &keys[1..] {
-            match db.get_opt(key, &read_options)? {
-                Some(meta_value) => {
-                    let parsed_meta = ParsedInternalValue::new(&meta_value);
-
-                    // Check if it's the right type
-                    if parsed_meta.data_type() != DataType::Sets {
-                        return Err(StorageError::InvalidFormat(format!(
-                            "Wrong type for key: {}",
-                            String::from_utf8_lossy(key)
-                        )));
-                    }
-
-                    // Skip if expired
-                    if parsed_meta.is_expired(
-                        SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs(),
-                    ) {
-                        continue;
-                    }
-
-                    // Add to valid sets
-                    valid_sets.push(KeyVersion {
-                        key: key.to_vec(),
-                        version: parsed_meta.version(),
-                    });
-                }
-                None => {
-                    // Key not found, skip
-                }
-            }
-        }
-
-        // Process the first key
-        match db.get_opt(keys[0], &read_options)? {
-            Some(meta_value) => {
-                let parsed_meta = ParsedInternalValue::new(&meta_value);
-
-                // Check if it's the right type
-                if parsed_meta.data_type() != DataType::Sets {
-                    return Err(StorageError::InvalidFormat(format!(
-                        "Wrong type for key: {}",
-                        String::from_utf8_lossy(keys[0])
-                    )));
-                }
-
-                // Skip if expired
-                if parsed_meta.is_expired(
-                    SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs(),
-                ) {
-                    // Empty result
-                } else {
-                    // Get the version
-                    let version = parsed_meta.version();
-
-                    // Create prefix for iteration
-                    let prefix = self.encode_sets_member_prefix(keys[0], version);
-
-                    // Iterate through all members of the first set
-                    let iter = db.iterator_cf_opt(
-                        self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                        read_options.clone(),
-                        IteratorMode::From(&prefix, Direction::Forward),
-                    );
-
-                    for (key_bytes, _) in iter {
-                        // Check if key starts with prefix
-                        if !key_bytes.starts_with(&prefix) {
-                            break;
-                        }
-
-                        // Extract member from key
-                        let member = self.decode_sets_member_from_key(&key_bytes);
-
-                        // Check if member exists in any other set
-                        let mut found = false;
-                        for key_version in &valid_sets {
-                            let member_key = self.encode_sets_member_key(
-                                &key_version.key,
-                                key_version.version,
-                                &member,
-                            );
-
-                            match db.get_cf_opt(
-                                self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                                &member_key,
-                                &read_options,
-                            )? {
-                                Some(_) => {
-                                    found = true;
-                                    break;
-                                }
-                                None => {
-                                    // Not found in this set
-                                }
-                            }
-                        }
-
-                        // Add to result if not found in any other set
-                        if !found {
-                            let member_str = String::from_utf8_lossy(&member).to_string();
-                            members.push(member_str.clone());
-                            value_to_dest.push(member_str);
-                        }
-                    }
-                }
-            }
-            None => {
-                // First key not found, empty result
-            }
-        }
-
-        // Store the result in the destination key
-        let mut batch = WriteBatch::default();
-        let mut version = 0;
-        let mut statistic = 0;
-
-        // Check if destination key exists
-        match db.get_opt(destination, &read_options)? {
-            Some(meta_value) => {
-                if ParsedInternalValue::new(&meta_value).data_type() == DataType::Sets {
-                    let mut parsed_meta = ParsedInternalValue::new(&meta_value);
-                    statistic = parsed_meta.size();
-                    version = parsed_meta.update_version();
-                    parsed_meta.set_size(members.len() as u64);
-                    batch.put(destination, &parsed_meta.encode());
-                } else {
-                    // Create new set
-                    let mut sets_meta = InternalValue::new(DataType::Sets, &[]);
-                    sets_meta.set_size(members.len() as u64);
-                    version = sets_meta.update_version();
-                    batch.put(destination, &sets_meta.encode());
-                }
-            }
-            None => {
-                // Create new set
-                let mut sets_meta = InternalValue::new(DataType::Sets, &[]);
-                sets_meta.set_size(members.len() as u64);
-                version = sets_meta.update_version();
-                batch.put(destination, &sets_meta.encode());
-            }
-        }
-
-        // Add all members to the destination set
-        for member_str in &members {
-            let member_key =
-                self.encode_sets_member_key(destination, version, member_str.as_bytes());
-            let empty_value = InternalValue::new(DataType::None, &[]).encode();
-            batch.put_cf(
-                self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                &member_key,
-                &empty_value,
-            );
-        }
-
-        // Write batch to DB
-        db.write_opt(batch, &self.default_write_options)?;
-
-        // Update statistics
-        self.update_specific_key_statistics(
-            DataType::Sets,
-            &String::from_utf8_lossy(destination).to_string(),
-            statistic,
-        )?;
-
-        // Set return value
-        *ret = members.len() as i32;
-
-        Ok(())
-    }
-
-    /// Returns the members of the set resulting from the intersection of all the given sets
-    pub fn sinter(&self, keys: &[&[u8]], members: &mut Vec<String>) -> Result<()> {
-        if keys.is_empty() {
-            return Err(StorageError::InvalidFormat(
-                "SInter invalid parameter, no keys".to_string(),
-            ));
-        }
-
-        let db = self
-            .db
-            .as_ref()
-            .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-
-        // Create snapshot and read options
-        let snapshot = db.snapshot();
-        let mut read_options = ReadOptions::default();
-        read_options.set_snapshot(&snapshot);
-
-        // Store valid sets (key, version)
-        let mut valid_sets = Vec::new();
-
-        // Process all keys except the first one
-        for &key in &keys[1..] {
-            match db.get_opt(key, &read_options)? {
-                Some(meta_value) => {
-                    let parsed_meta = ParsedInternalValue::new(&meta_value);
-
-                    // Check if it's the right type
-                    if parsed_meta.data_type() != DataType::Sets {
-                        return Err(StorageError::InvalidFormat(format!(
-                            "Wrong type for key: {}",
-                            String::from_utf8_lossy(key)
-                        )));
-                    }
-
-                    // Return empty result if any key is expired or empty
-                    if parsed_meta.is_expired(
-                        SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs(),
-                    ) {
-                        return Ok(());
-                    }
-
-                    // Add to valid sets
-                    valid_sets.push(KeyVersion {
-                        key: key.to_vec(),
-                        version: parsed_meta.version(),
-                    });
-                }
-                None => {
-                    // If any key doesn't exist, return empty result
-                    return Ok(());
-                }
-            }
-        }
-
-        // Process the first key
-        match db.get_opt(keys[0], &read_options)? {
-            Some(meta_value) => {
-                let parsed_meta = ParsedInternalValue::new(&meta_value);
-
-                // Check if it's the right type
-                if parsed_meta.data_type() != DataType::Sets {
-                    return Err(StorageError::InvalidFormat(format!(
-                        "Wrong type for key: {}",
-                        String::from_utf8_lossy(keys[0])
-                    )));
-                }
-
-                // Return empty result if the first key is expired
-                if parsed_meta.is_expired(
-                    SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs(),
-                ) {
-                    return Ok(());
-                }
-
-                // Get the version
-                let version = parsed_meta.version();
-
-                // Create prefix for iteration
-                let prefix = self.encode_sets_member_prefix(keys[0], version);
-
-                // Iterate through all members of the first set
-                let iter = db.iterator_cf_opt(
-                    self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                    read_options.clone(),
-                    IteratorMode::From(&prefix, Direction::Forward),
-                );
-
-                for (key_bytes, _) in iter {
-                    // Check if key starts with prefix
-                    if !key_bytes.starts_with(&prefix) {
-                        break;
-                    }
-
-                    // Extract member from key
-                    let member = self.decode_sets_member_from_key(&key_bytes);
-
-                    // Check if member exists in all other sets
-                    let mut reliable = true;
-                    for key_version in &valid_sets {
-                        let member_key = self.encode_sets_member_key(
-                            &key_version.key,
-                            key_version.version,
-                            &member,
-                        );
-
-                        match db.get_cf_opt(
-                            self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                            &member_key,
-                            &read_options,
-                        )? {
-                            Some(_) => {
-                                // Member exists in this set, continue checking
-                            }
-                            None => {
-                                // Member doesn't exist in this set, not in intersection
-                                reliable = false;
-                                break;
-                            }
-                        }
-                    }
-
-                    // Add to result if found in all sets
-                    if reliable {
-                        members.push(String::from_utf8_lossy(&member).to_string());
-                    }
-                }
-            }
-            None => {
-                // First key not found, return empty result
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Store the intersection of the sets in a new set at destination
-    pub fn sinterstore(
-        &self,
-        destination: &[u8],
-        keys: &[&[u8]],
-        value_to_dest: &mut Vec<String>,
-        ret: &mut i32,
-    ) -> Result<()> {
-        if keys.is_empty() {
-            return Err(StorageError::InvalidFormat(
-                "SInterstore invalid parameter, no keys".to_string(),
-            ));
-        }
-
-        let db = self
-            .db
-            .as_ref()
-            .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-
-        // Create lock for the destination key
-        let _lock = ScopeRecordLock::new(self.lock_mgr.as_ref(), destination);
-
-        // Create snapshot and read options
-        let snapshot = db.snapshot();
-        let mut read_options = ReadOptions::default();
-        read_options.set_snapshot(&snapshot);
-
-        // Store valid sets (key, version)
-        let mut valid_sets = Vec::new();
-        let mut have_invalid_sets = false;
-        let mut members = Vec::new();
-
-        // Process all keys except the first one
-        for &key in &keys[1..] {
-            match db.get_opt(key, &read_options)? {
-                Some(meta_value) => {
-                    let parsed_meta = ParsedInternalValue::new(&meta_value);
-
-                    // Check if it's the right type
-                    if parsed_meta.data_type() != DataType::Sets {
-                        return Err(StorageError::InvalidFormat(format!(
-                            "Wrong type for key: {}",
-                            String::from_utf8_lossy(key)
-                        )));
-                    }
-
-                    // If any key is expired or empty, we have invalid sets
-                    if parsed_meta.is_expired(
-                        SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs(),
-                    ) {
-                        have_invalid_sets = true;
-                        break;
-                    }
-
-                    // Add to valid sets
-                    valid_sets.push(KeyVersion {
-                        key: key.to_vec(),
-                        version: parsed_meta.version(),
-                    });
-                }
-                None => {
-                    // If any key doesn't exist, we have invalid sets
-                    have_invalid_sets = true;
-                    break;
-                }
-            }
-        }
-
-        // If we don't have invalid sets, process the first key
-        if !have_invalid_sets {
-            match db.get_opt(keys[0], &read_options)? {
-                Some(meta_value) => {
-                    let parsed_meta = ParsedInternalValue::new(&meta_value);
-
-                    // Check if it's the right type
-                    if parsed_meta.data_type() != DataType::Sets {
-                        return Err(StorageError::InvalidFormat(format!(
-                            "Wrong type for key: {}",
-                            String::from_utf8_lossy(keys[0])
-                        )));
-                    }
-
-                    // If the first key is expired, we have invalid sets
-                    if parsed_meta.is_expired(
-                        SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs(),
-                    ) {
-                        have_invalid_sets = true;
-                    } else {
-                        // Get the version
-                        let version = parsed_meta.version();
-
-                        // Create prefix for iteration
-                        let prefix = self.encode_sets_member_prefix(keys[0], version);
-
-                        // Iterate through all members of the first set
-                        let iter = db.iterator_cf_opt(
-                            self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                            read_options.clone(),
-                            IteratorMode::From(&prefix, Direction::Forward),
-                        );
-
-                        for (key_bytes, _) in iter {
-                            // Check if key starts with prefix
-                            if !key_bytes.starts_with(&prefix) {
-                                break;
-                            }
-
-                            // Extract member from key
-                            let member = self.decode_sets_member_from_key(&key_bytes);
-
-                            // Check if member exists in all other sets
-                            let mut reliable = true;
-                            for key_version in &valid_sets {
-                                let member_key = self.encode_sets_member_key(
-                                    &key_version.key,
-                                    key_version.version,
-                                    &member,
-                                );
-
-                                match db.get_cf_opt(
-                                    self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                                    &member_key,
-                                    &read_options,
-                                )? {
-                                    Some(_) => {
-                                        // Member exists in this set, continue checking
-                                    }
-                                    None => {
-                                        // Member doesn't exist in this set, not in intersection
-                                        reliable = false;
-                                        break;
-                                    }
-                                }
-                            }
-
-                            // Add to result if found in all sets
-                            if reliable {
-                                let member_str = String::from_utf8_lossy(&member).to_string();
-                                members.push(member_str.clone());
-                                value_to_dest.push(member_str);
-                            }
-                        }
-                    }
-                }
-                None => {
-                    // First key not found, empty result
-                }
-            }
-        }
-
-        // Store the result in the destination key
-        let mut batch = WriteBatch::default();
-        let mut version = 0;
-        let mut statistic = 0;
-
-        // Check if destination key exists
-        match db.get_opt(destination, &read_options)? {
-            Some(meta_value) => {
-                if ParsedInternalValue::new(&meta_value).data_type() == DataType::Sets {
-                    let mut parsed_meta = ParsedInternalValue::new(&meta_value);
-                    statistic = parsed_meta.size();
-                    version = parsed_meta.update_version();
-                    parsed_meta.set_size(members.len() as u64);
-                    batch.put(destination, &parsed_meta.encode());
-                } else {
-                    // Create new set
-                    let mut sets_meta = InternalValue::new(DataType::Sets, &[]);
-                    sets_meta.set_size(members.len() as u64);
-                    version = sets_meta.update_version();
-                    batch.put(destination, &sets_meta.encode());
-                }
-            }
-            None => {
-                // Create new set
-                let mut sets_meta = InternalValue::new(DataType::Sets, &[]);
-                sets_meta.set_size(members.len() as u64);
-                version = sets_meta.update_version();
-                batch.put(destination, &sets_meta.encode());
-            }
-        }
-
-        // Add all members to the destination set
-        for member_str in &members {
-            let member_key =
-                self.encode_sets_member_key(destination, version, member_str.as_bytes());
-            let empty_value = InternalValue::new(DataType::None, &[]).encode();
-            batch.put_cf(
-                self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                &member_key,
-                &empty_value,
-            );
-        }
-
-        // Write batch to DB
-        db.write_opt(batch, &self.default_write_options)?;
-
-        // Update statistics
-        self.update_specific_key_statistics(
-            DataType::Sets,
-            &String::from_utf8_lossy(destination).to_string(),
-            statistic,
-        )?;
-
-        // Set return value
-        *ret = members.len() as i32;
-
-        Ok(())
-    }
-
-    /// Check if member is a member of the set stored at key
-    pub fn sismember(&self, key: &[u8], member: &[u8], ret: &mut i32) -> Result<()> {
-        let db = self
-            .db
-            .as_ref()
-            .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-
-        *ret = 0;
-
-        // Create read options
-        let read_options = ReadOptions::default();
-
-        // Get the meta value
-        match db.get_opt(key, &read_options)? {
-            Some(meta_value) => {
-                let parsed_meta = ParsedInternalValue::new(&meta_value);
-
-                // Check if it's the right type
-                if parsed_meta.data_type() != DataType::Sets {
-                    return Err(StorageError::InvalidFormat(format!(
-                        "Wrong type for key: {}",
-                        String::from_utf8_lossy(key)
-                    )));
-                }
-
-                // Check if expired
-                if parsed_meta.is_expired(
-                    SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs(),
-                ) {
-                    return Ok(());
-                }
-
-                // Get the version
-                let version = parsed_meta.version();
-
-                // Create member key
-                let member_key = self.encode_sets_member_key(key, version, member);
-
-                // Check if member exists
-                match db.get_cf_opt(
-                    self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                    &member_key,
-                    &read_options,
-                )? {
-                    Some(_) => {
-                        *ret = 1;
-                    }
-                    None => {
-                        *ret = 0;
-                    }
-                }
-            }
-            None => {
-                // Key not found
-                *ret = 0;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Get all the members in a set
-    pub fn smembers(&self, key: &[u8], members: &mut Vec<String>) -> Result<()> {
-        let db = self
-            .db
-            .as_ref()
-            .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-
-        // Create read options
-        let read_options = ReadOptions::default();
-
-        // Get the meta value
-        match db.get_opt(key, &read_options)? {
-            Some(meta_value) => {
-                let parsed_meta = ParsedInternalValue::new(&meta_value);
-
-                // Check if it's the right type
-                if parsed_meta.data_type() != DataType::Sets {
-                    return Err(StorageError::InvalidFormat(format!(
-                        "Wrong type for key: {}",
-                        String::from_utf8_lossy(key)
-                    )));
-                }
-
-                // Check if expired
-                if parsed_meta.is_expired(
-                    SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs(),
-                ) {
-                    return Ok(());
-                }
-
-                // Get the version
-                let version = parsed_meta.version();
-
-                // Create prefix for iteration
-                let prefix = self.encode_sets_member_prefix(key, version);
-
-                // Iterate through all members
-                let iter = db.iterator_cf_opt(
-                    self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                    read_options.clone(),
-                    IteratorMode::From(&prefix, Direction::Forward),
-                );
-
-                for (key_bytes, _) in iter {
-                    // Check if key starts with prefix
-                    if !key_bytes.starts_with(&prefix) {
-                        break;
-                    }
-
-                    // Extract member from key
-                    let member = self.decode_sets_member_from_key(&key_bytes);
-                    members.push(String::from_utf8_lossy(&member).to_string());
-                }
-            }
-            None => {
-                // Key not found, return empty result
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Get all the members in a set with TTL
-    pub fn smembers_with_ttl(
-        &self,
-        key: &[u8],
-        members: &mut Vec<String>,
-        ttl: &mut i64,
-    ) -> Result<()> {
-        let db = self
-            .db
-            .as_ref()
-            .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-
-        // Create read options
-        let read_options = ReadOptions::default();
-
-        // Get the meta value
-        match db.get_opt(key, &read_options)? {
-            Some(meta_value) => {
-                let parsed_meta = ParsedInternalValue::new(&meta_value);
-
-                // Check if it's the right type
-                if parsed_meta.data_type() != DataType::Sets {
-                    return Err(StorageError::InvalidFormat(format!(
-                        "Wrong type for key: {}",
-                        String::from_utf8_lossy(key)
-                    )));
-                }
-
-                // Check if expired
-                if parsed_meta.is_expired(
-                    SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs(),
-                ) {
-                    return Err(StorageError::KeyNotFound("Stale".to_string()));
-                }
-
-                // Calculate TTL
-                let etime = parsed_meta.etime();
-                if etime == 0 {
-                    *ttl = -1; // No expiration
-                } else {
-                    let now = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs();
-                    *ttl = if etime > now {
-                        (etime - now) as i64
-                    } else {
-                        -2
-                    };
-                }
-
-                // Get the version
-                let version = parsed_meta.version();
-
-                // Create prefix for iteration
-                let prefix = self.encode_sets_member_prefix(key, version);
-
-                // Iterate through all members
-                let iter = db.iterator_cf_opt(
-                    self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                    read_options.clone(),
-                    IteratorMode::From(&prefix, Direction::Forward),
-                );
-
-                for (key_bytes, _) in iter {
-                    // Check if key starts with prefix
-                    if !key_bytes.starts_with(&prefix) {
-                        break;
-                    }
-
-                    // Extract member from key
-                    let member = self.decode_sets_member_from_key(&key_bytes);
-                    members.push(String::from_utf8_lossy(&member).to_string());
-                }
-            }
-            None => {
-                return Err(StorageError::KeyNotFound(
-                    String::from_utf8_lossy(key).to_string(),
-                ));
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Move member from the set at source to the set at destination
-    pub fn smove(
-        &self,
-        source: &[u8],
-        destination: &[u8],
-        member: &[u8],
-        ret: &mut i32,
-    ) -> Result<()> {
-        let db = self
-            .db
-            .as_ref()
-            .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-
-        *ret = 0;
-
-        // Create batch for atomic operations
-        let mut batch = WriteBatch::default();
-
-        // Create locks for both keys
-        let keys = vec![source.to_vec(), destination.to_vec()];
-        let _locks = self.lock_mgr.as_ref().multi_lock(&keys);
-
-        let mut version = 0;
-        let mut statistic = 0;
-
-        // Check source key
-        match db.get_opt(source, &self.default_read_options)? {
-            Some(meta_value) => {
-                let mut parsed_meta = ParsedInternalValue::new(&meta_value);
-
-                // Check if it's the right type
-                if parsed_meta.data_type() != DataType::Sets {
-                    return Err(StorageError::InvalidFormat(format!(
-                        "Wrong type for key: {}",
-                        String::from_utf8_lossy(source)
-                    )));
-                }
-
-                // Check if expired
-                if parsed_meta.is_expired(
-                    SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs(),
-                ) {
-                    return Ok(());
-                }
-
-                // Get the version
-                version = parsed_meta.version();
-
-                // Create member key
-                let member_key = self.encode_sets_member_key(source, version, member);
-
-                // Check if member exists in source
-                match db.get_cf_opt(
-                    self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                    &member_key,
-                    &self.default_read_options,
-                )? {
-                    Some(_) => {
-                        // Member exists, remove it from source
-                        *ret = 1;
-
-                        // Update source meta value
-                        parsed_meta.set_size(parsed_meta.size() - 1);
-                        batch.put(source, &parsed_meta.encode());
-
-                        // Delete member from source
-                        batch.delete_cf(
-                            self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                            &member_key,
-                        );
-                        statistic += 1;
-                    }
-                    None => {
-                        // Member doesn't exist in source
-                        return Ok(());
-                    }
-                }
-            }
-            None => {
-                // Source key doesn't exist
-                return Ok(());
-            }
-        }
-
-        // If member was found in source, add it to destination
-        if *ret == 1 {
-            // Check destination key
-            match db.get_opt(destination, &self.default_read_options)? {
-                Some(meta_value) => {
-                    let mut parsed_meta = ParsedInternalValue::new(&meta_value);
-
-                    // Check if it's the right type
-                    if parsed_meta.data_type() != DataType::Sets {
-                        if parsed_meta.is_expired(
-                            SystemTime::now()
-                                .duration_since(UNIX_EPOCH)
-                                .unwrap()
-                                .as_secs(),
-                        ) {
-                            // Create new set if expired
-                            let mut sets_meta = InternalValue::new(DataType::Sets, &[]);
-                            sets_meta.set_size(1);
-                            version = sets_meta.update_version();
-                            batch.put(destination, &sets_meta.encode());
-
-                            // Add member to destination
-                            let member_key =
-                                self.encode_sets_member_key(destination, version, member);
-                            let empty_value = InternalValue::new(DataType::None, &[]).encode();
-                            batch.put_cf(
-                                self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                                &member_key,
-                                &empty_value,
-                            );
-                        } else {
-                            return Err(StorageError::InvalidFormat(format!(
-                                "Wrong type for key: {}",
-                                String::from_utf8_lossy(destination)
-                            )));
-                        }
-                    } else if parsed_meta.is_expired(
-                        SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs(),
-                    ) || parsed_meta.size() == 0
-                    {
-                        // Initialize meta value if expired or empty
-                        version = parsed_meta.update_version();
-                        parsed_meta.set_size(1);
-                        batch.put(destination, &parsed_meta.encode());
-
-                        // Add member to destination
-                        let member_key = self.encode_sets_member_key(destination, version, member);
-                        let empty_value = InternalValue::new(DataType::None, &[]).encode();
-                        batch.put_cf(
-                            self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                            &member_key,
-                            &empty_value,
-                        );
-                    } else {
-                        // Check if member already exists in destination
-                        version = parsed_meta.version();
-                        let member_key = self.encode_sets_member_key(destination, version, member);
-
-                        match db.get_cf_opt(
-                            self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                            &member_key,
-                            &self.default_read_options,
-                        )? {
-                            Some(_) => {
-                                // Member already exists, nothing to do
-                            }
-                            None => {
-                                // Add member to destination
-                                parsed_meta.set_size(parsed_meta.size() + 1);
-                                batch.put(destination, &parsed_meta.encode());
-
-                                let empty_value = InternalValue::new(DataType::None, &[]).encode();
-                                batch.put_cf(
-                                    self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                                    &member_key,
-                                    &empty_value,
-                                );
-                            }
-                        }
-                    }
-                }
-                None => {
-                    // Create new set
-                    let mut sets_meta = InternalValue::new(DataType::Sets, &[]);
-                    sets_meta.set_size(1);
-                    version = sets_meta.update_version();
-                    batch.put(destination, &sets_meta.encode());
-
-                    // Add member to destination
-                    let member_key = self.encode_sets_member_key(destination, version, member);
-                    let empty_value = InternalValue::new(DataType::None, &[]).encode();
-                    batch.put_cf(
-                        self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
-                        &member_key,
-                        &empty_value,
-                    );
-                }
-            }
-        }
-
-        // Write batch to DB
-        db.write_opt(batch, &self.default_write_options)?;
-
-        // Update statistics
-        if statistic > 0 {
-            self.update_specific_key_statistics(
-                DataType::Sets,
-                &String::from_utf8_lossy(source).to_string(),
-                statistic,
-            )?;
-        }
-
-        Ok(())
-    }
+    // /// Get the number of members in a set
+    // pub fn scard(&self, key: &[u8], ret: &mut i32) -> Result<()> {
+    //     let db = self
+    //         .db
+    //         .as_ref()
+    //         .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
+    //
+    //     *ret = 0;
+    //
+    //     // Try to get the meta value
+    //     let read_options = ReadOptions::default();
+    //     match db.get_opt(key, &read_options)? {
+    //         Some(meta_value) => {
+    //             // Parse the meta value
+    //             let parsed_meta = ParsedInternalValue::new(&meta_value);
+    //
+    //             // Check if it's the right type
+    //             if parsed_meta.data_type() != DataType::Sets {
+    //                 return Err(StorageError::InvalidFormat(format!(
+    //                     "Wrong type for key: {}",
+    //                     String::from_utf8_lossy(key)
+    //                 )));
+    //             }
+    //
+    //             // Check if expired
+    //             if parsed_meta.is_expired(
+    //                 SystemTime::now()
+    //                     .duration_since(UNIX_EPOCH)
+    //                     .unwrap()
+    //                     .as_secs(),
+    //             ) {
+    //                 return Err(StorageError::KeyNotFound("Stale".to_string()));
+    //             }
+    //
+    //             // Get the count
+    //             *ret = parsed_meta.size() as i32;
+    //
+    //             if *ret == 0 {
+    //                 return Err(StorageError::KeyNotFound("Deleted".to_string()));
+    //             }
+    //         }
+    //         None => {
+    //             // Key not found
+    //         }
+    //     }
+    //
+    //     Ok(())
+    // }
+
+    // /// Returns the members of the set resulting from the difference between the first set and all the successive sets
+    // pub fn sdiff(&self, keys: &[&[u8]], members: &mut Vec<String>) -> Result<()> {
+    //     if keys.is_empty() {
+    //         return Err(StorageError::InvalidFormat(
+    //             "SDiff invalid parameter, no keys".to_string(),
+    //         ));
+    //     }
+    //
+    //     let db = self
+    //         .db
+    //         .as_ref()
+    //         .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
+    //
+    //     // Create snapshot and read options
+    //     let snapshot = db.snapshot();
+    //     let mut read_options = ReadOptions::default();
+    //     read_options.set_snapshot(&snapshot);
+    //
+    //     // Store valid sets (key, version)
+    //     let mut valid_sets = Vec::new();
+    //
+    //     // Process all keys except the first one
+    //     for &key in &keys[1..] {
+    //         match db.get_opt(key, &read_options)? {
+    //             Some(meta_value) => {
+    //                 let parsed_meta = ParsedInternalValue::new(&meta_value);
+    //
+    //                 // Check if it's the right type
+    //                 if parsed_meta.data_type() != DataType::Sets {
+    //                     return Err(StorageError::InvalidFormat(format!(
+    //                         "Wrong type for key: {}",
+    //                         String::from_utf8_lossy(key)
+    //                     )));
+    //                 }
+    //
+    //                 // Skip if expired
+    //                 if parsed_meta.is_expired(
+    //                     SystemTime::now()
+    //                         .duration_since(UNIX_EPOCH)
+    //                         .unwrap()
+    //                         .as_secs(),
+    //                 ) {
+    //                     continue;
+    //                 }
+    //
+    //                 // Add to valid sets
+    //                 valid_sets.push((key, parsed_meta.version()));
+    //             }
+    //             None => {
+    //                 // Key not found, skip
+    //             }
+    //         }
+    //     }
+    //
+    //     // Process the first key
+    //     match db.get_opt(keys[0], &read_options)? {
+    //         Some(meta_value) => {
+    //             let parsed_meta = ParsedInternalValue::new(&meta_value);
+    //
+    //             // Check if it's the right type
+    //             if parsed_meta.data_type() != DataType::Sets {
+    //                 return Err(StorageError::InvalidFormat(format!(
+    //                     "Wrong type for key: {}",
+    //                     String::from_utf8_lossy(keys[0])
+    //                 )));
+    //             }
+    //
+    //             // Skip if expired
+    //             if parsed_meta.is_expired(
+    //                 SystemTime::now()
+    //                     .duration_since(UNIX_EPOCH)
+    //                     .unwrap()
+    //                     .as_secs(),
+    //             ) {
+    //                 return Ok(());
+    //             }
+    //
+    //             // Get the version
+    //             let version = parsed_meta.version();
+    //
+    //             // Create prefix for iteration
+    //             let prefix = self.encode_sets_member_prefix(keys[0], version);
+    //
+    //             // Iterate through all members of the first set
+    //             let iter = db.iterator_cf_opt(
+    //                 self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                 read_options.clone(),
+    //                 IteratorMode::From(&prefix, Direction::Forward),
+    //             );
+    //
+    //             for (key_bytes, _) in iter {
+    //                 // Check if key starts with prefix
+    //                 if !key_bytes.starts_with(&prefix) {
+    //                     break;
+    //                 }
+    //
+    //                 // Extract member from key
+    //                 let member = self.decode_sets_member_from_key(&key_bytes);
+    //
+    //                 // Check if member exists in any other set
+    //                 let mut found = false;
+    //                 for &(other_key, other_version) in &valid_sets {
+    //                     let member_key =
+    //                         self.encode_sets_member_key(other_key, other_version, &member);
+    //
+    //                     match db.get_cf_opt(
+    //                         self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                         &member_key,
+    //                         &read_options,
+    //                     )? {
+    //                         Some(_) => {
+    //                             found = true;
+    //                             break;
+    //                         }
+    //                         None => {
+    //                             // Not found in this set
+    //                         }
+    //                     }
+    //                 }
+    //
+    //                 // Add to result if not found in any other set
+    //                 if !found {
+    //                     members.push(String::from_utf8_lossy(&member).to_string());
+    //                 }
+    //             }
+    //         }
+    //         None => {
+    //             // First key not found, return empty result
+    //         }
+    //     }
+    //
+    //     Ok(())
+    // }
+
+    // /// Helper method to encode sets member key
+    // fn encode_sets_member_key(&self, key: &[u8], version: u64, member: &[u8]) -> Vec<u8> {
+    //     // In a real implementation, this would encode the key in the format expected by the C++ code
+    //     // For simplicity, we'll use a basic format here
+    //     let mut result = Vec::with_capacity(key.len() + 8 + member.len() + 2);
+    //     result.extend_from_slice(key);
+    //     result.push(0); // separator
+    //
+    //     // Add version (8 bytes)
+    //     result.extend_from_slice(&version.to_be_bytes());
+    //
+    //     result.push(0); // separator
+    //     result.extend_from_slice(member);
+    //
+    //     result
+    // }
+
+    // /// Helper method to encode sets member prefix for iteration
+    // fn encode_sets_member_prefix(&self, key: &[u8], version: u64) -> Vec<u8> {
+    //     let mut result = Vec::with_capacity(key.len() + 9);
+    //     result.extend_from_slice(key);
+    //     result.push(0); // separator
+    //
+    //     // Add version (8 bytes)
+    //     result.extend_from_slice(&version.to_be_bytes());
+    //
+    //     result.push(0); // separator
+    //
+    //     result
+    // }
+
+    // /// Helper method to decode member from sets member key
+    // fn decode_sets_member_from_key(&self, key: &[u8]) -> Vec<u8> {
+    //     // Find the second separator
+    //     let mut separator_count = 0;
+    //     let mut pos = 0;
+    //
+    //     for (i, &byte) in key.iter().enumerate() {
+    //         if byte == 0 {
+    //             separator_count += 1;
+    //             if separator_count == 2 {
+    //                 pos = i + 1;
+    //                 break;
+    //             }
+    //         }
+    //     }
+    //
+    //     if pos > 0 && pos < key.len() {
+    //         key[pos..].to_vec()
+    //     } else {
+    //         Vec::new()
+    //     }
+    // }
+
+    // /// Store the difference between the first set and all the successive sets into a destination key
+    // pub fn sdiffstore(
+    //     &self,
+    //     destination: &[u8],
+    //     keys: &[&[u8]],
+    //     value_to_dest: &mut Vec<String>,
+    //     ret: &mut i32,
+    // ) -> Result<()> {
+    //     if keys.is_empty() {
+    //         return Err(StorageError::InvalidFormat(
+    //             "SDiffstore invalid parameter, no keys".to_string(),
+    //         ));
+    //     }
+    //
+    //     let db = self
+    //         .db
+    //         .as_ref()
+    //         .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
+    //
+    //     // Create lock for the destination key
+    //     let _lock = ScopeRecordLock::new(self.lock_mgr.as_ref(), destination);
+    //
+    //     // Create snapshot and read options
+    //     let snapshot = db.snapshot();
+    //     let mut read_options = ReadOptions::default();
+    //     read_options.set_snapshot(&snapshot);
+    //
+    //     // Store valid sets (key, version)
+    //     let mut valid_sets = Vec::new();
+    //     let mut members = Vec::new();
+    //
+    //     // Process all keys except the first one
+    //     for &key in &keys[1..] {
+    //         match db.get_opt(key, &read_options)? {
+    //             Some(meta_value) => {
+    //                 let parsed_meta = ParsedInternalValue::new(&meta_value);
+    //
+    //                 // Check if it's the right type
+    //                 if parsed_meta.data_type() != DataType::Sets {
+    //                     return Err(StorageError::InvalidFormat(format!(
+    //                         "Wrong type for key: {}",
+    //                         String::from_utf8_lossy(key)
+    //                     )));
+    //                 }
+    //
+    //                 // Skip if expired
+    //                 if parsed_meta.is_expired(
+    //                     SystemTime::now()
+    //                         .duration_since(UNIX_EPOCH)
+    //                         .unwrap()
+    //                         .as_secs(),
+    //                 ) {
+    //                     continue;
+    //                 }
+    //
+    //                 // Add to valid sets
+    //                 valid_sets.push(KeyVersion {
+    //                     key: key.to_vec(),
+    //                     version: parsed_meta.version(),
+    //                 });
+    //             }
+    //             None => {
+    //                 // Key not found, skip
+    //             }
+    //         }
+    //     }
+    //
+    //     // Process the first key
+    //     match db.get_opt(keys[0], &read_options)? {
+    //         Some(meta_value) => {
+    //             let parsed_meta = ParsedInternalValue::new(&meta_value);
+    //
+    //             // Check if it's the right type
+    //             if parsed_meta.data_type() != DataType::Sets {
+    //                 return Err(StorageError::InvalidFormat(format!(
+    //                     "Wrong type for key: {}",
+    //                     String::from_utf8_lossy(keys[0])
+    //                 )));
+    //             }
+    //
+    //             // Skip if expired
+    //             if parsed_meta.is_expired(
+    //                 SystemTime::now()
+    //                     .duration_since(UNIX_EPOCH)
+    //                     .unwrap()
+    //                     .as_secs(),
+    //             ) {
+    //                 // Empty result
+    //             } else {
+    //                 // Get the version
+    //                 let version = parsed_meta.version();
+    //
+    //                 // Create prefix for iteration
+    //                 let prefix = self.encode_sets_member_prefix(keys[0], version);
+    //
+    //                 // Iterate through all members of the first set
+    //                 let iter = db.iterator_cf_opt(
+    //                     self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                     read_options.clone(),
+    //                     IteratorMode::From(&prefix, Direction::Forward),
+    //                 );
+    //
+    //                 for (key_bytes, _) in iter {
+    //                     // Check if key starts with prefix
+    //                     if !key_bytes.starts_with(&prefix) {
+    //                         break;
+    //                     }
+    //
+    //                     // Extract member from key
+    //                     let member = self.decode_sets_member_from_key(&key_bytes);
+    //
+    //                     // Check if member exists in any other set
+    //                     let mut found = false;
+    //                     for key_version in &valid_sets {
+    //                         let member_key = self.encode_sets_member_key(
+    //                             &key_version.key,
+    //                             key_version.version,
+    //                             &member,
+    //                         );
+    //
+    //                         match db.get_cf_opt(
+    //                             self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                             &member_key,
+    //                             &read_options,
+    //                         )? {
+    //                             Some(_) => {
+    //                                 found = true;
+    //                                 break;
+    //                             }
+    //                             None => {
+    //                                 // Not found in this set
+    //                             }
+    //                         }
+    //                     }
+    //
+    //                     // Add to result if not found in any other set
+    //                     if !found {
+    //                         let member_str = String::from_utf8_lossy(&member).to_string();
+    //                         members.push(member_str.clone());
+    //                         value_to_dest.push(member_str);
+    //                     }
+    //                 }
+    //             }
+    //         }
+    //         None => {
+    //             // First key not found, empty result
+    //         }
+    //     }
+    //
+    //     // Store the result in the destination key
+    //     let mut batch = WriteBatch::default();
+    //     let mut version = 0;
+    //     let mut statistic = 0;
+    //
+    //     // Check if destination key exists
+    //     match db.get_opt(destination, &read_options)? {
+    //         Some(meta_value) => {
+    //             if ParsedInternalValue::new(&meta_value).data_type() == DataType::Sets {
+    //                 let mut parsed_meta = ParsedInternalValue::new(&meta_value);
+    //                 statistic = parsed_meta.size();
+    //                 version = parsed_meta.update_version();
+    //                 parsed_meta.set_size(members.len() as u64);
+    //                 batch.put(destination, &parsed_meta.encode());
+    //             } else {
+    //                 // Create new set
+    //                 let mut sets_meta = InternalValue::new(DataType::Sets, &[]);
+    //                 sets_meta.set_size(members.len() as u64);
+    //                 version = sets_meta.update_version();
+    //                 batch.put(destination, &sets_meta.encode());
+    //             }
+    //         }
+    //         None => {
+    //             // Create new set
+    //             let mut sets_meta = InternalValue::new(DataType::Sets, &[]);
+    //             sets_meta.set_size(members.len() as u64);
+    //             version = sets_meta.update_version();
+    //             batch.put(destination, &sets_meta.encode());
+    //         }
+    //     }
+    //
+    //     // Add all members to the destination set
+    //     for member_str in &members {
+    //         let member_key =
+    //             self.encode_sets_member_key(destination, version, member_str.as_bytes());
+    //         let empty_value = InternalValue::new(DataType::None, &[]).encode();
+    //         batch.put_cf(
+    //             self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //             &member_key,
+    //             &empty_value,
+    //         );
+    //     }
+    //
+    //     // Write batch to DB
+    //     db.write_opt(batch, &self.default_write_options)?;
+    //
+    //     // Update statistics
+    //     self.update_specific_key_statistics(
+    //         DataType::Sets,
+    //         &String::from_utf8_lossy(destination).to_string(),
+    //         statistic,
+    //     )?;
+    //
+    //     // Set return value
+    //     *ret = members.len() as i32;
+    //
+    //     Ok(())
+    // }
+    //
+    // /// Returns the members of the set resulting from the intersection of all the given sets
+    // pub fn sinter(&self, keys: &[&[u8]], members: &mut Vec<String>) -> Result<()> {
+    //     if keys.is_empty() {
+    //         return Err(StorageError::InvalidFormat(
+    //             "SInter invalid parameter, no keys".to_string(),
+    //         ));
+    //     }
+    //
+    //     let db = self
+    //         .db
+    //         .as_ref()
+    //         .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
+    //
+    //     // Create snapshot and read options
+    //     let snapshot = db.snapshot();
+    //     let mut read_options = ReadOptions::default();
+    //     read_options.set_snapshot(&snapshot);
+    //
+    //     // Store valid sets (key, version)
+    //     let mut valid_sets = Vec::new();
+    //
+    //     // Process all keys except the first one
+    //     for &key in &keys[1..] {
+    //         match db.get_opt(key, &read_options)? {
+    //             Some(meta_value) => {
+    //                 let parsed_meta = ParsedInternalValue::new(&meta_value);
+    //
+    //                 // Check if it's the right type
+    //                 if parsed_meta.data_type() != DataType::Sets {
+    //                     return Err(StorageError::InvalidFormat(format!(
+    //                         "Wrong type for key: {}",
+    //                         String::from_utf8_lossy(key)
+    //                     )));
+    //                 }
+    //
+    //                 // Return empty result if any key is expired or empty
+    //                 if parsed_meta.is_expired(
+    //                     SystemTime::now()
+    //                         .duration_since(UNIX_EPOCH)
+    //                         .unwrap()
+    //                         .as_secs(),
+    //                 ) {
+    //                     return Ok(());
+    //                 }
+    //
+    //                 // Add to valid sets
+    //                 valid_sets.push(KeyVersion {
+    //                     key: key.to_vec(),
+    //                     version: parsed_meta.version(),
+    //                 });
+    //             }
+    //             None => {
+    //                 // If any key doesn't exist, return empty result
+    //                 return Ok(());
+    //             }
+    //         }
+    //     }
+    //
+    //     // Process the first key
+    //     match db.get_opt(keys[0], &read_options)? {
+    //         Some(meta_value) => {
+    //             let parsed_meta = ParsedInternalValue::new(&meta_value);
+    //
+    //             // Check if it's the right type
+    //             if parsed_meta.data_type() != DataType::Sets {
+    //                 return Err(StorageError::InvalidFormat(format!(
+    //                     "Wrong type for key: {}",
+    //                     String::from_utf8_lossy(keys[0])
+    //                 )));
+    //             }
+    //
+    //             // Return empty result if the first key is expired
+    //             if parsed_meta.is_expired(
+    //                 SystemTime::now()
+    //                     .duration_since(UNIX_EPOCH)
+    //                     .unwrap()
+    //                     .as_secs(),
+    //             ) {
+    //                 return Ok(());
+    //             }
+    //
+    //             // Get the version
+    //             let version = parsed_meta.version();
+    //
+    //             // Create prefix for iteration
+    //             let prefix = self.encode_sets_member_prefix(keys[0], version);
+    //
+    //             // Iterate through all members of the first set
+    //             let iter = db.iterator_cf_opt(
+    //                 self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                 read_options.clone(),
+    //                 IteratorMode::From(&prefix, Direction::Forward),
+    //             );
+    //
+    //             for (key_bytes, _) in iter {
+    //                 // Check if key starts with prefix
+    //                 if !key_bytes.starts_with(&prefix) {
+    //                     break;
+    //                 }
+    //
+    //                 // Extract member from key
+    //                 let member = self.decode_sets_member_from_key(&key_bytes);
+    //
+    //                 // Check if member exists in all other sets
+    //                 let mut reliable = true;
+    //                 for key_version in &valid_sets {
+    //                     let member_key = self.encode_sets_member_key(
+    //                         &key_version.key,
+    //                         key_version.version,
+    //                         &member,
+    //                     );
+    //
+    //                     match db.get_cf_opt(
+    //                         self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                         &member_key,
+    //                         &read_options,
+    //                     )? {
+    //                         Some(_) => {
+    //                             // Member exists in this set, continue checking
+    //                         }
+    //                         None => {
+    //                             // Member doesn't exist in this set, not in intersection
+    //                             reliable = false;
+    //                             break;
+    //                         }
+    //                     }
+    //                 }
+    //
+    //                 // Add to result if found in all sets
+    //                 if reliable {
+    //                     members.push(String::from_utf8_lossy(&member).to_string());
+    //                 }
+    //             }
+    //         }
+    //         None => {
+    //             // First key not found, return empty result
+    //         }
+    //     }
+    //
+    //     Ok(())
+    // }
+
+    // /// Store the intersection of the sets in a new set at destination
+    // pub fn sinterstore(
+    //     &self,
+    //     destination: &[u8],
+    //     keys: &[&[u8]],
+    //     value_to_dest: &mut Vec<String>,
+    //     ret: &mut i32,
+    // ) -> Result<()> {
+    //     if keys.is_empty() {
+    //         return Err(StorageError::InvalidFormat(
+    //             "SInterstore invalid parameter, no keys".to_string(),
+    //         ));
+    //     }
+    //
+    //     let db = self
+    //         .db
+    //         .as_ref()
+    //         .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
+    //
+    //     // Create lock for the destination key
+    //     let _lock = ScopeRecordLock::new(self.lock_mgr.as_ref(), destination);
+    //
+    //     // Create snapshot and read options
+    //     let snapshot = db.snapshot();
+    //     let mut read_options = ReadOptions::default();
+    //     read_options.set_snapshot(&snapshot);
+    //
+    //     // Store valid sets (key, version)
+    //     let mut valid_sets = Vec::new();
+    //     let mut have_invalid_sets = false;
+    //     let mut members = Vec::new();
+    //
+    //     // Process all keys except the first one
+    //     for &key in &keys[1..] {
+    //         match db.get_opt(key, &read_options)? {
+    //             Some(meta_value) => {
+    //                 let parsed_meta = ParsedInternalValue::new(&meta_value);
+    //
+    //                 // Check if it's the right type
+    //                 if parsed_meta.data_type() != DataType::Sets {
+    //                     return Err(StorageError::InvalidFormat(format!(
+    //                         "Wrong type for key: {}",
+    //                         String::from_utf8_lossy(key)
+    //                     )));
+    //                 }
+    //
+    //                 // If any key is expired or empty, we have invalid sets
+    //                 if parsed_meta.is_expired(
+    //                     SystemTime::now()
+    //                         .duration_since(UNIX_EPOCH)
+    //                         .unwrap()
+    //                         .as_secs(),
+    //                 ) {
+    //                     have_invalid_sets = true;
+    //                     break;
+    //                 }
+    //
+    //                 // Add to valid sets
+    //                 valid_sets.push(KeyVersion {
+    //                     key: key.to_vec(),
+    //                     version: parsed_meta.version(),
+    //                 });
+    //             }
+    //             None => {
+    //                 // If any key doesn't exist, we have invalid sets
+    //                 have_invalid_sets = true;
+    //                 break;
+    //             }
+    //         }
+    //     }
+    //
+    //     // If we don't have invalid sets, process the first key
+    //     if !have_invalid_sets {
+    //         match db.get_opt(keys[0], &read_options)? {
+    //             Some(meta_value) => {
+    //                 let parsed_meta = ParsedInternalValue::new(&meta_value);
+    //
+    //                 // Check if it's the right type
+    //                 if parsed_meta.data_type() != DataType::Sets {
+    //                     return Err(StorageError::InvalidFormat(format!(
+    //                         "Wrong type for key: {}",
+    //                         String::from_utf8_lossy(keys[0])
+    //                     )));
+    //                 }
+    //
+    //                 // If the first key is expired, we have invalid sets
+    //                 if parsed_meta.is_expired(
+    //                     SystemTime::now()
+    //                         .duration_since(UNIX_EPOCH)
+    //                         .unwrap()
+    //                         .as_secs(),
+    //                 ) {
+    //                     have_invalid_sets = true;
+    //                 } else {
+    //                     // Get the version
+    //                     let version = parsed_meta.version();
+    //
+    //                     // Create prefix for iteration
+    //                     let prefix = self.encode_sets_member_prefix(keys[0], version);
+    //
+    //                     // Iterate through all members of the first set
+    //                     let iter = db.iterator_cf_opt(
+    //                         self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                         read_options.clone(),
+    //                         IteratorMode::From(&prefix, Direction::Forward),
+    //                     );
+    //
+    //                     for (key_bytes, _) in iter {
+    //                         // Check if key starts with prefix
+    //                         if !key_bytes.starts_with(&prefix) {
+    //                             break;
+    //                         }
+    //
+    //                         // Extract member from key
+    //                         let member = self.decode_sets_member_from_key(&key_bytes);
+    //
+    //                         // Check if member exists in all other sets
+    //                         let mut reliable = true;
+    //                         for key_version in &valid_sets {
+    //                             let member_key = self.encode_sets_member_key(
+    //                                 &key_version.key,
+    //                                 key_version.version,
+    //                                 &member,
+    //                             );
+    //
+    //                             match db.get_cf_opt(
+    //                                 self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                                 &member_key,
+    //                                 &read_options,
+    //                             )? {
+    //                                 Some(_) => {
+    //                                     // Member exists in this set, continue checking
+    //                                 }
+    //                                 None => {
+    //                                     // Member doesn't exist in this set, not in intersection
+    //                                     reliable = false;
+    //                                     break;
+    //                                 }
+    //                             }
+    //                         }
+    //
+    //                         // Add to result if found in all sets
+    //                         if reliable {
+    //                             let member_str = String::from_utf8_lossy(&member).to_string();
+    //                             members.push(member_str.clone());
+    //                             value_to_dest.push(member_str);
+    //                         }
+    //                     }
+    //                 }
+    //             }
+    //             None => {
+    //                 // First key not found, empty result
+    //             }
+    //         }
+    //     }
+    //
+    //     // Store the result in the destination key
+    //     let mut batch = WriteBatch::default();
+    //     let mut version = 0;
+    //     let mut statistic = 0;
+    //
+    //     // Check if destination key exists
+    //     match db.get_opt(destination, &read_options)? {
+    //         Some(meta_value) => {
+    //             if ParsedInternalValue::new(&meta_value).data_type() == DataType::Sets {
+    //                 let mut parsed_meta = ParsedInternalValue::new(&meta_value);
+    //                 statistic = parsed_meta.size();
+    //                 version = parsed_meta.update_version();
+    //                 parsed_meta.set_size(members.len() as u64);
+    //                 batch.put(destination, &parsed_meta.encode());
+    //             } else {
+    //                 // Create new set
+    //                 let mut sets_meta = InternalValue::new(DataType::Sets, &[]);
+    //                 sets_meta.set_size(members.len() as u64);
+    //                 version = sets_meta.update_version();
+    //                 batch.put(destination, &sets_meta.encode());
+    //             }
+    //         }
+    //         None => {
+    //             // Create new set
+    //             let mut sets_meta = InternalValue::new(DataType::Sets, &[]);
+    //             sets_meta.set_size(members.len() as u64);
+    //             version = sets_meta.update_version();
+    //             batch.put(destination, &sets_meta.encode());
+    //         }
+    //     }
+    //
+    //     // Add all members to the destination set
+    //     for member_str in &members {
+    //         let member_key =
+    //             self.encode_sets_member_key(destination, version, member_str.as_bytes());
+    //         let empty_value = InternalValue::new(DataType::None, &[]).encode();
+    //         batch.put_cf(
+    //             self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //             &member_key,
+    //             &empty_value,
+    //         );
+    //     }
+    //
+    //     // Write batch to DB
+    //     db.write_opt(batch, &self.default_write_options)?;
+    //
+    //     // Update statistics
+    //     self.update_specific_key_statistics(
+    //         DataType::Sets,
+    //         &String::from_utf8_lossy(destination).to_string(),
+    //         statistic,
+    //     )?;
+    //
+    //     // Set return value
+    //     *ret = members.len() as i32;
+    //
+    //     Ok(())
+    // }
+
+    // /// Check if member is a member of the set stored at key
+    // pub fn sismember(&self, key: &[u8], member: &[u8], ret: &mut i32) -> Result<()> {
+    //     let db = self
+    //         .db
+    //         .as_ref()
+    //         .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
+    //
+    //     *ret = 0;
+    //
+    //     // Create read options
+    //     let read_options = ReadOptions::default();
+    //
+    //     // Get the meta value
+    //     match db.get_opt(key, &read_options)? {
+    //         Some(meta_value) => {
+    //             let parsed_meta = ParsedInternalValue::new(&meta_value);
+    //
+    //             // Check if it's the right type
+    //             if parsed_meta.data_type() != DataType::Sets {
+    //                 return Err(StorageError::InvalidFormat(format!(
+    //                     "Wrong type for key: {}",
+    //                     String::from_utf8_lossy(key)
+    //                 )));
+    //             }
+    //
+    //             // Check if expired
+    //             if parsed_meta.is_expired(
+    //                 SystemTime::now()
+    //                     .duration_since(UNIX_EPOCH)
+    //                     .unwrap()
+    //                     .as_secs(),
+    //             ) {
+    //                 return Ok(());
+    //             }
+    //
+    //             // Get the version
+    //             let version = parsed_meta.version();
+    //
+    //             // Create member key
+    //             let member_key = self.encode_sets_member_key(key, version, member);
+    //
+    //             // Check if member exists
+    //             match db.get_cf_opt(
+    //                 self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                 &member_key,
+    //                 &read_options,
+    //             )? {
+    //                 Some(_) => {
+    //                     *ret = 1;
+    //                 }
+    //                 None => {
+    //                     *ret = 0;
+    //                 }
+    //             }
+    //         }
+    //         None => {
+    //             // Key not found
+    //             *ret = 0;
+    //         }
+    //     }
+    //
+    //     Ok(())
+    // }
+
+    // /// Get all the members in a set
+    // pub fn smembers(&self, key: &[u8], members: &mut Vec<String>) -> Result<()> {
+    //     let db = self
+    //         .db
+    //         .as_ref()
+    //         .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
+    //
+    //     // Create read options
+    //     let read_options = ReadOptions::default();
+    //
+    //     // Get the meta value
+    //     match db.get_opt(key, &read_options)? {
+    //         Some(meta_value) => {
+    //             let parsed_meta = ParsedInternalValue::new(&meta_value);
+    //
+    //             // Check if it's the right type
+    //             if parsed_meta.data_type() != DataType::Sets {
+    //                 return Err(StorageError::InvalidFormat(format!(
+    //                     "Wrong type for key: {}",
+    //                     String::from_utf8_lossy(key)
+    //                 )));
+    //             }
+    //
+    //             // Check if expired
+    //             if parsed_meta.is_expired(
+    //                 SystemTime::now()
+    //                     .duration_since(UNIX_EPOCH)
+    //                     .unwrap()
+    //                     .as_secs(),
+    //             ) {
+    //                 return Ok(());
+    //             }
+    //
+    //             // Get the version
+    //             let version = parsed_meta.version();
+    //
+    //             // Create prefix for iteration
+    //             let prefix = self.encode_sets_member_prefix(key, version);
+    //
+    //             // Iterate through all members
+    //             let iter = db.iterator_cf_opt(
+    //                 self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                 read_options.clone(),
+    //                 IteratorMode::From(&prefix, Direction::Forward),
+    //             );
+    //
+    //             for (key_bytes, _) in iter {
+    //                 // Check if key starts with prefix
+    //                 if !key_bytes.starts_with(&prefix) {
+    //                     break;
+    //                 }
+    //
+    //                 // Extract member from key
+    //                 let member = self.decode_sets_member_from_key(&key_bytes);
+    //                 members.push(String::from_utf8_lossy(&member).to_string());
+    //             }
+    //         }
+    //         None => {
+    //             // Key not found, return empty result
+    //         }
+    //     }
+    //
+    //     Ok(())
+    // }
+
+    // /// Get all the members in a set with TTL
+    // pub fn smembers_with_ttl(
+    //     &self,
+    //     key: &[u8],
+    //     members: &mut Vec<String>,
+    //     ttl: &mut i64,
+    // ) -> Result<()> {
+    //     let db = self
+    //         .db
+    //         .as_ref()
+    //         .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
+    //
+    //     // Create read options
+    //     let read_options = ReadOptions::default();
+    //
+    //     // Get the meta value
+    //     match db.get_opt(key, &read_options)? {
+    //         Some(meta_value) => {
+    //             let parsed_meta = ParsedInternalValue::new(&meta_value);
+    //
+    //             // Check if it's the right type
+    //             if parsed_meta.data_type() != DataType::Sets {
+    //                 return Err(StorageError::InvalidFormat(format!(
+    //                     "Wrong type for key: {}",
+    //                     String::from_utf8_lossy(key)
+    //                 )));
+    //             }
+    //
+    //             // Check if expired
+    //             if parsed_meta.is_expired(
+    //                 SystemTime::now()
+    //                     .duration_since(UNIX_EPOCH)
+    //                     .unwrap()
+    //                     .as_secs(),
+    //             ) {
+    //                 return Err(StorageError::KeyNotFound("Stale".to_string()));
+    //             }
+    //
+    //             // Calculate TTL
+    //             let etime = parsed_meta.etime();
+    //             if etime == 0 {
+    //                 *ttl = -1; // No expiration
+    //             } else {
+    //                 let now = SystemTime::now()
+    //                     .duration_since(UNIX_EPOCH)
+    //                     .unwrap()
+    //                     .as_secs();
+    //                 *ttl = if etime > now {
+    //                     (etime - now) as i64
+    //                 } else {
+    //                     -2
+    //                 };
+    //             }
+    //
+    //             // Get the version
+    //             let version = parsed_meta.version();
+    //
+    //             // Create prefix for iteration
+    //             let prefix = self.encode_sets_member_prefix(key, version);
+    //
+    //             // Iterate through all members
+    //             let iter = db.iterator_cf_opt(
+    //                 self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                 read_options.clone(),
+    //                 IteratorMode::From(&prefix, Direction::Forward),
+    //             );
+    //
+    //             for (key_bytes, _) in iter {
+    //                 // Check if key starts with prefix
+    //                 if !key_bytes.starts_with(&prefix) {
+    //                     break;
+    //                 }
+    //
+    //                 // Extract member from key
+    //                 let member = self.decode_sets_member_from_key(&key_bytes);
+    //                 members.push(String::from_utf8_lossy(&member).to_string());
+    //             }
+    //         }
+    //         None => {
+    //             return Err(StorageError::KeyNotFound(
+    //                 String::from_utf8_lossy(key).to_string(),
+    //             ));
+    //         }
+    //     }
+    //
+    //     Ok(())
+    // }
+
+    // /// Move member from the set at source to the set at destination
+    // pub fn smove(
+    //     &self,
+    //     source: &[u8],
+    //     destination: &[u8],
+    //     member: &[u8],
+    //     ret: &mut i32,
+    // ) -> Result<()> {
+    //     let db = self
+    //         .db
+    //         .as_ref()
+    //         .ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
+    //
+    //     *ret = 0;
+    //
+    //     // Create batch for atomic operations
+    //     let mut batch = WriteBatch::default();
+    //
+    //     // Create locks for both keys
+    //     let keys = vec![source.to_vec(), destination.to_vec()];
+    //     let _locks = self.lock_mgr.as_ref().multi_lock(&keys);
+    //
+    //     let mut version = 0;
+    //     let mut statistic = 0;
+    //
+    //     // Check source key
+    //     match db.get_opt(source, &self.default_read_options)? {
+    //         Some(meta_value) => {
+    //             let mut parsed_meta = ParsedInternalValue::new(&meta_value);
+    //
+    //             // Check if it's the right type
+    //             if parsed_meta.data_type() != DataType::Sets {
+    //                 return Err(StorageError::InvalidFormat(format!(
+    //                     "Wrong type for key: {}",
+    //                     String::from_utf8_lossy(source)
+    //                 )));
+    //             }
+    //
+    //             // Check if expired
+    //             if parsed_meta.is_expired(
+    //                 SystemTime::now()
+    //                     .duration_since(UNIX_EPOCH)
+    //                     .unwrap()
+    //                     .as_secs(),
+    //             ) {
+    //                 return Ok(());
+    //             }
+    //
+    //             // Get the version
+    //             version = parsed_meta.version();
+    //
+    //             // Create member key
+    //             let member_key = self.encode_sets_member_key(source, version, member);
+    //
+    //             // Check if member exists in source
+    //             match db.get_cf_opt(
+    //                 self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                 &member_key,
+    //                 &self.default_read_options,
+    //             )? {
+    //                 Some(_) => {
+    //                     // Member exists, remove it from source
+    //                     *ret = 1;
+    //
+    //                     // Update source meta value
+    //                     parsed_meta.set_size(parsed_meta.size() - 1);
+    //                     batch.put(source, &parsed_meta.encode());
+    //
+    //                     // Delete member from source
+    //                     batch.delete_cf(
+    //                         self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                         &member_key,
+    //                     );
+    //                     statistic += 1;
+    //                 }
+    //                 None => {
+    //                     // Member doesn't exist in source
+    //                     return Ok(());
+    //                 }
+    //             }
+    //         }
+    //         None => {
+    //             // Source key doesn't exist
+    //             return Ok(());
+    //         }
+    //     }
+    //
+    //     // If member was found in source, add it to destination
+    //     if *ret == 1 {
+    //         // Check destination key
+    //         match db.get_opt(destination, &self.default_read_options)? {
+    //             Some(meta_value) => {
+    //                 let mut parsed_meta = ParsedInternalValue::new(&meta_value);
+    //
+    //                 // Check if it's the right type
+    //                 if parsed_meta.data_type() != DataType::Sets {
+    //                     if parsed_meta.is_expired(
+    //                         SystemTime::now()
+    //                             .duration_since(UNIX_EPOCH)
+    //                             .unwrap()
+    //                             .as_secs(),
+    //                     ) {
+    //                         // Create new set if expired
+    //                         let mut sets_meta = InternalValue::new(DataType::Sets, &[]);
+    //                         sets_meta.set_size(1);
+    //                         version = sets_meta.update_version();
+    //                         batch.put(destination, &sets_meta.encode());
+    //
+    //                         // Add member to destination
+    //                         let member_key =
+    //                             self.encode_sets_member_key(destination, version, member);
+    //                         let empty_value = InternalValue::new(DataType::None, &[]).encode();
+    //                         batch.put_cf(
+    //                             self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                             &member_key,
+    //                             &empty_value,
+    //                         );
+    //                     } else {
+    //                         return Err(StorageError::InvalidFormat(format!(
+    //                             "Wrong type for key: {}",
+    //                             String::from_utf8_lossy(destination)
+    //                         )));
+    //                     }
+    //                 } else if parsed_meta.is_expired(
+    //                     SystemTime::now()
+    //                         .duration_since(UNIX_EPOCH)
+    //                         .unwrap()
+    //                         .as_secs(),
+    //                 ) || parsed_meta.size() == 0
+    //                 {
+    //                     // Initialize meta value if expired or empty
+    //                     version = parsed_meta.update_version();
+    //                     parsed_meta.set_size(1);
+    //                     batch.put(destination, &parsed_meta.encode());
+    //
+    //                     // Add member to destination
+    //                     let member_key = self.encode_sets_member_key(destination, version, member);
+    //                     let empty_value = InternalValue::new(DataType::None, &[]).encode();
+    //                     batch.put_cf(
+    //                         self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                         &member_key,
+    //                         &empty_value,
+    //                     );
+    //                 } else {
+    //                     // Check if member already exists in destination
+    //                     version = parsed_meta.version();
+    //                     let member_key = self.encode_sets_member_key(destination, version, member);
+    //
+    //                     match db.get_cf_opt(
+    //                         self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                         &member_key,
+    //                         &self.default_read_options,
+    //                     )? {
+    //                         Some(_) => {
+    //                             // Member already exists, nothing to do
+    //                         }
+    //                         None => {
+    //                             // Add member to destination
+    //                             parsed_meta.set_size(parsed_meta.size() + 1);
+    //                             batch.put(destination, &parsed_meta.encode());
+    //
+    //                             let empty_value = InternalValue::new(DataType::None, &[]).encode();
+    //                             batch.put_cf(
+    //                                 self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                                 &member_key,
+    //                                 &empty_value,
+    //                             );
+    //                         }
+    //                     }
+    //                 }
+    //             }
+    //             None => {
+    //                 // Create new set
+    //                 let mut sets_meta = InternalValue::new(DataType::Sets, &[]);
+    //                 sets_meta.set_size(1);
+    //                 version = sets_meta.update_version();
+    //                 batch.put(destination, &sets_meta.encode());
+    //
+    //                 // Add member to destination
+    //                 let member_key = self.encode_sets_member_key(destination, version, member);
+    //                 let empty_value = InternalValue::new(DataType::None, &[]).encode();
+    //                 batch.put_cf(
+    //                     self.get_handle(crate::redis::ColumnFamilyIndex::SetsDataCF),
+    //                     &member_key,
+    //                     &empty_value,
+    //                 );
+    //             }
+    //         }
+    //     }
+    //
+    //     // Write batch to DB
+    //     db.write_opt(batch, &self.default_write_options)?;
+    //
+    //     // Update statistics
+    //     if statistic > 0 {
+    //         self.update_specific_key_statistics(
+    //             DataType::Sets,
+    //             &String::from_utf8_lossy(source).to_string(),
+    //             statistic,
+    //         )?;
+    //     }
+    //
+    //     Ok(())
+    // }
 }

--- a/src/storage/tests/redis_set_test.rs
+++ b/src/storage/tests/redis_set_test.rs
@@ -21,7 +21,9 @@ mod redis_set_test {
 
     use bytes::BufMut;
     use kstd::lock_mgr::LockMgr;
-    use storage::{BgTaskHandler, ColumnFamilyIndex, Redis, StorageOptions, unique_test_db_path};
+    use storage::{
+        BaseMetaKey, BgTaskHandler, ColumnFamilyIndex, Redis, StorageOptions, unique_test_db_path,
+    };
 
     // Build a valid Set meta bytes:
     // layout: type(1) + count(8) + version(8) + reserve(16) + ctime(8) + etime(8)
@@ -63,7 +65,8 @@ mod redis_set_test {
         {
             let db = redis.db.as_ref().unwrap();
             let cf = redis.get_cf_handle(ColumnFamilyIndex::MetaCF).unwrap();
-            db.put_cf(&cf, key, &meta_bytes).unwrap();
+            let encoded_key = BaseMetaKey::new(key).encode().unwrap();
+            db.put_cf(&cf, &encoded_key, &meta_bytes).unwrap();
         }
 
         // Add members (with duplicates) via sadd
@@ -111,7 +114,8 @@ mod redis_set_test {
         {
             let db = redis.db.as_ref().unwrap();
             let cf = redis.get_cf_handle(ColumnFamilyIndex::MetaCF).unwrap();
-            db.put_cf(&cf, key, &meta_bytes).unwrap();
+            let encoded_key = BaseMetaKey::new(key).encode().unwrap();
+            db.put_cf(&cf, &encoded_key, &meta_bytes).unwrap();
         }
 
         // Call sadd with duplicates; expect only unique inserts counted
@@ -149,7 +153,8 @@ mod redis_set_test {
         {
             let db = redis.db.as_ref().unwrap();
             let cf = redis.get_cf_handle(ColumnFamilyIndex::MetaCF).unwrap();
-            db.put_cf(&cf, key, &meta_bytes).unwrap();
+            let encoded_key = BaseMetaKey::new(key).encode().unwrap();
+            db.put_cf(&cf, &encoded_key, &meta_bytes).unwrap();
         }
 
         let members: Vec<&[u8]> = vec![b"x".as_ref(), b"y".as_ref(), b"x".as_ref()];

--- a/src/storage/tests/redis_set_test.rs
+++ b/src/storage/tests/redis_set_test.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(test)]
+mod redis_set_test {
+    use std::sync::Arc;
+
+    use bytes::BufMut;
+    use kstd::lock_mgr::LockMgr;
+    use storage::{BgTaskHandler, ColumnFamilyIndex, Redis, StorageOptions, unique_test_db_path};
+
+    // Build a valid Set meta bytes:
+    // layout: type(1) + count(8) + version(8) + reserve(16) + ctime(8) + etime(8)
+    fn build_empty_set_meta_bytes() -> Vec<u8> {
+        let mut buf = Vec::with_capacity(1 + 8 + 8 + 16 + 8 + 8);
+        // DataType::Set = 2
+        buf.put_u8(2u8);
+        // count = 0
+        buf.put_u64_le(0);
+        // version = 0 (will be replaced by initial_meta_value in sadd)
+        buf.put_u64_le(0);
+        // reserve 16 bytes
+        buf.extend_from_slice(&[0u8; 16]);
+        // ctime, etime = 0 (may be updated by sadd)
+        buf.put_u64_le(0);
+        buf.put_u64_le(0);
+        buf
+    }
+
+    #[test]
+    fn test_sadd_basic_and_dedup() {
+        let test_db_path = unique_test_db_path();
+
+        if test_db_path.exists() {
+            std::fs::remove_dir_all(&test_db_path).unwrap();
+        }
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+
+        let result = redis.open(test_db_path.to_str().unwrap());
+        assert!(result.is_ok(), "open redis db failed: {:?}", result.err());
+
+        // Pre-create set meta (sadd currently requires existing set meta for the key)
+        let key = b"set_key_1";
+        let meta_bytes = build_empty_set_meta_bytes();
+        {
+            let db = redis.db.as_ref().unwrap();
+            let cf = redis.get_cf_handle(ColumnFamilyIndex::MetaCF).unwrap();
+            db.put_cf(&cf, key, &meta_bytes).unwrap();
+        }
+
+        // Call sadd with duplicates; expect only unique inserts counted
+        let members: Vec<&[u8]> = vec![b"a".as_ref(), b"b".as_ref(), b"a".as_ref()];
+        let mut ret = 0;
+        let sadd_res = redis.sadd(key, &members, &mut ret);
+        assert!(sadd_res.is_ok(), "sadd failed: {:?}", sadd_res.err());
+        assert_eq!(ret, 2);
+
+        redis.set_need_close(true);
+        drop(redis);
+
+        if test_db_path.exists() {
+            std::fs::remove_dir_all(test_db_path).unwrap();
+        }
+    }
+}

--- a/src/storage/tests/redis_set_test.rs
+++ b/src/storage/tests/redis_set_test.rs
@@ -68,28 +68,18 @@ mod redis_set_test {
 
         // Add members (with duplicates) via sadd
         let members: Vec<&[u8]> = vec![b"m1".as_ref(), b"m2".as_ref(), b"m1".as_ref()];
-        let mut added = 0;
-        let sadd_res = redis.sadd(key, &members, &mut added);
-        assert!(sadd_res.is_ok(), "sadd failed: {:?}", sadd_res.err());
+        let added = redis.sadd(key, &members).expect("sadd failed");
         assert_eq!(added, 2);
 
         // Fetch members
-        let mut out = Vec::<String>::new();
-        let smembers_res = redis.smembers(key, &mut out);
-        assert!(
-            smembers_res.is_ok(),
-            "smembers failed: {:?}",
-            smembers_res.err()
-        );
-
+        let mut out = redis.smembers(key).expect("smembers failed");
         out.sort();
         let mut expected = vec!["m1".to_string(), "m2".to_string()];
         expected.sort();
         assert_eq!(out, expected);
 
         // Missing key should error
-        let mut out_missing = Vec::<String>::new();
-        let missing_res = redis.smembers(b"missing_key_members", &mut out_missing);
+        let missing_res = redis.smembers(b"missing_key_members");
         assert!(missing_res.is_err());
 
         redis.set_need_close(true);
@@ -126,10 +116,8 @@ mod redis_set_test {
 
         // Call sadd with duplicates; expect only unique inserts counted
         let members: Vec<&[u8]> = vec![b"a".as_ref(), b"b".as_ref(), b"a".as_ref()];
-        let mut ret = 0;
-        let sadd_res = redis.sadd(key, &members, &mut ret);
-        assert!(sadd_res.is_ok(), "sadd failed: {:?}", sadd_res.err());
-        assert_eq!(ret, 2);
+        let added = redis.sadd(key, &members).expect("sadd failed");
+        assert_eq!(added, 2);
 
         redis.set_need_close(true);
         drop(redis);
@@ -165,20 +153,15 @@ mod redis_set_test {
         }
 
         let members: Vec<&[u8]> = vec![b"x".as_ref(), b"y".as_ref(), b"x".as_ref()];
-        let mut added = 0;
-        let sadd_res = redis.sadd(key, &members, &mut added);
-        assert!(sadd_res.is_ok(), "sadd failed: {:?}", sadd_res.err());
+        let added = redis.sadd(key, &members).expect("sadd failed");
         assert_eq!(added, 2);
 
         // scard should report 2
-        let mut card = 0;
-        let scard_res = redis.scard(key, &mut card);
-        assert!(scard_res.is_ok(), "scard failed: {:?}", scard_res.err());
+        let card = redis.scard(key).expect("scard failed");
         assert_eq!(card, 2);
 
         // scard on missing key should error
-        let mut card_missing = 0;
-        let scard_missing = redis.scard(b"missing_key", &mut card_missing);
+        let scard_missing = redis.scard(b"missing_key");
         assert!(scard_missing.is_err());
 
         redis.set_need_close(true);

--- a/src/storage/tests/redis_string_test.rs
+++ b/src/storage/tests/redis_string_test.rs
@@ -22,7 +22,6 @@ mod redis_string_test {
     use kstd::lock_mgr::LockMgr;
     use storage::{BgTaskHandler, Redis, StorageOptions, unique_test_db_path};
 
-    #[cfg(not(miri))]
     #[test]
     fn test_redis_set() {
         let test_db_path = unique_test_db_path();
@@ -69,7 +68,6 @@ mod redis_string_test {
         }
     }
 
-    #[cfg(not(miri))]
     #[test]
     fn test_redis_set_multiple() {
         let test_db_path = unique_test_db_path();
@@ -110,7 +108,6 @@ mod redis_string_test {
         }
     }
 
-    #[cfg(not(miri))]
     #[test]
     fn test_redis_concurrent_set_get() {
         let test_db_path = unique_test_db_path();
@@ -181,7 +178,6 @@ mod redis_string_test {
         }
     }
 
-    #[cfg(not(miri))]
     #[test]
     fn test_redis_concurrent_set_get_same_key() {
         let test_db_path = unique_test_db_path();
@@ -244,7 +240,6 @@ mod redis_string_test {
         }
     }
 
-    #[cfg(not(miri))]
     #[test]
     fn test_redis_concurrent_set_get_mixed() {
         let test_db_path = unique_test_db_path();
@@ -349,7 +344,6 @@ mod redis_string_test {
         }
     }
 
-    #[cfg(not(miri))]
     #[test]
     fn test_redis_concurrent_stress() {
         let test_db_path = unique_test_db_path();


### PR DESCRIPTION
实现 base_data_key_format
实现 redis set sadd, smembers, scard命令

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Expanded public API: storage, options, error handling (new invalid-argument error), Redis integrations, and task utilities.
  - Added member key encoding/decoding types with public constructors/accessors and a meta-value accessor to read encoded bytes.

- Refactor
  - Module reorganization and centralized lint/annotation adjustments with no functional API changes.

- Tests
  - Added Redis Set tests and made several Redis String tests run unconditionally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->