### PR TITLE
feat: support config file as parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
 name = "client"
 version = "0.1.0"
 dependencies = [
@@ -466,7 +506,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
@@ -1965,6 +2005,8 @@ dependencies = [
 name = "server"
 version = "0.1.0"
 dependencies = [
+ "clap",
+ "conf",
  "env_logger",
  "log",
  "net",
@@ -2086,6 +2128,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ async-channel = "2.5.0"
 tokio-util = "0.7.16"
 async-trait = "0.1"
 foyer = { version = "0.18", features = ["nightly"] }
+clap = { version = "4.0", features = ["derive"] }
 
 ## workspaces members
 engine = { path = "src/engine" }

--- a/src/conf/src/config.rs
+++ b/src/conf/src/config.rs
@@ -22,10 +22,15 @@ use validator::Validate;
 use crate::de_func::{deserialize_bool_from_yes_no, deserialize_memory};
 use crate::error::Error;
 
+const DEFAULT_BINDING: &str = "127.0.0.1";
+const DEFAULT_PORT: u16 = 9221;
+
 // config struct define
 #[derive(Debug, Deserialize, Validate)]
 #[serde(default)]
 pub struct Config {
+    pub binding: String,
+
     #[validate(range(min = 1024, max = 65535))]
     pub port: u16,
 
@@ -105,7 +110,8 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            port: 8080,
+            binding: DEFAULT_BINDING.to_string(),
+            port: DEFAULT_PORT,
             timeout: 50,
             memory: 1024 * 1024 * 1024,
             log_dir: "/data/kiwi_rs/logs".to_string(),

--- a/src/conf/src/lib.rs
+++ b/src/conf/src/lib.rs
@@ -73,6 +73,7 @@ mod tests {
     #[test]
     fn test_validate_port_range() {
         let mut invalid_config = Config {
+            binding: "127.0.0.1".to_string(),
             port: 999,
             timeout: 100,
             redis_compatible_mode: false,

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -11,6 +11,8 @@ net.workspace = true
 tokio.workspace = true
 env_logger.workspace = true
 log.workspace = true
+conf.workspace = true
+clap = { version = "4.0", features = ["derive"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Is this #66 want?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a --config command-line option to load settings from a file.
  - Server binding address and port are now configurable; defaults are 127.0.0.1:9221.

- **Chores**
  - Enabled CLI parsing and workspace dependency for CLI support.
  - Updated tests to account for the new binding field in configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->