### PR TITLE
refactor(storage): update Redis hash operations 

### DIFF
--- a/src/storage/src/base_meta_value_format.rs
+++ b/src/storage/src/base_meta_value_format.rs
@@ -69,7 +69,7 @@ impl BaseMetaValue {
         self.inner.version
     }
 
-    fn encode(&self) -> BytesMut {
+    pub fn encode(&self) -> BytesMut {
         // type(1) + user_value + version(8) + reserve(16) + ctime(8) + etime(8)
         let needed = TYPE_LENGTH
             + self.inner.user_value.len()

--- a/src/storage/src/base_meta_value_format.rs
+++ b/src/storage/src/base_meta_value_format.rs
@@ -32,9 +32,8 @@ use crate::{
 };
 
 #[allow(dead_code)]
-type HashesMetaValue = BaseMetaValue;
-#[allow(dead_code)]
-type ParsedHashesMetaValue = ParsedBaseMetaValue;
+pub type HashesMetaValue = BaseMetaValue;
+pub type ParsedHashesMetaValue = ParsedBaseMetaValue;
 #[allow(dead_code)]
 type SetsMetaValue = BaseMetaValue;
 #[allow(dead_code)]

--- a/src/storage/src/base_value_format.rs
+++ b/src/storage/src/base_value_format.rs
@@ -212,6 +212,10 @@ impl ParsedInternalValue {
     pub fn is_valid(&self) -> bool {
         !self.is_stale()
     }
+
+    pub fn data_type(&self) -> DataType {
+        self.data_type
+    }
 }
 
 /// This macro is used to forward the base function to the structure
@@ -248,6 +252,11 @@ macro_rules! delegate_parsed_value {
             #[allow(dead_code)]
             pub fn version(&self) -> u64 {
                 self.inner.version()
+            }
+
+            #[allow(dead_code)]
+            pub fn data_type(&self) -> DataType {
+                self.inner.data_type()
             }
         }
     };

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -138,4 +138,12 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    // all the redis error use this error type
+    #[snafu(display("{}", message))]
+    RedisErr {
+        message: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -39,6 +39,7 @@ mod storage_impl;
 mod storage_murmur3;
 
 // commands
+mod redis_hashes;
 mod redis_sets;
 mod redis_strings;
 

--- a/src/storage/src/redis.rs
+++ b/src/storage/src/redis.rs
@@ -402,6 +402,19 @@ impl Drop for Redis {
     }
 }
 
+/// Retrieves the database reference and the specified column family handles.
+///
+/// # Parameters
+/// - `$self`: The receiver, typically a reference to a `Redis` instance.
+/// - `$cf`: One or more column family identifiers to retrieve handles for.
+///
+/// # Returns
+/// Returns a tuple containing:
+/// - A reference to the database (`db`).
+/// - A vector of column family handles corresponding to the provided identifiers.
+///
+/// # Errors
+/// Returns an error if the database is not initialized or if any column family handle is not found.
 #[macro_export]
 macro_rules! get_db_and_cfs {
     ($self:expr $(, $cf:expr)*) => {{

--- a/src/storage/src/redis.rs
+++ b/src/storage/src/redis.rs
@@ -401,3 +401,24 @@ impl Drop for Redis {
         }
     }
 }
+
+#[macro_export]
+macro_rules! get_db_and_cfs {
+    ($self:expr $(, $cf:expr)*) => {{
+        let db = $self.db.as_ref().context(OptionNoneSnafu {
+            message: "db is not initialized".to_string(),
+        })?;
+
+        let cfs = vec![
+            $(
+                $self
+                    .get_cf_handle($cf)
+                    .context(OptionNoneSnafu {
+                        message: format!("{:?} cf handle not found", $cf),
+                    })?
+            ),*
+        ];
+
+        (db, cfs)
+    }};
+}

--- a/src/storage/src/redis_hashes.rs
+++ b/src/storage/src/redis_hashes.rs
@@ -1,678 +1,106 @@
-/*
- * Copyright (c) 2024-present, arana-db Community.  All rights reserved.
- * 
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Redis hashes operations implementation
 //! This module provides hash operations for Redis storage
 
-use std::time::{SystemTime, UNIX_EPOCH};
-use rocksdb::{WriteBatch, WriteOptions, ReadOptions, Direction, IteratorMode};
+use rocksdb::ReadOptions;
+use snafu::OptionExt;
+use snafu::ResultExt;
 
-use crate::{Result, StorageError};
-use crate::base_data_value_format::{DataType, InternalValue, ParsedInternalValue};
-use crate::redis::Redis;
-use crate::types::{FieldValue, ValueStatus};
+use crate::base_data_value_format::ParsedBaseDataValue;
+use crate::base_meta_value_format::ParsedHashesMetaValue;
+use crate::error::{InvalidFormatSnafu, OptionNoneSnafu, RocksSnafu};
+use crate::get_db_and_cfs;
+use crate::member_data_key_format::MemberDataKey;
+use crate::{BaseMetaKey, ColumnFamilyIndex, DataType, Redis, Result};
 
 impl Redis {
     /// Delete one or more hash fields
-    pub fn hdel(&self, key: &[u8], fields: &[Vec<u8>], ret: &mut i32) -> Result<()> {
-        let db = self.db.as_ref().ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-        
-        // Get the hash metadata
-        let read_options = ReadOptions::default();
-        match db.get_opt(key, &read_options)? {
-            Some(meta_value) => {
-                // Parse the metadata
-                let mut parsed_meta = ParsedInternalValue::new(&meta_value);
-                if parsed_meta.data_type() != DataType::Hash {
-                    return Err(StorageError::InvalidFormat("Wrong type of value".to_string()));
-                }
-                
-                // Check if expired
-                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
-                if parsed_meta.is_expired(now) {
-                    *ret = 0;
-                    return Ok(());
-                }
-                
-                // Get hash size
-                let hash_size = parsed_meta.size();
-                if hash_size == 0 {
-                    *ret = 0;
-                    return Ok(());
-                }
-                
-                // Create batch
-                let mut batch = WriteBatch::default();
-                let mut deleted = 0;
-                
-                // Delete fields
-                for field in fields {
-                    // Create data key
-                    let data_key = self.encode_hash_data_key(key, field, parsed_meta.version());
-                    
-                    // Check if field exists
-                    match db.get_cf_opt(self.get_handle(crate::redis::ColumnFamilyIndex::HashesDataCF), &data_key, &read_options)? {
-                        Some(_) => {
-                            // Delete field
-                            batch.delete_cf(self.get_handle(crate::redis::ColumnFamilyIndex::HashesDataCF), &data_key);
-                            deleted += 1;
-                        },
-                        None => {}
-                    }
-                }
-                
-                if deleted > 0 {
-                    // Update metadata
-                    let new_size = hash_size - deleted as u64;
-                    
-                    // If hash is empty, delete the key
-                    if new_size == 0 {
-                        batch.delete(key);
-                    } else {
-                        // Update metadata
-                        parsed_meta.set_size(new_size);
-                        let new_meta_value = parsed_meta.encode();
-                        batch.put(key, &new_meta_value);
-                    }
-                    
-                    // Write batch to DB
-                    db.write_opt(batch, &self.default_write_options)?;
-                    
-                    // Update statistics
-                    self.update_specific_key_statistics(DataType::Hash, &String::from_utf8_lossy(key).to_string(), deleted as u64)?;
-                }
-                
-                *ret = deleted;
-                Ok(())
-            },
-            None => {
-                *ret = 0;
-                Ok(())
-            }
-        }
+    pub fn hdel(&self, _key: &[u8], _fields: &[Vec<u8>]) -> Result<i32> {
+        unimplemented!("hdel is not implemented");
     }
-    
+
     /// Determine if a hash field exists
     pub fn hexists(&self, key: &[u8], field: &[u8]) -> Result<bool> {
-        let db = self.db.as_ref().ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-        
-        // Get the hash metadata
-        let read_options = ReadOptions::default();
-        match db.get_opt(key, &read_options)? {
-            Some(meta_value) => {
-                // Parse the metadata
-                let parsed_meta = ParsedInternalValue::new(&meta_value);
-                if parsed_meta.data_type() != DataType::Hash {
-                    return Err(StorageError::InvalidFormat("Wrong type of value".to_string()));
-                }
-                
-                // Check if expired
-                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
-                if parsed_meta.is_expired(now) {
-                    return Ok(false);
-                }
-                
-                // Get hash size
-                let hash_size = parsed_meta.size();
-                if hash_size == 0 {
-                    return Ok(false);
-                }
-                
-                // Create data key
-                let data_key = self.encode_hash_data_key(key, field, parsed_meta.version());
-                
-                // Check if field exists
-                match db.get_cf_opt(self.get_handle(crate::redis::ColumnFamilyIndex::HashesDataCF), &data_key, &read_options)? {
-                    Some(_) => Ok(true),
-                    None => Ok(false)
-                }
-            },
-            None => Ok(false)
-        }
+        let ret = self.hget(key, field)?;
+        Ok(ret.is_some())
     }
-    
+
     /// Get the value of a hash field
-    pub fn hget(&self, key: &[u8], field: &[u8], value: &mut String) -> Result<()> {
-        let db = self.db.as_ref().ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-        
-        // Get the hash metadata
-        let read_options = ReadOptions::default();
-        match db.get_opt(key, &read_options)? {
-            Some(meta_value) => {
-                // Parse the metadata
-                let parsed_meta = ParsedInternalValue::new(&meta_value);
-                if parsed_meta.data_type() != DataType::Hash {
-                    return Err(StorageError::InvalidFormat("Wrong type of value".to_string()));
+    pub fn hget(&self, _key: &[u8], _field: &[u8]) -> Result<Option<String>> {
+        let (db, cfs) = get_db_and_cfs!(
+            self,
+            ColumnFamilyIndex::MetaCF,
+            ColumnFamilyIndex::HashesDataCF
+        );
+        let meta_cf = &cfs[0];
+        let data_cf = &cfs[1];
+
+        let mut read_options = ReadOptions::default();
+        read_options.set_snapshot(&db.snapshot());
+
+        let base_meta_key = BaseMetaKey::new(_key).encode()?;
+        if let Some(meta_val_bytes) = db
+            .get_cf_opt(meta_cf, &base_meta_key, &read_options)
+            .context(RocksSnafu)?
+        {
+            let meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
+            if meta_val.is_stale() {
+                return Ok(None);
+            }
+            if meta_val.inner.data_type != DataType::Hash {
+                return InvalidFormatSnafu {
+                    message: format!(
+                        "Wrong type of value, expected: {:?}, got: {:?}",
+                        DataType::Hash,
+                        meta_val.inner.data_type
+                    ),
                 }
-                
-                // Check if expired
-                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
-                if parsed_meta.is_expired(now) {
-                    return Err(StorageError::KeyNotFound(String::from_utf8_lossy(key).to_string()));
-                }
-                
-                // Get hash size
-                let hash_size = parsed_meta.size();
-                if hash_size == 0 {
-                    return Err(StorageError::KeyNotFound("Empty hash".to_string()));
-                }
-                
-                // Create data key
-                let data_key = self.encode_hash_data_key(key, field, parsed_meta.version());
-                
-                // Get the value
-                match db.get_cf_opt(self.get_handle(crate::redis::ColumnFamilyIndex::HashesDataCF), &data_key, &read_options)? {
-                    Some(data_value) => {
-                        // Parse the data value
-                        let parsed_data = ParsedInternalValue::new(&data_value);
-                        *value = String::from_utf8_lossy(parsed_data.user_value()).to_string();
-                        Ok(())
-                    },
-                    None => {
-                        Err(StorageError::KeyNotFound("Hash field not found".to_string()))
-                    }
-                }
-            },
-            None => {
-                Err(StorageError::KeyNotFound(String::from_utf8_lossy(key).to_string()))
+                .fail();
+            }
+            let version = meta_val.version();
+            let data_key = MemberDataKey::new(_key, version, _field);
+            if let Some(data_val_bytes) = db
+                .get_cf_opt(data_cf, &data_key.encode()?, &read_options)
+                .context(RocksSnafu)?
+            {
+                let mut data_val = ParsedBaseDataValue::new(&data_val_bytes[..])?;
+                data_val.strip_suffix();
+                return Ok(Some(
+                    String::from_utf8_lossy(&data_val.user_value()).to_string(),
+                ));
             }
         }
+
+        Ok(None)
     }
-    
-    /// Get all the fields and values in a hash
-    pub fn hgetall(&self, key: &[u8], fvs: &mut Vec<FieldValue>) -> Result<()> {
-        let db = self.db.as_ref().ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-        
-        // Get the hash metadata
-        let read_options = ReadOptions::default();
-        match db.get_opt(key, &read_options)? {
-            Some(meta_value) => {
-                // Parse the metadata
-                let parsed_meta = ParsedInternalValue::new(&meta_value);
-                if parsed_meta.data_type() != DataType::Hash {
-                    return Err(StorageError::InvalidFormat("Wrong type of value".to_string()));
-                }
-                
-                // Check if expired
-                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
-                if parsed_meta.is_expired(now) {
-                    return Ok(());
-                }
-                
-                // Get hash size
-                let hash_size = parsed_meta.size();
-                if hash_size == 0 {
-                    return Ok(());
-                }
-                
-                // Create prefix for data keys
-                let prefix = self.encode_hash_prefix(key, parsed_meta.version());
-                
-                // Iterate over all fields
-                let iter_opt = ReadOptions::default();
-                let iter = db.iterator_cf_opt(
-                    self.get_handle(crate::redis::ColumnFamilyIndex::HashesDataCF),
-                    iter_opt,
-                    IteratorMode::From(&prefix, Direction::Forward)
-                );
-                
-                for result in iter {
-                    let (k, v) = result?;
-                    // Check if key has the correct prefix
-                    if !k.starts_with(&prefix) {
-                        break;
-                    }
-                    
-                    // Extract field from key
-                    let field = self.decode_hash_field(&k, &prefix);
-                    
-                    // Parse the data value
-                    let parsed_data = ParsedInternalValue::new(&v);
-                    let value = String::from_utf8_lossy(parsed_data.user_value()).to_string();
-                    
-                    // Add to result
-                    fvs.push(FieldValue {
-                        field: field.to_vec(),
-                        value: value.into_bytes(),
-                    });
-                }
-                
-                Ok(())
-            },
-            None => Ok(())
-        }
-    }
-    
-    /// Get all the fields and values in a hash with TTL
-    pub fn hgetall_with_ttl(&self, key: &[u8], fvs: &mut Vec<FieldValue>, ttl: &mut i64) -> Result<()> {
-        let db = self.db.as_ref().ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-        
-        // Get the hash metadata
-        let read_options = ReadOptions::default();
-        match db.get_opt(key, &read_options)? {
-            Some(meta_value) => {
-                // Parse the metadata
-                let parsed_meta = ParsedInternalValue::new(&meta_value);
-                if parsed_meta.data_type() != DataType::Hash {
-                    return Err(StorageError::InvalidFormat("Wrong type of value".to_string()));
-                }
-                
-                // Check if expired
-                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
-                if parsed_meta.is_expired(now) {
-                    *ttl = -2; // Expired
-                    return Ok(());
-                }
-                
-                // Calculate TTL
-                let etime = parsed_meta.etime();
-                if etime > 0 {
-                    *ttl = etime as i64 - now as i64;
-                    if *ttl < 0 {
-                        *ttl = 0;
-                    }
-                } else {
-                    *ttl = -1; // No expiration
-                }
-                
-                // Get hash size
-                let hash_size = parsed_meta.size();
-                if hash_size == 0 {
-                    return Ok(());
-                }
-                
-                // Create prefix for data keys
-                let prefix = self.encode_hash_prefix(key, parsed_meta.version());
-                
-                // Iterate over all fields
-                let iter_opt = ReadOptions::default();
-                let iter = db.iterator_cf_opt(
-                    self.get_handle(crate::redis::ColumnFamilyIndex::HashesDataCF),
-                    iter_opt,
-                    IteratorMode::From(&prefix, Direction::Forward)
-                );
-                
-                for result in iter {
-                    let (k, v) = result?;
-                    // Check if key has the correct prefix
-                    if !k.starts_with(&prefix) {
-                        break;
-                    }
-                    
-                    // Extract field from key
-                    let field = self.decode_hash_field(&k, &prefix);
-                    
-                    // Parse the data value
-                    let parsed_data = ParsedInternalValue::new(&v);
-                    let value = String::from_utf8_lossy(parsed_data.user_value()).to_string();
-                    
-                    // Add to result
-                    fvs.push(FieldValue {
-                        field: field.to_vec(),
-                        value: value.into_bytes(),
-                    });
-                }
-                
-                Ok(())
-            },
-            None => {
-                *ttl = -2; // Key does not exist
-                Ok(())
-            }
-        }
-    }
-    
+
     /// Get all the fields in a hash
-    pub fn hkeys(&self, key: &[u8], fields: &mut Vec<String>) -> Result<()> {
-        let db = self.db.as_ref().ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-        
-        // Get the hash metadata
-        let read_options = ReadOptions::default();
-        match db.get_opt(key, &read_options)? {
-            Some(meta_value) => {
-                // Parse the metadata
-                let parsed_meta = ParsedInternalValue::new(&meta_value);
-                if parsed_meta.data_type() != DataType::Hash {
-                    return Err(StorageError::InvalidFormat("Wrong type of value".to_string()));
-                }
-                
-                // Check if expired
-                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
-                if parsed_meta.is_expired(now) {
-                    return Ok(());
-                }
-                
-                // Get hash size
-                let hash_size = parsed_meta.size();
-                if hash_size == 0 {
-                    return Ok(());
-                }
-                
-                // Create prefix for data keys
-                let prefix = self.encode_hash_prefix(key, parsed_meta.version());
-                
-                // Iterate over all fields
-                let iter_opt = ReadOptions::default();
-                let iter = db.iterator_cf_opt(
-                    self.get_handle(crate::redis::ColumnFamilyIndex::HashesDataCF),
-                    iter_opt,
-                    IteratorMode::From(&prefix, Direction::Forward)
-                );
-                
-                for result in iter {
-                    let (k, _) = result?;
-                    // Check if key has the correct prefix
-                    if !k.starts_with(&prefix) {
-                        break;
-                    }
-                    
-                    // Extract field from key
-                    let field = self.decode_hash_field(&k, &prefix);
-                    
-                    // Add to result
-                    fields.push(String::from_utf8_lossy(field).to_string());
-                }
-                
-                Ok(())
-            },
-            None => Ok(())
-        }
+    pub fn hkeys(&self, _key: &[u8]) -> Result<Vec<String>> {
+        unimplemented!("hkeys is not implemented");
     }
-    
+
     /// Get the number of fields in a hash
-    pub fn hlen(&self, key: &[u8], len: &mut i32) -> Result<()> {
-        let db = self.db.as_ref().ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-        
-        // Get the hash metadata
-        let read_options = ReadOptions::default();
-        match db.get_opt(key, &read_options)? {
-            Some(meta_value) => {
-                // Parse the metadata
-                let parsed_meta = ParsedInternalValue::new(&meta_value);
-                if parsed_meta.data_type() != DataType::Hash {
-                    return Err(StorageError::InvalidFormat("Wrong type of value".to_string()));
-                }
-                
-                // Check if expired
-                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
-                if parsed_meta.is_expired(now) {
-                    *len = 0;
-                    return Ok(());
-                }
-                
-                // Return the length
-                *len = parsed_meta.size() as i32;
-                Ok(())
-            },
-            None => {
-                *len = 0;
-                Ok(())
-            }
-        }
+    pub fn hlen(&self, _key: &[u8]) -> Result<i32> {
+        unimplemented!("hlen is not implemented");
     }
-    
-    /// Set the string value of a hash field
-    pub fn hset(&self, key: &[u8], field: &[u8], value: &[u8], res: &mut i32) -> Result<()> {
-        let db = self.db.as_ref().ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-        
-        let mut version = 0;
-        let mut hash_size = 0;
-        let mut timestamp = 0;
-        let mut exists = false;
-        
-        // Get the hash metadata
-        let read_options = ReadOptions::default();
-        match db.get_opt(key, &read_options)? {
-            Some(meta_value) => {
-                // Parse the metadata
-                let parsed_meta = ParsedInternalValue::new(&meta_value);
-                if parsed_meta.data_type() != DataType::Hash {
-                    return Err(StorageError::InvalidFormat("Wrong type of value".to_string()));
-                }
-                
-                // Check if expired
-                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
-                if !parsed_meta.is_expired(now) {
-                    version = parsed_meta.version();
-                    hash_size = parsed_meta.size();
-                    timestamp = parsed_meta.etime();
-                    
-                    // Check if field exists
-                    let data_key = self.encode_hash_data_key(key, field, version);
-                    match db.get_cf_opt(self.get_handle(crate::redis::ColumnFamilyIndex::HashesDataCF), &data_key, &read_options)? {
-                        Some(_) => {
-                            exists = true;
-                        },
-                        None => {}
-                    }
-                }
-            },
-            None => {}
-        }
-        
-        // Create batch
-        let mut batch = WriteBatch::default();
-        
-        // Create metadata
-        let mut internal_meta = InternalValue::new(DataType::Hashes, &[]);
-        internal_meta.set_version(version);
-        if !exists {
-            internal_meta.set_size(hash_size + 1);
-        } else {
-            internal_meta.set_size(hash_size);
-        }
-        if timestamp > 0 {
-            internal_meta.set_etime(timestamp);
-        }
-        let meta_value = internal_meta.encode();
-        
-        // Add metadata to batch
-        batch.put(key, &meta_value);
-        
-        // Create data key
-        let data_key = self.encode_hash_data_key(key, field, version);
-        
-        // Create data value
-        let internal_data = InternalValue::new(DataType::Hashes, value);
-        let data_value = internal_data.encode();
-        
-        // Add to batch
-        batch.put_cf(self.get_handle(crate::redis::ColumnFamilyIndex::HashesDataCF), &data_key, &data_value);
-        
-        // Write batch to DB
-        db.write_opt(batch, &self.default_write_options)?;
-        
-        // Update statistics
-        self.update_specific_key_statistics(DataType::Hashes, &String::from_utf8_lossy(key).to_string(), 1)?;
-        
-        // Set the return value
-        *res = if exists { 0 } else { 1 };
-        
-        Ok(())
-    }
-    
-    /// Set the value of a hash field, only if the field does not exist
-    pub fn hsetnx(&self, key: &[u8], field: &[u8], value: &[u8], ret: &mut i32) -> Result<()> {
-        let db = self.db.as_ref().ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-        
-        let mut version = 0;
-        let mut hash_size = 0;
-        let mut timestamp = 0;
-        let mut exists = false;
-        
-        // Get the hash metadata
-        let read_options = ReadOptions::default();
-        match db.get_opt(key, &read_options)? {
-            Some(meta_value) => {
-                // Parse the metadata
-                let parsed_meta = ParsedInternalValue::new(&meta_value);
-                if parsed_meta.data_type() != DataType::Hash {
-                    return Err(StorageError::InvalidFormat("Wrong type of value".to_string()));
-                }
-                
-                // Check if expired
-                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
-                if !parsed_meta.is_expired(now) {
-                    version = parsed_meta.version();
-                    hash_size = parsed_meta.size();
-                    timestamp = parsed_meta.etime();
-                    
-                    // Check if field exists
-                    let data_key = self.encode_hash_data_key(key, field, version);
-                    match db.get_cf_opt(self.get_handle(crate::redis::ColumnFamilyIndex::HashesDataCF), &data_key, &read_options)? {
-                        Some(_) => {
-                            exists = true;
-                            *ret = 0; // Field exists, not set
-                            return Ok(());
-                        },
-                        None => {}
-                    }
-                }
-            },
-            None => {}
-        }
-        
-        // Create batch
-        let mut batch = WriteBatch::default();
-        
-        // Create metadata
-        let mut internal_meta = InternalValue::new(DataType::Hashes, &[]);
-        internal_meta.set_version(version);
-        internal_meta.set_size(hash_size + 1);
-        if timestamp > 0 {
-            internal_meta.set_etime(timestamp);
-        }
-        let meta_value = internal_meta.encode();
-        
-        // Add metadata to batch
-        batch.put(key, &meta_value);
-        
-        // Create data key
-        let data_key = self.encode_hash_data_key(key, field, version);
-        
-        // Create data value
-        let internal_data = InternalValue::new(DataType::Hashes, value);
-        let data_value = internal_data.encode();
-        
-        // Add to batch
-        batch.put_cf(self.get_handle(crate::redis::ColumnFamilyIndex::HashesDataCF), &data_key, &data_value);
-        
-        // Write batch to DB
-        db.write_opt(batch, &self.default_write_options)?;
-        
-        // Update statistics
-        self.update_specific_key_statistics(DataType::Hashes, &String::from_utf8_lossy(key).to_string(), 1)?;
-        
-        // Set the return value
-        *ret = 1; // Field set
-        
-        Ok(())
-    }
-    
-    /// Get all the values in a hash
-    pub fn hvals(&self, key: &[u8], values: &mut Vec<String>) -> Result<()> {
-        let db = self.db.as_ref().ok_or_else(|| StorageError::InvalidFormat("DB not initialized".to_string()))?;
-        
-        // Get the hash metadata
-        let read_options = ReadOptions::default();
-        match db.get_opt(key, &read_options)? {
-            Some(meta_value) => {
-                // Parse the metadata
-                let parsed_meta = ParsedInternalValue::new(&meta_value);
-                if parsed_meta.data_type() != DataType::Hash {
-                    return Err(StorageError::InvalidFormat("Wrong type of value".to_string()));
-                }
-                
-                // Check if expired
-                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
-                if parsed_meta.is_expired(now) {
-                    return Ok(());
-                }
-                
-                // Get hash size
-                let hash_size = parsed_meta.size();
-                if hash_size == 0 {
-                    return Ok(());
-                }
-                
-                // Create prefix for data keys
-                let prefix = self.encode_hash_prefix(key, parsed_meta.version());
-                
-                // Iterate over all fields
-                let iter_opt = ReadOptions::default();
-                let iter = db.iterator_cf_opt(
-                    self.get_handle(crate::redis::ColumnFamilyIndex::HashesDataCF),
-                    iter_opt,
-                    IteratorMode::From(&prefix, Direction::Forward)
-                );
-                
-                for result in iter {
-                    let (k, v) = result?;
-                    // Check if key has the correct prefix
-                    if !k.starts_with(&prefix) {
-                        break;
-                    }
-                    
-                    // Parse the data value
-                    let parsed_data = ParsedInternalValue::new(&v);
-                    let value = String::from_utf8_lossy(parsed_data.user_value()).to_string();
-                    
-                    // Add to result
-                    values.push(value);
-                }
-                
-                Ok(())
-            },
-            None => Ok(())
-        }
-    }
-    
-    /// Helper method to encode hash data key
-    fn encode_hash_data_key(&self, key: &[u8], field: &[u8], version: u64) -> Vec<u8> {
-        // In a real implementation, this would encode the key properly
-        // For now, we'll use a simple format: key + "_" + field + "_" + version
-        let mut data_key = Vec::with_capacity(key.len() + field.len() + 20);
-        data_key.extend_from_slice(key);
-        data_key.push(b'_');
-        data_key.extend_from_slice(field);
-        data_key.push(b'_');
-        data_key.extend_from_slice(version.to_string().as_bytes());
-        data_key
-    }
-    
-    /// Helper method to encode hash prefix
-    fn encode_hash_prefix(&self, key: &[u8], version: u64) -> Vec<u8> {
-        // In a real implementation, this would encode the prefix properly
-        // For now, we'll use a simple format: key + "_"
-        let mut prefix = Vec::with_capacity(key.len() + 1);
-        prefix.extend_from_slice(key);
-        prefix.push(b'_');
-        prefix
-    }
-    
-    /// Helper method to decode hash field from data key
-    fn decode_hash_field<'a>(&self, data_key: &'a [u8], prefix: &[u8]) -> &'a [u8] {
-        // In a real implementation, this would decode the field properly
-        // For now, we'll extract the field from the data key
-        let field_start = prefix.len();
-        let field_end = data_key.iter().rposition(|&b| b == b'_').unwrap_or(data_key.len());
-        &data_key[field_start..field_end]
+
+    pub fn hset(&self, _key: &[u8], _field: &[u8], _value: &[u8]) -> Result<i32> {
+        unimplemented!("hset is not implemented");
     }
 }

--- a/src/storage/tests/redis_hash_test.rs
+++ b/src/storage/tests/redis_hash_test.rs
@@ -1,0 +1,135 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(test)]
+mod redis_hash_test {
+    use std::sync::Arc;
+
+    use kstd::lock_mgr::LockMgr;
+    use storage::{BgTaskHandler, Redis, StorageOptions, unique_test_db_path};
+
+    #[test]
+    fn test_hset_hget_hexists_basic() {
+        let test_db_path = unique_test_db_path();
+
+        if test_db_path.exists() {
+            std::fs::remove_dir_all(&test_db_path).unwrap();
+        }
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+
+        let result = redis.open(test_db_path.to_str().unwrap());
+        assert!(result.is_ok(), "open redis db failed: {:?}", result.err());
+
+        let key = b"test_hash";
+        let field = b"field1";
+        let mut value = b"value1";
+
+        // Test hset - should create new hash and return 1
+        let hset_result = redis.hset(key, field, value);
+        assert!(
+            hset_result.is_ok(),
+            "hset command failed: {:?}",
+            hset_result.err()
+        );
+        let hset_count = hset_result.unwrap();
+        assert_eq!(hset_count, 1);
+
+        // Test hset again with same field - should return 0 (field already exists)
+        let hset_result2 = redis.hset(key, field, b"value2");
+        assert!(
+            hset_result2.is_ok(),
+            "second hset failed: {:?}",
+            hset_result2.err()
+        );
+        let hset_count2 = hset_result2.unwrap();
+        assert_eq!(hset_count2, 0);
+        value = b"value2";
+
+        // Add a small delay to ensure data is persisted
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        // // Test hexists first
+        let hexists_result = redis.hexists(key, field);
+        assert!(
+            hexists_result.is_ok(),
+            "hexists failed: {:?}",
+            hexists_result.err()
+        );
+        assert_eq!(hexists_result.unwrap(), true);
+
+        // Test hget - should return the value
+        let hget_result = redis.hget(key, field);
+        assert!(
+            hget_result.is_ok(),
+            "hget command failed: {:?}",
+            hget_result.err()
+        );
+        let retrieved_value = hget_result.unwrap();
+        assert!(
+            retrieved_value.is_some(),
+            "hget returned None, expected value: {:?}",
+            String::from_utf8_lossy(value)
+        );
+        assert_eq!(
+            retrieved_value.unwrap(),
+            String::from_utf8_lossy(value).to_string()
+        );
+
+        redis.set_need_close(true);
+        drop(redis);
+
+        if test_db_path.exists() {
+            std::fs::remove_dir_all(test_db_path).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_hget_nonexistent_key() {
+        let test_db_path = unique_test_db_path();
+
+        if test_db_path.exists() {
+            std::fs::remove_dir_all(&test_db_path).unwrap();
+        }
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+
+        let result = redis.open(test_db_path.to_str().unwrap());
+        assert!(result.is_ok(), "open redis db failed: {:?}", result.err());
+
+        let key = b"nonexistent_hash";
+        let field = b"field1";
+
+        // Test hget on non-existent key
+        let hget_result = redis.hget(key, field);
+        assert!(hget_result.is_ok(), "hget failed: {:?}", hget_result.err());
+        assert_eq!(hget_result.unwrap(), None);
+
+        redis.set_need_close(true);
+        drop(redis);
+
+        if test_db_path.exists() {
+            std::fs::remove_dir_all(test_db_path).unwrap();
+        }
+    }
+}

--- a/src/storage/tests/redis_hash_test.rs
+++ b/src/storage/tests/redis_hash_test.rs
@@ -40,7 +40,7 @@ mod redis_hash_test {
 
         let key = b"test_hash";
         let field = b"field1";
-        let mut value = b"value1";
+        let value = b"value1";
 
         // Test hset - should create new hash and return 1
         let hset_result = redis.hset(key, field, value);
@@ -61,7 +61,6 @@ mod redis_hash_test {
         );
         let hset_count2 = hset_result2.unwrap();
         assert_eq!(hset_count2, 0);
-        value = b"value2";
 
         // Add a small delay to ensure data is persisted
         std::thread::sleep(std::time::Duration::from_millis(10));
@@ -75,6 +74,7 @@ mod redis_hash_test {
         );
         assert_eq!(hexists_result.unwrap(), true);
 
+        let expected_val = b"value2";
         // Test hget - should return the value
         let hget_result = redis.hget(key, field);
         assert!(
@@ -86,11 +86,11 @@ mod redis_hash_test {
         assert!(
             retrieved_value.is_some(),
             "hget returned None, expected value: {:?}",
-            String::from_utf8_lossy(value)
+            String::from_utf8_lossy(expected_val)
         );
         assert_eq!(
             retrieved_value.unwrap(),
-            String::from_utf8_lossy(value).to_string()
+            String::from_utf8_lossy(expected_val).to_string()
         );
 
         redis.set_need_close(true);


### PR DESCRIPTION
- Changed `HashesMetaValue` and `ParsedHashesMetaValue` to public types.
- Introduced a new module `redis_hashes` for Redis hash operations.
- Updated `hdel`, `hget`, `hkeys`, and `hlen` methods to unimplemented stubs.
- Enhanced `hget` to include metadata checks and return appropriate results.
- Added a macro `get_db_and_cfs` for easier database and column family access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redis Hash API simplified: commands now return values/results (e.g., hget -> Optional, hkeys -> list, hlen/hset/hdel -> counts); several legacy hash commands removed.
* **New Features**
  * Exposed hash metadata types, value metadata accessors, and made value encoding accessible. Added a Redis-specific error variant.
* **Tests**
  * Integration tests for basic hash behavior (hset/hget/hexists and missing-key handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->