### PR TITLE
feat(storage): implement load_cursor_start_key and store_cursor_start_key

### DIFF
--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -29,7 +29,7 @@ use crate::base_value_format::DataType;
 use crate::error::{Error, MpscSnafu, Result};
 use crate::options::OptionType;
 use crate::slot_indexer::SlotIndexer;
-use crate::{Redis, StorageOptions, base_data_value_format, data_type_to_tag};
+use crate::{Redis, StorageOptions, data_type_to_tag};
 
 pub enum TaskType {
     None = 0,

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -352,19 +352,16 @@ impl Storage {
         let index_key = format!("{}{}", data_type_to_tag(dtype), cursor);
         match self.cursors_store.get(&index_key) {
             Some(entry) => {
-                let index_value = entry.value().clone();
+                let index_value = entry.value();
                 if index_value.len() < 3 {
                     return Err(Error::InvalidFormat {
                         message: "Invalid cursor data: too short".to_string(),
                         location: snafu::location!(),
                     });
                 }
-                *cursor_type = index_value.chars().next().unwrap();
-                *start_key = if index_value.len() > 1 {
-                    index_value[1..].to_string()
-                } else {
-                    String::new()
-                };
+                let b = index_value.as_bytes();
+                *cursor_type = b[0] as char;
+                *start_key = index_value[1..].to_string();
                 Ok(())
             }
             None => Err(Error::KeyNotFound {

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -342,11 +342,14 @@ impl Storage {
         unimplemented!("This function is not implemented yet");
     }
 
-    pub fn load_cursor_start_key() {
-        unimplemented!("This function is not implemented yet");
+    pub fn load_cursor_start_key(&self, cursor_id: &str) -> Option<String> {
+        self.cursors_store
+            .get(cursor_id)
+            .map(|entry| entry.value().clone())
     }
 
-    pub fn store_cursor_start_key() {
-        unimplemented!("This function is not implemented yet");
+    pub fn store_cursor_start_key(&self, cursor_id: &str, start_key: &str) {
+        self.cursors_store
+            .insert(cursor_id.to_string(), start_key.to_string());
     }
 }

--- a/src/storage/tests/cursor_management_test.rs
+++ b/src/storage/tests/cursor_management_test.rs
@@ -1,10 +1,33 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[cfg(test)]
 mod cursor_management_test {
-    use storage::{DataType, storage::Storage};
+    use std::sync::Arc;
+
+    use storage::{DataType, StorageOptions, storage::Storage, unique_test_db_path};
 
     #[test]
     fn test_store_and_load_cursor_basic() {
-        let storage = Storage::new(1, 0);
+        let test_db_path = unique_test_db_path();
+        let mut storage = Storage::new(1, 0);
+        let options = Arc::new(StorageOptions::default());
+
+        let _receiver = storage.open(options, &test_db_path).unwrap();
 
         // Test basic storage and load
         let result =
@@ -19,11 +42,19 @@ mod cursor_management_test {
         assert!(result.is_ok());
         assert_eq!(cursor_type, 's');
         assert_eq!(start_key, "test_key_001");
+
+        if test_db_path.exists() {
+            std::fs::remove_dir_all(test_db_path).unwrap();
+        }
     }
 
     #[test]
     fn test_load_nonexist_cursor() {
-        let storage = Storage::new(1, 0);
+        let test_db_path = unique_test_db_path();
+        let mut storage = Storage::new(1, 0);
+        let options = Arc::new(StorageOptions::default());
+
+        let _receiver = storage.open(options, &test_db_path).unwrap();
 
         let mut cursor_type = '\0';
         let mut start_key = String::new();
@@ -31,11 +62,19 @@ mod cursor_management_test {
             storage.load_cursor_start_key(DataType::Set, 99999, &mut cursor_type, &mut start_key);
 
         assert!(result.is_err());
+
+        if test_db_path.exists() {
+            std::fs::remove_dir_all(test_db_path).unwrap();
+        }
     }
 
     #[test]
     fn test_multiple_data_types() {
-        let storage = Storage::new(1, 0);
+        let test_db_path = unique_test_db_path();
+        let mut storage = Storage::new(1, 0);
+        let options = Arc::new(StorageOptions::default());
+
+        let _receiver = storage.open(options, &test_db_path).unwrap();
 
         // Test different data types
         let test_cases = vec![
@@ -59,6 +98,10 @@ mod cursor_management_test {
 
             assert_eq!(cursor_type, expected_type);
             assert_eq!(start_key, key);
+        }
+
+        if test_db_path.exists() {
+            std::fs::remove_dir_all(test_db_path).unwrap();
         }
     }
 }

--- a/src/storage/tests/cursor_management_test.rs
+++ b/src/storage/tests/cursor_management_test.rs
@@ -43,6 +43,7 @@ mod cursor_management_test {
         assert_eq!(cursor_type, 's');
         assert_eq!(start_key, "test_key_001");
 
+        drop(storage);
         if test_db_path.exists() {
             std::fs::remove_dir_all(test_db_path).unwrap();
         }
@@ -62,7 +63,7 @@ mod cursor_management_test {
             storage.load_cursor_start_key(DataType::Set, 99999, &mut cursor_type, &mut start_key);
 
         assert!(result.is_err());
-
+        drop(storage);
         if test_db_path.exists() {
             std::fs::remove_dir_all(test_db_path).unwrap();
         }
@@ -99,7 +100,7 @@ mod cursor_management_test {
             assert_eq!(cursor_type, expected_type);
             assert_eq!(start_key, key);
         }
-
+        drop(storage);
         if test_db_path.exists() {
             std::fs::remove_dir_all(test_db_path).unwrap();
         }

--- a/src/storage/tests/cursor_management_test.rs
+++ b/src/storage/tests/cursor_management_test.rs
@@ -1,0 +1,64 @@
+#[cfg(test)]
+mod cursor_management_test {
+    use storage::{DataType, storage::Storage};
+
+    #[test]
+    fn test_store_and_load_cursor_basic() {
+        let storage = Storage::new(1, 0);
+
+        // Test basic storage and load
+        let result =
+            storage.store_cursor_start_key(DataType::Set, 12345, 's', "test_key_001".to_string());
+        assert!(result.is_ok());
+
+        let mut cursor_type = '\0';
+        let mut start_key = String::new();
+        let result =
+            storage.load_cursor_start_key(DataType::Set, 12345, &mut cursor_type, &mut start_key);
+
+        assert!(result.is_ok());
+        assert_eq!(cursor_type, 's');
+        assert_eq!(start_key, "test_key_001");
+    }
+
+    #[test]
+    fn test_load_nonexist_cursor() {
+        let storage = Storage::new(1, 0);
+
+        let mut cursor_type = '\0';
+        let mut start_key = String::new();
+        let result =
+            storage.load_cursor_start_key(DataType::Set, 99999, &mut cursor_type, &mut start_key);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_multiple_data_types() {
+        let storage = Storage::new(1, 0);
+
+        // Test different data types
+        let test_cases = vec![
+            (DataType::String, 'k', "string_key"),
+            (DataType::Hash, 'h', "hash_key"),
+            (DataType::Set, 's', "set_key"),
+            (DataType::List, 'l', "list_key"),
+            (DataType::ZSet, 'z', "zset_key"),
+        ];
+
+        for (dtype, expected_type, key) in test_cases {
+            storage
+                .store_cursor_start_key(dtype, 1001, expected_type, key.to_string())
+                .unwrap();
+
+            let mut cursor_type = '\0';
+            let mut start_key = String::new();
+            storage
+                .load_cursor_start_key(dtype, 1001, &mut cursor_type, &mut start_key)
+                .unwrap();
+
+            assert_eq!(cursor_type, expected_type);
+            assert_eq!(start_key, key);
+        }
+    }
+}


### PR DESCRIPTION
## Description  
Implemented cursor management functionality in the Storage struct, completing the previously empty implementations.  
  
## Changes  
- Implement `load_cursor_start_key()` method: loads cursor start key from cursors_store cache  
- Implement `store_cursor_start_key()` method: stores cursor start key to cursors_store cache  
  
## Technical Details  
- Supports cursor state management for Redis SCAN operations  
  
## Testing  
- [✓ ] Compilation passes  
- [✓ ] Formatting checks pass  
- [✓ ] Clippy static analysis passes  
  
## issue
#120 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent cursor storage and restoration across sessions for all data types, preserving list positions.
* **Bug Fixes**
  * Added validation and explicit errors for missing or malformed cursor data; removal of entries when cursors are cleared.
* **Tests**
  * Added tests for store/load round-trips, missing-cursor behavior, multi-type scenarios, and cursor removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->