### PR TITLE
feat(resp): implement full RESP3 support with unified architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,6 +1859,7 @@ name = "resp"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "memchr",
  "nom 8.0.0",
  "thiserror 1.0.69",
 ]

--- a/src/resp/Cargo.toml
+++ b/src/resp/Cargo.toml
@@ -10,3 +10,4 @@ workspace = true
 bytes.workspace = true
 thiserror.workspace = true
 nom.workspace = true
+memchr = "2"

--- a/src/resp/src/compat.rs
+++ b/src/resp/src/compat.rs
@@ -43,7 +43,7 @@ pub enum MapMode {
 }
 
 /// Configuration for converting RESP3 types to older RESP versions.
-/// 
+///
 /// This policy defines how RESP3-specific types (Boolean, Double, Map, etc.)
 /// should be represented when encoding to RESP1 or RESP2 protocols.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -58,7 +58,7 @@ pub struct DownlevelPolicy {
 
 impl Default for DownlevelPolicy {
     /// Creates a default downlevel policy with conservative conversion settings.
-    /// 
+    ///
     /// Default settings:
     /// - Boolean → Integer (true → :1, false → :0)
     /// - Double → BulkString (3.14 → $4\r\n3.14\r\n)

--- a/src/resp/src/compat.rs
+++ b/src/resp/src/compat.rs
@@ -1,3 +1,20 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BooleanMode {
     Integer,

--- a/src/resp/src/compat.rs
+++ b/src/resp/src/compat.rs
@@ -1,0 +1,34 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BooleanMode {
+    Integer,
+    SimpleString,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DoubleMode {
+    BulkString,
+    IntegerIfWhole,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MapMode {
+    FlatArray,
+    ArrayOfPairs,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DownlevelPolicy {
+    pub boolean_mode: BooleanMode,
+    pub double_mode: DoubleMode,
+    pub map_mode: MapMode,
+}
+
+impl Default for DownlevelPolicy {
+    fn default() -> Self {
+        Self {
+            boolean_mode: BooleanMode::Integer,
+            double_mode: DoubleMode::BulkString,
+            map_mode: MapMode::FlatArray,
+        }
+    }
+}

--- a/src/resp/src/compat.rs
+++ b/src/resp/src/compat.rs
@@ -15,32 +15,54 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// Defines how Boolean values should be converted when encoding to older RESP versions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BooleanMode {
+    /// Convert Boolean to Integer: true → :1, false → :0
     Integer,
+    /// Convert Boolean to Simple String: true → +OK, false → +ERR
     SimpleString,
 }
 
+/// Defines how Double values should be converted when encoding to older RESP versions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DoubleMode {
+    /// Convert Double to Bulk String: 3.14 → $4\r\n3.14\r\n
     BulkString,
+    /// Convert Double to Integer if whole number: 2.0 → :2, 2.5 → BulkString
     IntegerIfWhole,
 }
 
+/// Defines how Map values should be converted when encoding to older RESP versions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MapMode {
+    /// Convert Map to flat Array: Map{k1:v1,k2:v2} → *4\r\nk1\r\nv1\r\nk2\r\nv2\r\n
     FlatArray,
+    /// Convert Map to Array of pairs: Map{k1:v1,k2:v2} → *2\r\n*2\r\nk1\r\nv1\r\n*2\r\nk2\r\nv2\r\n
     ArrayOfPairs,
 }
 
+/// Configuration for converting RESP3 types to older RESP versions.
+/// 
+/// This policy defines how RESP3-specific types (Boolean, Double, Map, etc.)
+/// should be represented when encoding to RESP1 or RESP2 protocols.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DownlevelPolicy {
+    /// How to convert Boolean values
     pub boolean_mode: BooleanMode,
+    /// How to convert Double values
     pub double_mode: DoubleMode,
+    /// How to convert Map values
     pub map_mode: MapMode,
 }
 
 impl Default for DownlevelPolicy {
+    /// Creates a default downlevel policy with conservative conversion settings.
+    /// 
+    /// Default settings:
+    /// - Boolean → Integer (true → :1, false → :0)
+    /// - Double → BulkString (3.14 → $4\r\n3.14\r\n)
+    /// - Map → FlatArray (Map{k:v} → *2\r\nk\r\nv\r\n)
     fn default() -> Self {
         Self {
             boolean_mode: BooleanMode::Integer,

--- a/src/resp/src/encode.rs
+++ b/src/resp/src/encode.rs
@@ -370,6 +370,11 @@ impl RespEncode for RespEncoder {
                 }
                 self.append_crlf()
             }
+            // RESP3-only variants (Null, Boolean, Double, BulkError, VerbatimString,
+            // BigNumber, Map, Set, Push) are not encoded in the legacy RESP2 encoder
+            // and are silently skipped. These should be handled by version-specific
+            // encoders (Resp1Encoder, Resp2Encoder, Resp3Encoder) with appropriate
+            // downlevel conversion policies.
             _ => self,
         }
     }

--- a/src/resp/src/encode.rs
+++ b/src/resp/src/encode.rs
@@ -370,6 +370,7 @@ impl RespEncode for RespEncoder {
                 }
                 self.append_crlf()
             }
+            _ => self,
         }
     }
 }

--- a/src/resp/src/factory.rs
+++ b/src/resp/src/factory.rs
@@ -15,22 +15,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
-//
-// Licensed to the Apache Software Foundation (ASF) under one or more
-// contributor license agreements.  See the NOTICE file distributed with
-// this work for additional information regarding copyright ownership.
-// The ASF licenses this file to You under the Apache License, Version 2.0
-// (the "License"); you may not use this file except in compliance with
-// the License.  You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/// Factory functions for creating RESP protocol encoders and decoders.
+/// 
+/// This module provides convenient factory functions to create version-specific
+/// encoder and decoder instances based on the desired RESP protocol version.
 
 use crate::{
     compat::DownlevelPolicy,
@@ -38,6 +26,21 @@ use crate::{
     types::RespVersion,
 };
 
+/// Create a new decoder for the specified RESP version.
+/// 
+/// # Arguments
+/// * `version` - The RESP protocol version to create a decoder for
+/// 
+/// # Returns
+/// A boxed decoder instance that implements the `Decoder` trait
+/// 
+/// # Examples
+/// ```
+/// use resp::{RespVersion, new_decoder};
+/// 
+/// let mut decoder = new_decoder(RespVersion::RESP3);
+/// decoder.push("+OK\r\n".into());
+/// ```
 pub fn new_decoder(version: RespVersion) -> Box<dyn Decoder> {
     match version {
         RespVersion::RESP1 => Box::new(crate::resp1::decoder::Resp1Decoder::default()),
@@ -46,6 +49,22 @@ pub fn new_decoder(version: RespVersion) -> Box<dyn Decoder> {
     }
 }
 
+/// Create a new encoder for the specified RESP version.
+/// 
+/// # Arguments
+/// * `version` - The RESP protocol version to create an encoder for
+/// 
+/// # Returns
+/// A boxed encoder instance that implements the `Encoder` trait
+/// 
+/// # Examples
+/// ```
+/// use resp::{RespData, RespVersion, new_encoder};
+/// 
+/// let mut encoder = new_encoder(RespVersion::RESP3);
+/// let bytes = encoder.encode_one(&RespData::Boolean(true)).unwrap();
+/// assert_eq!(bytes.as_ref(), b"#t\r\n");
+/// ```
 pub fn new_encoder(version: RespVersion) -> Box<dyn Encoder> {
     match version {
         RespVersion::RESP1 => Box::new(crate::resp1::encoder::Resp1Encoder::default()),
@@ -54,6 +73,27 @@ pub fn new_encoder(version: RespVersion) -> Box<dyn Encoder> {
     }
 }
 
+/// Create a new encoder for the specified RESP version with custom downlevel policy.
+/// 
+/// # Arguments
+/// * `version` - The RESP protocol version to create an encoder for
+/// * `policy` - The downlevel compatibility policy for RESP3 types
+/// 
+/// # Returns
+/// A boxed encoder instance that implements the `Encoder` trait
+/// 
+/// # Examples
+/// ```
+/// use resp::{BooleanMode, DownlevelPolicy, RespData, RespVersion, new_encoder_with_policy};
+/// 
+/// let policy = DownlevelPolicy {
+///     boolean_mode: BooleanMode::SimpleString,
+///     ..Default::default()
+/// };
+/// let mut encoder = new_encoder_with_policy(RespVersion::RESP2, policy);
+/// let bytes = encoder.encode_one(&RespData::Boolean(true)).unwrap(); // "+OK\r\n"
+/// assert_eq!(bytes.as_ref(), b"+OK\r\n");
+/// ```
 pub fn new_encoder_with_policy(version: RespVersion, policy: DownlevelPolicy) -> Box<dyn Encoder> {
     match version {
         RespVersion::RESP1 => Box::new(crate::resp1::encoder::Resp1Encoder::with_policy(policy)),

--- a/src/resp/src/factory.rs
+++ b/src/resp/src/factory.rs
@@ -1,0 +1,46 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    compat::DownlevelPolicy,
+    traits::{Decoder, Encoder},
+    types::RespVersion,
+};
+
+pub fn new_decoder(version: RespVersion) -> Box<dyn Decoder> {
+    match version {
+        RespVersion::RESP1 => Box::new(crate::resp1::decoder::Resp1Decoder::default()),
+        RespVersion::RESP2 => Box::new(crate::resp2::decoder::Resp2Decoder::default()),
+        RespVersion::RESP3 => Box::new(crate::resp3::decoder::Resp3Decoder::default()),
+    }
+}
+
+pub fn new_encoder(version: RespVersion) -> Box<dyn Encoder> {
+    match version {
+        RespVersion::RESP1 => Box::new(crate::resp1::encoder::Resp1Encoder::default()),
+        RespVersion::RESP2 => Box::new(crate::resp2::encoder::Resp2Encoder::default()),
+        RespVersion::RESP3 => Box::new(crate::resp3::encoder::Resp3Encoder),
+    }
+}
+
+pub fn new_encoder_with_policy(version: RespVersion, policy: DownlevelPolicy) -> Box<dyn Encoder> {
+    match version {
+        RespVersion::RESP1 => Box::new(crate::resp1::encoder::Resp1Encoder::with_policy(policy)),
+        RespVersion::RESP2 => Box::new(crate::resp2::encoder::Resp2Encoder::with_policy(policy)),
+        RespVersion::RESP3 => Box::new(crate::resp3::encoder::Resp3Encoder),
+    }
+}

--- a/src/resp/src/factory.rs
+++ b/src/resp/src/factory.rs
@@ -69,7 +69,7 @@ pub fn new_encoder(version: RespVersion) -> Box<dyn Encoder> {
     match version {
         RespVersion::RESP1 => Box::new(crate::resp1::encoder::Resp1Encoder::default()),
         RespVersion::RESP2 => Box::new(crate::resp2::encoder::Resp2Encoder::default()),
-        RespVersion::RESP3 => Box::new(crate::resp3::encoder::Resp3Encoder),
+        RespVersion::RESP3 => Box::new(crate::resp3::encoder::Resp3Encoder::default()),
     }
 }
 
@@ -98,6 +98,6 @@ pub fn new_encoder_with_policy(version: RespVersion, policy: DownlevelPolicy) ->
     match version {
         RespVersion::RESP1 => Box::new(crate::resp1::encoder::Resp1Encoder::with_policy(policy)),
         RespVersion::RESP2 => Box::new(crate::resp2::encoder::Resp2Encoder::with_policy(policy)),
-        RespVersion::RESP3 => Box::new(crate::resp3::encoder::Resp3Encoder),
+        RespVersion::RESP3 => Box::new(crate::resp3::encoder::Resp3Encoder::default()),
     }
 }

--- a/src/resp/src/factory.rs
+++ b/src/resp/src/factory.rs
@@ -15,10 +15,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Factory functions for creating RESP protocol encoders and decoders.
-/// 
-/// This module provides convenient factory functions to create version-specific
-/// encoder and decoder instances based on the desired RESP protocol version.
+//! Factory functions for creating RESP protocol encoders and decoders.
+//!
+//! This module provides convenient factory functions to create version-specific
+//! encoder and decoder instances based on the desired RESP protocol version.
 
 use crate::{
     compat::DownlevelPolicy,
@@ -27,17 +27,17 @@ use crate::{
 };
 
 /// Create a new decoder for the specified RESP version.
-/// 
+///
 /// # Arguments
 /// * `version` - The RESP protocol version to create a decoder for
-/// 
+///
 /// # Returns
 /// A boxed decoder instance that implements the `Decoder` trait
-/// 
+///
 /// # Examples
 /// ```
 /// use resp::{RespVersion, new_decoder};
-/// 
+///
 /// let mut decoder = new_decoder(RespVersion::RESP3);
 /// decoder.push("+OK\r\n".into());
 /// ```
@@ -50,17 +50,17 @@ pub fn new_decoder(version: RespVersion) -> Box<dyn Decoder> {
 }
 
 /// Create a new encoder for the specified RESP version.
-/// 
+///
 /// # Arguments
 /// * `version` - The RESP protocol version to create an encoder for
-/// 
+///
 /// # Returns
 /// A boxed encoder instance that implements the `Encoder` trait
-/// 
+///
 /// # Examples
 /// ```
 /// use resp::{RespData, RespVersion, new_encoder};
-/// 
+///
 /// let mut encoder = new_encoder(RespVersion::RESP3);
 /// let bytes = encoder.encode_one(&RespData::Boolean(true)).unwrap();
 /// assert_eq!(bytes.as_ref(), b"#t\r\n");
@@ -74,18 +74,18 @@ pub fn new_encoder(version: RespVersion) -> Box<dyn Encoder> {
 }
 
 /// Create a new encoder for the specified RESP version with custom downlevel policy.
-/// 
+///
 /// # Arguments
 /// * `version` - The RESP protocol version to create an encoder for
 /// * `policy` - The downlevel compatibility policy for RESP3 types
-/// 
+///
 /// # Returns
 /// A boxed encoder instance that implements the `Encoder` trait
-/// 
+///
 /// # Examples
 /// ```
 /// use resp::{BooleanMode, DownlevelPolicy, RespData, RespVersion, new_encoder_with_policy};
-/// 
+///
 /// let policy = DownlevelPolicy {
 ///     boolean_mode: BooleanMode::SimpleString,
 ///     ..Default::default()

--- a/src/resp/src/factory.rs
+++ b/src/resp/src/factory.rs
@@ -15,6 +15,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::{
     compat::DownlevelPolicy,
     traits::{Decoder, Encoder},

--- a/src/resp/src/multi.rs
+++ b/src/resp/src/multi.rs
@@ -81,7 +81,7 @@ pub fn decode_many(decoder: &mut dyn Decoder, chunk: Bytes) -> Vec<RespResult<Re
 /// assert_eq!(bytes.as_ref(), b"+OK\r\n:42\r\n");
 /// ```
 pub fn encode_many(encoder: &mut dyn Encoder, values: &[RespData]) -> RespResult<Bytes> {
-    let mut buf = BytesMut::new();
+    let mut buf = BytesMut::with_capacity(values.len() * 32); // Rough estimate
     for v in values {
         encoder.encode_into(v, &mut buf)?;
     }

--- a/src/resp/src/multi.rs
+++ b/src/resp/src/multi.rs
@@ -15,6 +15,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// Utilities for batch processing of RESP messages.
+/// 
+/// This module provides functions for encoding and decoding multiple RESP messages
+/// in a single operation, which is useful for pipelining and batch operations.
+
 use bytes::{Bytes, BytesMut};
 
 use crate::{
@@ -23,6 +28,27 @@ use crate::{
     types::RespData,
 };
 
+/// Decode multiple RESP messages from a single byte chunk.
+/// 
+/// This function pushes the entire chunk into the decoder and attempts to parse
+/// all complete messages available. Useful for processing pipelined commands.
+/// 
+/// # Arguments
+/// * `decoder` - The decoder instance to use for parsing
+/// * `chunk` - The byte chunk containing one or more RESP messages
+/// 
+/// # Returns
+/// A vector of parsing results. Each element is either `Ok(RespData)` for a
+/// successfully parsed message, or `Err(RespError)` for parsing errors.
+/// 
+/// # Examples
+/// ```
+/// use resp::{RespVersion, decode_many, new_decoder};
+/// 
+/// let mut decoder = new_decoder(RespVersion::RESP2);
+/// let results = decode_many(&mut *decoder, "+OK\r\n:42\r\n".into());
+/// assert_eq!(results.len(), 2);
+/// ```
 pub fn decode_many(decoder: &mut dyn Decoder, chunk: Bytes) -> Vec<RespResult<RespData>> {
     decoder.push(chunk);
     let mut out = Vec::new();
@@ -32,6 +58,28 @@ pub fn decode_many(decoder: &mut dyn Decoder, chunk: Bytes) -> Vec<RespResult<Re
     out
 }
 
+/// Encode multiple RESP messages into a single byte buffer.
+/// 
+/// This function encodes each `RespData` value in sequence and concatenates
+/// the results into a single `Bytes` buffer. Useful for building pipelined commands.
+/// 
+/// # Arguments
+/// * `encoder` - The encoder instance to use for encoding
+/// * `values` - A slice of `RespData` values to encode
+/// 
+/// # Returns
+/// A `Result` containing the concatenated encoded bytes, or an error if encoding fails.
+/// 
+/// # Examples
+/// ```
+/// use resp::{RespData, RespVersion, encode_many, new_encoder};
+/// 
+/// let mut encoder = new_encoder(RespVersion::RESP2);
+/// let values = vec![RespData::SimpleString("OK".into()), RespData::Integer(42)];
+/// let bytes = encode_many(&mut *encoder, &values).unwrap();
+/// // bytes contains "+OK\r\n:42\r\n"
+/// assert_eq!(bytes.as_ref(), b"+OK\r\n:42\r\n");
+/// ```
 pub fn encode_many(encoder: &mut dyn Encoder, values: &[RespData]) -> RespResult<Bytes> {
     let mut buf = BytesMut::new();
     for v in values {

--- a/src/resp/src/multi.rs
+++ b/src/resp/src/multi.rs
@@ -15,10 +15,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Utilities for batch processing of RESP messages.
-/// 
-/// This module provides functions for encoding and decoding multiple RESP messages
-/// in a single operation, which is useful for pipelining and batch operations.
+//! Utilities for batch processing of RESP messages.
+//!
+//! This module provides functions for encoding and decoding multiple RESP messages
+//! in a single operation, which is useful for pipelining and batch operations.
 
 use bytes::{Bytes, BytesMut};
 
@@ -29,22 +29,22 @@ use crate::{
 };
 
 /// Decode multiple RESP messages from a single byte chunk.
-/// 
+///
 /// This function pushes the entire chunk into the decoder and attempts to parse
 /// all complete messages available. Useful for processing pipelined commands.
-/// 
+///
 /// # Arguments
 /// * `decoder` - The decoder instance to use for parsing
 /// * `chunk` - The byte chunk containing one or more RESP messages
-/// 
+///
 /// # Returns
 /// A vector of parsing results. Each element is either `Ok(RespData)` for a
 /// successfully parsed message, or `Err(RespError)` for parsing errors.
-/// 
+///
 /// # Examples
 /// ```
 /// use resp::{RespVersion, decode_many, new_decoder};
-/// 
+///
 /// let mut decoder = new_decoder(RespVersion::RESP2);
 /// let results = decode_many(&mut *decoder, "+OK\r\n:42\r\n".into());
 /// assert_eq!(results.len(), 2);
@@ -59,21 +59,21 @@ pub fn decode_many(decoder: &mut dyn Decoder, chunk: Bytes) -> Vec<RespResult<Re
 }
 
 /// Encode multiple RESP messages into a single byte buffer.
-/// 
+///
 /// This function encodes each `RespData` value in sequence and concatenates
 /// the results into a single `Bytes` buffer. Useful for building pipelined commands.
-/// 
+///
 /// # Arguments
 /// * `encoder` - The encoder instance to use for encoding
 /// * `values` - A slice of `RespData` values to encode
-/// 
+///
 /// # Returns
 /// A `Result` containing the concatenated encoded bytes, or an error if encoding fails.
-/// 
+///
 /// # Examples
 /// ```
 /// use resp::{RespData, RespVersion, encode_many, new_encoder};
-/// 
+///
 /// let mut encoder = new_encoder(RespVersion::RESP2);
 /// let values = vec![RespData::SimpleString("OK".into()), RespData::Integer(42)];
 /// let bytes = encode_many(&mut *encoder, &values).unwrap();

--- a/src/resp/src/parse.rs
+++ b/src/resp/src/parse.rs
@@ -35,7 +35,7 @@ use crate::{
     types::{RespData, RespVersion},
 };
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 pub enum RespParseResult {
     Complete(RespData),
     Incomplete,

--- a/src/resp/src/resp1/decoder.rs
+++ b/src/resp/src/resp1/decoder.rs
@@ -1,3 +1,20 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::VecDeque;
 
 use bytes::Bytes;

--- a/src/resp/src/resp1/decoder.rs
+++ b/src/resp/src/resp1/decoder.rs
@@ -1,0 +1,52 @@
+use std::collections::VecDeque;
+
+use bytes::Bytes;
+
+use crate::{
+    error::RespResult,
+    parse::{Parse, RespParse, RespParseResult},
+    traits::Decoder,
+    types::{RespData, RespVersion},
+};
+
+#[derive(Default)]
+pub struct Resp1Decoder {
+    inner: RespParse,
+    out: VecDeque<RespResult<RespData>>,
+}
+
+impl Resp1Decoder {
+    pub fn new() -> Self {
+        Self {
+            inner: RespParse::new(RespVersion::RESP1),
+            out: VecDeque::new(),
+        }
+    }
+}
+
+impl Decoder for Resp1Decoder {
+    fn push(&mut self, data: Bytes) {
+        let mut res = self.inner.parse(data);
+        loop {
+            match res {
+                RespParseResult::Complete(d) => self.out.push_back(Ok(d)),
+                RespParseResult::Error(e) => self.out.push_back(Err(e)),
+                RespParseResult::Incomplete => break,
+            }
+            res = self.inner.parse(Bytes::new());
+        }
+    }
+
+    fn next(&mut self) -> Option<RespResult<RespData>> {
+        self.out.pop_front()
+    }
+
+    fn reset(&mut self) {
+        self.inner.reset();
+        self.out.clear();
+    }
+
+    fn version(&self) -> RespVersion {
+        RespVersion::RESP1
+    }
+}

--- a/src/resp/src/resp1/encoder.rs
+++ b/src/resp/src/resp1/encoder.rs
@@ -95,7 +95,11 @@ impl Resp1Encoder {
             }
             RespData::Double(v) => {
                 if let DoubleMode::IntegerIfWhole = self.policy.double_mode {
-                    if v.fract() == 0.0 && v.is_finite() {
+                    if v.fract() == 0.0
+                        && v.is_finite()
+                        && *v >= i64::MIN as f64
+                        && *v <= i64::MAX as f64
+                    {
                         self.inner.append_integer(*v as i64);
                         return;
                     }

--- a/src/resp/src/resp1/encoder.rs
+++ b/src/resp/src/resp1/encoder.rs
@@ -1,3 +1,20 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use bytes::{Bytes, BytesMut};
 
 use crate::{

--- a/src/resp/src/resp1/encoder.rs
+++ b/src/resp/src/resp1/encoder.rs
@@ -1,0 +1,123 @@
+use bytes::{Bytes, BytesMut};
+
+use crate::{
+    compat::{BooleanMode, DoubleMode, DownlevelPolicy, MapMode},
+    encode::{RespEncode, RespEncoder},
+    error::RespResult,
+    traits::Encoder,
+    types::{RespData, RespVersion},
+};
+
+#[derive(Default)]
+pub struct Resp1Encoder {
+    inner: RespEncoder,
+    policy: DownlevelPolicy,
+}
+
+impl Resp1Encoder {
+    pub fn new() -> Self {
+        Self {
+            inner: RespEncoder::new(RespVersion::RESP1),
+            policy: DownlevelPolicy::default(),
+        }
+    }
+
+    pub fn with_policy(policy: DownlevelPolicy) -> Self {
+        Self {
+            inner: RespEncoder::new(RespVersion::RESP1),
+            policy,
+        }
+    }
+}
+
+impl Encoder for Resp1Encoder {
+    fn encode_one(&mut self, data: &RespData) -> RespResult<Bytes> {
+        self.inner.clear();
+        self.encode_downleveled(data);
+        Ok(self.inner.get_response())
+    }
+
+    fn encode_into(&mut self, data: &RespData, out: &mut BytesMut) -> RespResult<()> {
+        let bytes = self.encode_one(data)?;
+        out.extend_from_slice(&bytes);
+        Ok(())
+    }
+
+    fn version(&self) -> RespVersion {
+        RespVersion::RESP1
+    }
+}
+
+impl Resp1Encoder {
+    fn encode_downleveled(&mut self, data: &RespData) {
+        match data {
+            // RESP1 uses inline/simple/integer/bulk/array semantics basically consistent
+            RespData::SimpleString(_)
+            | RespData::Error(_)
+            | RespData::Integer(_)
+            | RespData::BulkString(_)
+            | RespData::Array(_)
+            | RespData::Inline(_) => {
+                self.inner.encode_resp_data(data);
+            }
+            // Downlevel mapping strategy consistent with RESP2
+            RespData::Null => {
+                self.inner.set_line_string("$-1");
+            }
+            RespData::Boolean(b) => {
+                match self.policy.boolean_mode {
+                    BooleanMode::Integer => self.inner.append_integer(if *b { 1 } else { 0 }),
+                    BooleanMode::SimpleString => {
+                        if *b {
+                            self.inner.append_simple_string("OK")
+                        } else {
+                            self.inner.append_simple_string("ERR")
+                        }
+                    }
+                };
+            }
+            RespData::Double(v) => {
+                if let DoubleMode::IntegerIfWhole = self.policy.double_mode {
+                    if v.fract() == 0.0 && v.is_finite() {
+                        self.inner.append_integer(*v as i64);
+                        return;
+                    }
+                }
+                self.inner.append_string(&format!("{}", v));
+            }
+            crate::types::RespData::BulkError(msg) => {
+                self.inner
+                    .append_string_raw(&format!("-{}\r\n", String::from_utf8_lossy(msg)));
+            }
+            crate::types::RespData::VerbatimString { data, .. } => {
+                self.inner.append_bulk_string(data);
+            }
+            crate::types::RespData::BigNumber(s) => {
+                self.inner.append_string(s);
+            }
+            crate::types::RespData::Map(entries) => match self.policy.map_mode {
+                MapMode::FlatArray => {
+                    self.inner.append_array_len((entries.len() * 2) as i64);
+                    for (k, v) in entries {
+                        self.encode_downleveled(k);
+                        self.encode_downleveled(v);
+                    }
+                }
+                MapMode::ArrayOfPairs => {
+                    self.inner.append_array_len(entries.len() as i64);
+                    for (k, v) in entries {
+                        self.inner.append_array_len(2);
+                        self.encode_downleveled(k);
+                        self.encode_downleveled(v);
+                    }
+                }
+            },
+            crate::types::RespData::Set(items) | crate::types::RespData::Push(items) => {
+                self.inner.append_array_len(items.len() as i64);
+                for it in items {
+                    self.encode_downleveled(it);
+                }
+            }
+        }
+    }
+}

--- a/src/resp/src/resp1/mod.rs
+++ b/src/resp/src/resp1/mod.rs
@@ -1,0 +1,2 @@
+pub mod decoder;
+pub mod encoder;

--- a/src/resp/src/resp1/mod.rs
+++ b/src/resp/src/resp1/mod.rs
@@ -1,2 +1,19 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub mod decoder;
 pub mod encoder;

--- a/src/resp/src/resp2/decoder.rs
+++ b/src/resp/src/resp2/decoder.rs
@@ -1,0 +1,52 @@
+use std::collections::VecDeque;
+
+use bytes::Bytes;
+
+use crate::{
+    error::RespResult,
+    parse::{Parse, RespParse, RespParseResult},
+    traits::Decoder,
+    types::{RespData, RespVersion},
+};
+
+#[derive(Default)]
+pub struct Resp2Decoder {
+    inner: RespParse,
+    out: VecDeque<RespResult<RespData>>,
+}
+
+impl Resp2Decoder {
+    pub fn new() -> Self {
+        Self {
+            inner: RespParse::new(RespVersion::RESP2),
+            out: VecDeque::new(),
+        }
+    }
+}
+
+impl Decoder for Resp2Decoder {
+    fn push(&mut self, data: Bytes) {
+        let mut res = self.inner.parse(data);
+        loop {
+            match res {
+                RespParseResult::Complete(d) => self.out.push_back(Ok(d)),
+                RespParseResult::Error(e) => self.out.push_back(Err(e)),
+                RespParseResult::Incomplete => break,
+            }
+            res = self.inner.parse(Bytes::new());
+        }
+    }
+
+    fn next(&mut self) -> Option<RespResult<RespData>> {
+        self.out.pop_front()
+    }
+
+    fn reset(&mut self) {
+        self.inner.reset();
+        self.out.clear();
+    }
+
+    fn version(&self) -> RespVersion {
+        RespVersion::RESP2
+    }
+}

--- a/src/resp/src/resp2/decoder.rs
+++ b/src/resp/src/resp2/decoder.rs
@@ -1,3 +1,20 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::VecDeque;
 
 use bytes::Bytes;

--- a/src/resp/src/resp2/encoder.rs
+++ b/src/resp/src/resp2/encoder.rs
@@ -1,3 +1,20 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use bytes::{Bytes, BytesMut};
 
 use crate::{

--- a/src/resp/src/resp2/encoder.rs
+++ b/src/resp/src/resp2/encoder.rs
@@ -95,7 +95,11 @@ impl Resp2Encoder {
             }
             RespData::Double(v) => {
                 if let DoubleMode::IntegerIfWhole = self.policy.double_mode {
-                    if v.fract() == 0.0 && v.is_finite() {
+                    if v.fract() == 0.0
+                        && v.is_finite()
+                        && *v >= i64::MIN as f64
+                        && *v <= i64::MAX as f64
+                    {
                         self.inner.append_integer(*v as i64);
                         return;
                     }

--- a/src/resp/src/resp2/encoder.rs
+++ b/src/resp/src/resp2/encoder.rs
@@ -1,0 +1,123 @@
+use bytes::{Bytes, BytesMut};
+
+use crate::{
+    compat::{BooleanMode, DoubleMode, DownlevelPolicy, MapMode},
+    encode::{RespEncode, RespEncoder},
+    error::RespResult,
+    traits::Encoder,
+    types::{RespData, RespVersion},
+};
+
+#[derive(Default)]
+pub struct Resp2Encoder {
+    inner: RespEncoder,
+    policy: DownlevelPolicy,
+}
+
+impl Resp2Encoder {
+    pub fn new() -> Self {
+        Self {
+            inner: RespEncoder::new(RespVersion::RESP2),
+            policy: DownlevelPolicy::default(),
+        }
+    }
+
+    pub fn with_policy(policy: DownlevelPolicy) -> Self {
+        Self {
+            inner: RespEncoder::new(RespVersion::RESP2),
+            policy,
+        }
+    }
+}
+
+impl Encoder for Resp2Encoder {
+    fn encode_one(&mut self, data: &RespData) -> RespResult<Bytes> {
+        self.inner.clear();
+        self.encode_downleveled(data);
+        Ok(self.inner.get_response())
+    }
+
+    fn encode_into(&mut self, data: &RespData, out: &mut BytesMut) -> RespResult<()> {
+        let bytes = self.encode_one(data)?;
+        out.extend_from_slice(&bytes);
+        Ok(())
+    }
+
+    fn version(&self) -> RespVersion {
+        RespVersion::RESP2
+    }
+}
+
+impl Resp2Encoder {
+    fn encode_downleveled(&mut self, data: &RespData) {
+        match data {
+            // RESP2 native types
+            RespData::SimpleString(_)
+            | RespData::Error(_)
+            | RespData::Integer(_)
+            | RespData::BulkString(_)
+            | RespData::Array(_)
+            | RespData::Inline(_) => {
+                self.inner.encode_resp_data(data);
+            }
+            // Downlevel mappings
+            RespData::Null => {
+                self.inner.set_line_string("$-1");
+            }
+            RespData::Boolean(b) => {
+                match self.policy.boolean_mode {
+                    BooleanMode::Integer => self.inner.append_integer(if *b { 1 } else { 0 }),
+                    BooleanMode::SimpleString => {
+                        if *b {
+                            self.inner.append_simple_string("OK")
+                        } else {
+                            self.inner.append_simple_string("ERR")
+                        }
+                    }
+                };
+            }
+            RespData::Double(v) => {
+                if let DoubleMode::IntegerIfWhole = self.policy.double_mode {
+                    if v.fract() == 0.0 && v.is_finite() {
+                        self.inner.append_integer(*v as i64);
+                        return;
+                    }
+                }
+                self.inner.append_string(&format!("{}", v));
+            }
+            RespData::BulkError(msg) => {
+                self.inner
+                    .append_string_raw(&format!("-{}\r\n", String::from_utf8_lossy(msg)));
+            }
+            RespData::VerbatimString { data, .. } => {
+                self.inner.append_bulk_string(data);
+            }
+            RespData::BigNumber(s) => {
+                self.inner.append_string(s);
+            }
+            RespData::Map(entries) => match self.policy.map_mode {
+                MapMode::FlatArray => {
+                    self.inner.append_array_len((entries.len() * 2) as i64);
+                    for (k, v) in entries {
+                        self.encode_downleveled(k);
+                        self.encode_downleveled(v);
+                    }
+                }
+                MapMode::ArrayOfPairs => {
+                    self.inner.append_array_len(entries.len() as i64);
+                    for (k, v) in entries {
+                        self.inner.append_array_len(2);
+                        self.encode_downleveled(k);
+                        self.encode_downleveled(v);
+                    }
+                }
+            },
+            RespData::Set(items) | RespData::Push(items) => {
+                self.inner.append_array_len(items.len() as i64);
+                for it in items {
+                    self.encode_downleveled(it);
+                }
+            }
+        }
+    }
+}

--- a/src/resp/src/resp2/mod.rs
+++ b/src/resp/src/resp2/mod.rs
@@ -1,0 +1,2 @@
+pub mod decoder;
+pub mod encoder;

--- a/src/resp/src/resp2/mod.rs
+++ b/src/resp/src/resp2/mod.rs
@@ -1,2 +1,19 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub mod decoder;
 pub mod encoder;

--- a/src/resp/src/resp3/decoder.rs
+++ b/src/resp/src/resp3/decoder.rs
@@ -1,3 +1,20 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::VecDeque;
 
 use bytes::Bytes;

--- a/src/resp/src/resp3/decoder.rs
+++ b/src/resp/src/resp3/decoder.rs
@@ -31,909 +31,462 @@ pub struct Resp3Decoder {
     buf: bytes::BytesMut,
 }
 
+impl Resp3Decoder {
+    /// Parse a single RESP value from the buffer
+    /// Returns None if more data is needed, Some(Ok(value)) if parsing succeeded,
+    /// or Some(Err(error)) if parsing failed
+    fn parse_single_value(&mut self) -> Option<RespResult<RespData>> {
+        if self.buf.is_empty() {
+            return None;
+        }
+
+        match self.buf[0] {
+            // RESP3-specific types
+            b'_' => {
+                if self.buf.len() < 3 {
+                    return None;
+                }
+                if &self.buf[..3] == b"_\r\n" {
+                    let _ = self.buf.split_to(3);
+                    Some(Ok(RespData::Null))
+                } else {
+                    Some(Err(RespError::ParseError("invalid RESP3 null".into())))
+                }
+            }
+            b'#' => {
+                if self.buf.len() < 4 {
+                    return None;
+                }
+                if &self.buf[..4] == b"#t\r\n" {
+                    let _ = self.buf.split_to(4);
+                    Some(Ok(RespData::Boolean(true)))
+                } else if &self.buf[..4] == b"#f\r\n" {
+                    let _ = self.buf.split_to(4);
+                    Some(Ok(RespData::Boolean(false)))
+                } else {
+                    Some(Err(RespError::ParseError("invalid RESP3 boolean".into())))
+                }
+            }
+            b',' => {
+                if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
+                    let line_len = pos + 1;
+                    let line = &self.buf[..line_len];
+                    if line.len() < 3 || line[line.len() - 2] != b'\r' {
+                        return None;
+                    }
+                    let chunk = self.buf.split_to(line_len);
+                    let body = &chunk[1..chunk.len() - 2];
+                    if let Ok(s) = std::str::from_utf8(body) {
+                        let sl = s.to_ascii_lowercase();
+                        let val = if sl == "inf" {
+                            Some(f64::INFINITY)
+                        } else if sl == "-inf" {
+                            Some(f64::NEG_INFINITY)
+                        } else if sl == "nan" {
+                            Some(f64::NAN)
+                        } else {
+                            s.parse::<f64>().ok()
+                        };
+                        match val {
+                            Some(v) => Some(Ok(RespData::Double(v))),
+                            None => Some(Err(RespError::ParseError("invalid RESP3 double".into()))),
+                        }
+                    } else {
+                        Some(Err(RespError::ParseError("invalid RESP3 double".into())))
+                    }
+                } else {
+                    None
+                }
+            }
+            b'!' => {
+                if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
+                    if nl < 3 || self.buf[nl - 1] != b'\r' {
+                        return None;
+                    }
+                    let len_bytes = &self.buf[1..nl - 1];
+                    let len = match std::str::from_utf8(len_bytes)
+                        .ok()
+                        .and_then(|s| s.parse::<usize>().ok())
+                    {
+                        Some(v) => v,
+                        None => {
+                            return Some(Err(RespError::ParseError(
+                                "invalid bulk error len".into(),
+                            )));
+                        }
+                    };
+                    let need = nl + 1 + len + 2;
+                    if self.buf.len() < need {
+                        return None;
+                    }
+                    let chunk = self.buf.split_to(need);
+                    if &chunk[nl + 1 + len..need] != b"\r\n" {
+                        return Some(Err(RespError::ParseError(
+                            "invalid bulk error ending".into(),
+                        )));
+                    }
+                    let data = bytes::Bytes::copy_from_slice(&chunk[nl + 1..nl + 1 + len]);
+                    Some(Ok(RespData::BulkError(data)))
+                } else {
+                    None
+                }
+            }
+            b'=' => {
+                if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
+                    if nl < 3 || self.buf[nl - 1] != b'\r' {
+                        return None;
+                    }
+                    let len_bytes = &self.buf[1..nl - 1];
+                    let len = match std::str::from_utf8(len_bytes)
+                        .ok()
+                        .and_then(|s| s.parse::<usize>().ok())
+                    {
+                        Some(v) => v,
+                        None => {
+                            return Some(Err(RespError::ParseError("invalid verbatim len".into())));
+                        }
+                    };
+                    let need = nl + 1 + len + 2;
+                    if self.buf.len() < need {
+                        return None;
+                    }
+                    let chunk = self.buf.split_to(need);
+                    let content = &chunk[nl + 1..nl + 1 + len];
+                    if content.len() < 4 || content[3] != b':' {
+                        return Some(Err(RespError::ParseError("invalid verbatim header".into())));
+                    }
+                    let mut fmt = [0u8; 3];
+                    fmt.copy_from_slice(&content[0..3]);
+                    let data = bytes::Bytes::copy_from_slice(&content[4..]);
+                    if &chunk[nl + 1 + len..need] != b"\r\n" {
+                        return Some(Err(RespError::ParseError("invalid verbatim ending".into())));
+                    }
+                    Some(Ok(RespData::VerbatimString { format: fmt, data }))
+                } else {
+                    None
+                }
+            }
+            b'(' => {
+                if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
+                    let line_len = pos + 1;
+                    let chunk = self.buf.split_to(line_len);
+                    if chunk.len() < 3 || chunk[chunk.len() - 2] != b'\r' {
+                        return None;
+                    }
+                    let body = &chunk[1..chunk.len() - 2];
+                    match std::str::from_utf8(body) {
+                        Ok(s) => Some(Ok(RespData::BigNumber(s.to_string()))),
+                        Err(_) => Some(Err(RespError::ParseError("invalid big number".into()))),
+                    }
+                } else {
+                    None
+                }
+            }
+            // Standard RESP types
+            b'+' => {
+                if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
+                    let line_len = pos + 1;
+                    let line = &self.buf[..line_len];
+                    if line.len() < 3 || line[line.len() - 2] != b'\r' {
+                        return None;
+                    }
+                    let chunk = self.buf.split_to(line_len);
+                    let data = bytes::Bytes::copy_from_slice(&chunk[1..chunk.len() - 2]);
+                    Some(Ok(RespData::SimpleString(data)))
+                } else {
+                    None
+                }
+            }
+            b'-' => {
+                if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
+                    let line_len = pos + 1;
+                    let line = &self.buf[..line_len];
+                    if line.len() < 3 || line[line.len() - 2] != b'\r' {
+                        return None;
+                    }
+                    let chunk = self.buf.split_to(line_len);
+                    let data = bytes::Bytes::copy_from_slice(&chunk[1..chunk.len() - 2]);
+                    Some(Ok(RespData::Error(data)))
+                } else {
+                    None
+                }
+            }
+            b':' => {
+                if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
+                    let line_len = pos + 1;
+                    let line = &self.buf[..line_len];
+                    if line.len() < 3 || line[line.len() - 2] != b'\r' {
+                        return None;
+                    }
+                    let chunk = self.buf.split_to(line_len);
+                    let num_str = &chunk[1..chunk.len() - 2];
+                    match std::str::from_utf8(num_str)
+                        .ok()
+                        .and_then(|s| s.parse::<i64>().ok())
+                    {
+                        Some(n) => Some(Ok(RespData::Integer(n))),
+                        None => Some(Err(RespError::ParseError("invalid integer".into()))),
+                    }
+                } else {
+                    None
+                }
+            }
+            b'$' => {
+                if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
+                    if nl < 3 || self.buf[nl - 1] != b'\r' {
+                        return None;
+                    }
+                    let len_bytes = &self.buf[1..nl - 1];
+                    let len = match std::str::from_utf8(len_bytes)
+                        .ok()
+                        .and_then(|s| s.parse::<i64>().ok())
+                    {
+                        Some(v) => v,
+                        None => {
+                            return Some(Err(RespError::ParseError(
+                                "invalid bulk string len".into(),
+                            )));
+                        }
+                    };
+                    if len == -1 {
+                        let _ = self.buf.split_to(nl + 1);
+                        Some(Ok(RespData::BulkString(None)))
+                    } else if len >= 0 {
+                        let need = nl + 1 + len as usize + 2;
+                        if self.buf.len() < need {
+                            return None;
+                        }
+                        let chunk = self.buf.split_to(need);
+                        if &chunk[nl + 1 + len as usize..need] != b"\r\n" {
+                            return Some(Err(RespError::ParseError(
+                                "invalid bulk string ending".into(),
+                            )));
+                        }
+                        let data =
+                            bytes::Bytes::copy_from_slice(&chunk[nl + 1..nl + 1 + len as usize]);
+                        Some(Ok(RespData::BulkString(Some(data))))
+                    } else {
+                        Some(Err(RespError::ParseError(
+                            "negative bulk string len".into(),
+                        )))
+                    }
+                } else {
+                    None
+                }
+            }
+            b'*' => {
+                if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
+                    if nl < 3 || self.buf[nl - 1] != b'\r' {
+                        return None;
+                    }
+                    let len_bytes = &self.buf[1..nl - 1];
+                    let len = match std::str::from_utf8(len_bytes)
+                        .ok()
+                        .and_then(|s| s.parse::<i64>().ok())
+                    {
+                        Some(v) => v,
+                        None => {
+                            return Some(Err(RespError::ParseError("invalid array len".into())));
+                        }
+                    };
+                    if len == -1 {
+                        let _ = self.buf.split_to(nl + 1);
+                        Some(Ok(RespData::Array(None)))
+                    } else if len >= 0 {
+                        let _ = self.buf.split_to(nl + 1);
+                        let mut items = Vec::with_capacity(len as usize);
+                        for _ in 0..len {
+                            if let Some(result) = self.parse_single_value() {
+                                match result {
+                                    Ok(item) => items.push(item),
+                                    Err(e) => return Some(Err(e)),
+                                }
+                            } else {
+                                // Need more data, restore the buffer and return None
+                                return None;
+                            }
+                        }
+                        Some(Ok(RespData::Array(Some(items))))
+                    } else {
+                        Some(Err(RespError::ParseError("negative array len".into())))
+                    }
+                } else {
+                    None
+                }
+            }
+            b'%' => {
+                // Map: %<len>\r\n<k1><v1>...
+                if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
+                    if nl < 3 || self.buf[nl - 1] != b'\r' {
+                        return None;
+                    }
+                    let len_bytes = &self.buf[1..nl - 1];
+                    let pairs = match std::str::from_utf8(len_bytes)
+                        .ok()
+                        .and_then(|s| s.parse::<usize>().ok())
+                    {
+                        Some(v) => v,
+                        None => {
+                            return Some(Err(RespError::ParseError("invalid map len".into())));
+                        }
+                    };
+                    let _ = self.buf.split_to(nl + 1);
+                    let mut items = Vec::with_capacity(pairs);
+                    for _ in 0..pairs {
+                        // parse key
+                        if let Some(result) = self.parse_single_value() {
+                            match result {
+                                Ok(k) => {
+                                    // parse value
+                                    if let Some(result) = self.parse_single_value() {
+                                        match result {
+                                            Ok(v) => {
+                                                items.push((k, v));
+                                            }
+                                            Err(e) => {
+                                                return Some(Err(e));
+                                            }
+                                        }
+                                    } else {
+                                        // Need more data, restore the buffer and return
+                                        return None;
+                                    }
+                                }
+                                Err(e) => {
+                                    return Some(Err(e));
+                                }
+                            }
+                        } else {
+                            // Need more data, restore the buffer and return
+                            return None;
+                        }
+                    }
+                    Some(Ok(RespData::Map(items)))
+                } else {
+                    None
+                }
+            }
+            b'~' => {
+                // Set: ~<len>\r\n<item>...
+                if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
+                    if nl < 3 || self.buf[nl - 1] != b'\r' {
+                        return None;
+                    }
+                    let len_bytes = &self.buf[1..nl - 1];
+                    let count = match std::str::from_utf8(len_bytes)
+                        .ok()
+                        .and_then(|s| s.parse::<usize>().ok())
+                    {
+                        Some(v) => v,
+                        None => {
+                            return Some(Err(RespError::ParseError("invalid set len".into())));
+                        }
+                    };
+                    let _ = self.buf.split_to(nl + 1);
+                    let mut items = Vec::with_capacity(count);
+                    for _ in 0..count {
+                        if let Some(result) = self.parse_single_value() {
+                            match result {
+                                Ok(val) => {
+                                    items.push(val);
+                                }
+                                Err(e) => {
+                                    return Some(Err(e));
+                                }
+                            }
+                        } else {
+                            // Need more data, restore the buffer and return
+                            return None;
+                        }
+                    }
+                    Some(Ok(RespData::Set(items)))
+                } else {
+                    None
+                }
+            }
+            b'>' => {
+                // Push: >len\r\n<item>...
+                if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
+                    if nl < 3 || self.buf[nl - 1] != b'\r' {
+                        return None;
+                    }
+                    let len_bytes = &self.buf[1..nl - 1];
+                    let count = match std::str::from_utf8(len_bytes)
+                        .ok()
+                        .and_then(|s| s.parse::<usize>().ok())
+                    {
+                        Some(v) => v,
+                        None => {
+                            return Some(Err(RespError::ParseError("invalid push len".into())));
+                        }
+                    };
+                    let _ = self.buf.split_to(nl + 1);
+                    let mut items = Vec::with_capacity(count);
+                    for _ in 0..count {
+                        if let Some(result) = self.parse_single_value() {
+                            match result {
+                                Ok(val) => {
+                                    items.push(val);
+                                }
+                                Err(e) => {
+                                    return Some(Err(e));
+                                }
+                            }
+                        } else {
+                            // Need more data, restore the buffer and return
+                            return None;
+                        }
+                    }
+                    Some(Ok(RespData::Push(items)))
+                } else {
+                    None
+                }
+            }
+            // Inline command (no prefix, just data followed by \r\n)
+            _ => {
+                // Check if this looks like an inline command (no prefix, ends with \r\n)
+                if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
+                    let line_len = pos + 1;
+                    let line = &self.buf[..line_len];
+                    if line.len() >= 2 && line[line.len() - 2] == b'\r' {
+                        let chunk = self.buf.split_to(line_len);
+                        let data = &chunk[..chunk.len() - 2]; // Remove \r\n
+                        let parts: Vec<Bytes> = data
+                            .split(|&b| b == b' ')
+                            .map(|s| bytes::Bytes::copy_from_slice(s))
+                            .collect();
+                        Some(Ok(RespData::Inline(parts)))
+                    } else {
+                        Some(Err(RespError::ParseError("invalid inline command".into())))
+                    }
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
 impl Decoder for Resp3Decoder {
     fn push(&mut self, data: Bytes) {
         // keep empty to avoid unused import warning
         self.buf.extend_from_slice(&data);
 
         loop {
-            if self.buf.is_empty() {
+            if let Some(result) = self.parse_single_value() {
+                match result {
+                    Ok(data) => {
+                        self.out.push_back(Ok(data));
+                        continue;
+                    }
+                    Err(e) => {
+                        self.out.push_back(Err(e));
+                        break;
+                    }
+                }
+            } else {
+                // Need more data
                 break;
-            }
-            match self.buf[0] {
-                b'_' => {
-                    if self.buf.len() < 3 {
-                        break;
-                    }
-                    if &self.buf[..3] == b"_\r\n" {
-                        let _ = self.buf.split_to(3);
-                        self.out.push_back(Ok(RespData::Null));
-                        continue;
-                    } else {
-                        self.out
-                            .push_back(Err(RespError::ParseError("invalid RESP3 null".into())));
-                        break;
-                    }
-                }
-                b'#' => {
-                    if self.buf.len() < 4 {
-                        break;
-                    }
-                    // format: #t\r\n or #f\r\n
-                    if &self.buf[..4] == b"#t\r\n" {
-                        let _ = self.buf.split_to(4);
-                        self.out.push_back(Ok(RespData::Boolean(true)));
-                        continue;
-                    }
-                    if &self.buf[..4] == b"#f\r\n" {
-                        let _ = self.buf.split_to(4);
-                        self.out.push_back(Ok(RespData::Boolean(false)));
-                        continue;
-                    }
-                    self.out
-                        .push_back(Err(RespError::ParseError("invalid RESP3 boolean".into())));
-                    break;
-                }
-                b',' => {
-                    // format: ,<double>\r\n
-                    if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
-                        let line_len = pos + 1;
-                        let line = &self.buf[..line_len];
-                        if line.len() < 3 || line[line.len() - 2] != b'\r' {
-                            break;
-                        }
-                        // strip prefix ',' and CRLF
-                        let chunk = self.buf.split_to(line_len);
-                        let body = &chunk[1..chunk.len() - 2];
-                        if let Ok(s) = std::str::from_utf8(body) {
-                            let sl = s.to_ascii_lowercase();
-                            let val = if sl == "inf" {
-                                Some(f64::INFINITY)
-                            } else if sl == "-inf" {
-                                Some(f64::NEG_INFINITY)
-                            } else if sl == "nan" {
-                                Some(f64::NAN)
-                            } else {
-                                s.parse::<f64>().ok()
-                            };
-                            match val {
-                                Some(v) => {
-                                    self.out.push_back(Ok(RespData::Double(v)));
-                                    continue;
-                                }
-                                None => {
-                                    self.out.push_back(Err(RespError::ParseError(
-                                        "invalid RESP3 double".into(),
-                                    )));
-                                    break;
-                                }
-                            }
-                        } else {
-                            self.out.push_back(Err(RespError::ParseError(
-                                "invalid RESP3 double".into(),
-                            )));
-                            break;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                b'!' => {
-                    // Bulk error: !<len>\r\n<data>\r\n
-                    if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
-                        if nl < 3 || self.buf[nl - 1] != b'\r' {
-                            break;
-                        }
-                        let len_bytes = &self.buf[1..nl - 1];
-                        let len = match std::str::from_utf8(len_bytes)
-                            .ok()
-                            .and_then(|s| s.parse::<usize>().ok())
-                        {
-                            Some(v) => v,
-                            None => {
-                                self.out.push_back(Err(RespError::ParseError(
-                                    "invalid bulk error len".into(),
-                                )));
-                                break;
-                            }
-                        };
-                        let need = nl + 1 + len + 2;
-                        if self.buf.len() < need {
-                            break;
-                        }
-                        let chunk = self.buf.split_to(need);
-                        if &chunk[nl + 1 + len..need] != b"\r\n" {
-                            self.out.push_back(Err(RespError::ParseError(
-                                "invalid bulk error ending".into(),
-                            )));
-                            break;
-                        }
-                        let data = bytes::Bytes::copy_from_slice(&chunk[nl + 1..nl + 1 + len]);
-                        self.out.push_back(Ok(RespData::BulkError(data)));
-                        continue;
-                    } else {
-                        break;
-                    }
-                }
-                b'=' => {
-                    // Verbatim string: =<len>\r\n<fmt>:<data>\r\n, fmt is 3 bytes
-                    if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
-                        if nl < 3 || self.buf[nl - 1] != b'\r' {
-                            break;
-                        }
-                        let len_bytes = &self.buf[1..nl - 1];
-                        let len = match std::str::from_utf8(len_bytes)
-                            .ok()
-                            .and_then(|s| s.parse::<usize>().ok())
-                        {
-                            Some(v) => v,
-                            None => {
-                                self.out.push_back(Err(RespError::ParseError(
-                                    "invalid verbatim len".into(),
-                                )));
-                                break;
-                            }
-                        };
-                        let need = nl + 1 + len + 2;
-                        if self.buf.len() < need {
-                            break;
-                        }
-                        let chunk = self.buf.split_to(need);
-                        let content = &chunk[nl + 1..nl + 1 + len];
-                        if content.len() < 4 || content[3] != b':' {
-                            self.out.push_back(Err(RespError::ParseError(
-                                "invalid verbatim header".into(),
-                            )));
-                            break;
-                        }
-                        let mut fmt = [0u8; 3];
-                        fmt.copy_from_slice(&content[0..3]);
-                        let data = bytes::Bytes::copy_from_slice(&content[4..]);
-                        if &chunk[nl + 1 + len..need] != b"\r\n" {
-                            self.out.push_back(Err(RespError::ParseError(
-                                "invalid verbatim ending".into(),
-                            )));
-                            break;
-                        }
-                        self.out
-                            .push_back(Ok(RespData::VerbatimString { format: fmt, data }));
-                        continue;
-                    } else {
-                        break;
-                    }
-                }
-                b'(' => {
-                    // Big number: (<string>)\r\n, we treat contents as string until CRLF
-                    if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
-                        let line_len = pos + 1;
-                        let chunk = self.buf.split_to(line_len);
-                        if chunk.len() < 3 || chunk[chunk.len() - 2] != b'\r' {
-                            break;
-                        }
-                        let body = &chunk[1..chunk.len() - 2];
-                        match std::str::from_utf8(body) {
-                            Ok(s) => {
-                                self.out.push_back(Ok(RespData::BigNumber(s.to_string())));
-                                continue;
-                            }
-                            Err(_) => {
-                                self.out.push_back(Err(RespError::ParseError(
-                                    "invalid big number".into(),
-                                )));
-                                break;
-                            }
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                b'%' => {
-                    // Map: %<len>\r\n<k1><v1>... ; we only support nested scalars implemented so far
-                    if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
-                        if nl < 3 || self.buf[nl - 1] != b'\r' {
-                            break;
-                        }
-                        let len_bytes = &self.buf[1..nl - 1];
-                        let pairs = match std::str::from_utf8(len_bytes)
-                            .ok()
-                            .and_then(|s| s.parse::<usize>().ok())
-                        {
-                            Some(v) => v,
-                            None => {
-                                self.out.push_back(Err(RespError::ParseError(
-                                    "invalid map len".into(),
-                                )));
-                                break;
-                            }
-                        };
-                        let _ = self.buf.split_to(nl + 1);
-                        let mut items = Vec::with_capacity(pairs);
-                        for _ in 0..pairs {
-                            // parse key
-                            let k = if self.buf.is_empty() {
-                                break;
-                            } else {
-                                match self.buf[0] {
-                                    b'_' => {
-                                        if self.buf.len() < 3 {
-                                            break;
-                                        }
-                                        let _ = self.buf.split_to(3);
-                                        RespData::Null
-                                    }
-                                    b'#' => {
-                                        if self.buf.len() < 4 {
-                                            break;
-                                        }
-                                        let is_true = self.buf[1] == b't';
-                                        let _ = self.buf.split_to(4);
-                                        if is_true {
-                                            RespData::Boolean(true)
-                                        } else {
-                                            RespData::Boolean(false)
-                                        }
-                                    }
-                                    b',' => {
-                                        if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
-                                            let line = self.buf.split_to(pos + 1);
-                                            if line.len() < 3 || line[line.len() - 2] != b'\r' {
-                                                break;
-                                            }
-                                            let s =
-                                                std::str::from_utf8(&line[1..line.len() - 2]).ok();
-                                            let val = s.and_then(|s| {
-                                                let sl = s.to_ascii_lowercase();
-                                                if sl == "inf" {
-                                                    Some(f64::INFINITY)
-                                                } else if sl == "-inf" {
-                                                    Some(f64::NEG_INFINITY)
-                                                } else if sl == "nan" {
-                                                    Some(f64::NAN)
-                                                } else {
-                                                    s.parse::<f64>().ok()
-                                                }
-                                            });
-                                            match val {
-                                                Some(v) => RespData::Double(v),
-                                                None => {
-                                                    self.out.push_back(Err(RespError::ParseError(
-                                                        "invalid double".into(),
-                                                    )));
-                                                    break;
-                                                }
-                                            }
-                                        } else {
-                                            break;
-                                        }
-                                    }
-                                    b'!' => {
-                                        if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
-                                            if nl < 3 || self.buf[nl - 1] != b'\r' {
-                                                break;
-                                            }
-                                            let len = std::str::from_utf8(&self.buf[1..nl - 1])
-                                                .ok()
-                                                .and_then(|s| s.parse::<usize>().ok());
-                                            let len = match len {
-                                                Some(v) => v,
-                                                None => {
-                                                    self.out.push_back(Err(RespError::ParseError(
-                                                        "invalid bulk error len".into(),
-                                                    )));
-                                                    break;
-                                                }
-                                            };
-                                            let need = nl + 1 + len + 2;
-                                            if self.buf.len() < need {
-                                                break;
-                                            }
-                                            let chunk = self.buf.split_to(need);
-                                            if &chunk[nl + 1 + len..need] != b"\r\n" {
-                                                self.out.push_back(Err(RespError::ParseError(
-                                                    "invalid bulk error ending".into(),
-                                                )));
-                                                break;
-                                            }
-                                            RespData::BulkError(bytes::Bytes::copy_from_slice(
-                                                &chunk[nl + 1..nl + 1 + len],
-                                            ))
-                                        } else {
-                                            break;
-                                        }
-                                    }
-                                    _ => break,
-                                }
-                            };
-                            // parse value
-                            let v = if self.buf.is_empty() {
-                                break;
-                            } else {
-                                match self.buf[0] {
-                                    b'_' => {
-                                        if self.buf.len() < 3 {
-                                            break;
-                                        }
-                                        let _ = self.buf.split_to(3);
-                                        RespData::Null
-                                    }
-                                    b'#' => {
-                                        if self.buf.len() < 4 {
-                                            break;
-                                        }
-                                        let is_true = self.buf[1] == b't';
-                                        let _ = self.buf.split_to(4);
-                                        if is_true {
-                                            RespData::Boolean(true)
-                                        } else {
-                                            RespData::Boolean(false)
-                                        }
-                                    }
-                                    b',' => {
-                                        if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
-                                            let line = self.buf.split_to(pos + 1);
-                                            if line.len() < 3 || line[line.len() - 2] != b'\r' {
-                                                break;
-                                            }
-                                            let s =
-                                                std::str::from_utf8(&line[1..line.len() - 2]).ok();
-                                            let val = s.and_then(|s| {
-                                                let sl = s.to_ascii_lowercase();
-                                                if sl == "inf" {
-                                                    Some(f64::INFINITY)
-                                                } else if sl == "-inf" {
-                                                    Some(f64::NEG_INFINITY)
-                                                } else if sl == "nan" {
-                                                    Some(f64::NAN)
-                                                } else {
-                                                    s.parse::<f64>().ok()
-                                                }
-                                            });
-                                            match val {
-                                                Some(v) => RespData::Double(v),
-                                                None => {
-                                                    self.out.push_back(Err(RespError::ParseError(
-                                                        "invalid double".into(),
-                                                    )));
-                                                    break;
-                                                }
-                                            }
-                                        } else {
-                                            break;
-                                        }
-                                    }
-                                    b'!' => {
-                                        if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
-                                            if nl < 3 || self.buf[nl - 1] != b'\r' {
-                                                break;
-                                            }
-                                            let len = std::str::from_utf8(&self.buf[1..nl - 1])
-                                                .ok()
-                                                .and_then(|s| s.parse::<usize>().ok());
-                                            let len = match len {
-                                                Some(v) => v,
-                                                None => {
-                                                    self.out.push_back(Err(RespError::ParseError(
-                                                        "invalid bulk error len".into(),
-                                                    )));
-                                                    break;
-                                                }
-                                            };
-                                            let need = nl + 1 + len + 2;
-                                            if self.buf.len() < need {
-                                                break;
-                                            }
-                                            let chunk = self.buf.split_to(need);
-                                            if &chunk[nl + 1 + len..need] != b"\r\n" {
-                                                self.out.push_back(Err(RespError::ParseError(
-                                                    "invalid bulk error ending".into(),
-                                                )));
-                                                break;
-                                            }
-                                            RespData::BulkError(bytes::Bytes::copy_from_slice(
-                                                &chunk[nl + 1..nl + 1 + len],
-                                            ))
-                                        } else {
-                                            break;
-                                        }
-                                    }
-                                    _ => break,
-                                }
-                            };
-                            items.push((k, v));
-                        }
-                        self.out.push_back(Ok(RespData::Map(items)));
-                        continue;
-                    } else {
-                        break;
-                    }
-                }
-                b'~' => {
-                    // Set: ~<len>\r\n<item>...
-                    if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
-                        if nl < 3 || self.buf[nl - 1] != b'\r' {
-                            break;
-                        }
-                        let len_bytes = &self.buf[1..nl - 1];
-                        let count = match std::str::from_utf8(len_bytes)
-                            .ok()
-                            .and_then(|s| s.parse::<usize>().ok())
-                        {
-                            Some(v) => v,
-                            None => {
-                                self.out.push_back(Err(RespError::ParseError(
-                                    "invalid set len".into(),
-                                )));
-                                break;
-                            }
-                        };
-                        let _ = self.buf.split_to(nl + 1);
-                        let mut items = Vec::with_capacity(count);
-                        for _ in 0..count {
-                            if self.buf.is_empty() {
-                                break;
-                            }
-                            let val = match self.buf[0] {
-                                b'_' => {
-                                    if self.buf.len() < 3 {
-                                        break;
-                                    }
-                                    let _ = self.buf.split_to(3);
-                                    RespData::Null
-                                }
-                                b'#' => {
-                                    if self.buf.len() < 4 {
-                                        break;
-                                    }
-                                    let is_true = self.buf[1] == b't';
-                                    let _ = self.buf.split_to(4);
-                                    if is_true {
-                                        RespData::Boolean(true)
-                                    } else {
-                                        RespData::Boolean(false)
-                                    }
-                                }
-                                b',' => {
-                                    if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
-                                        let line = self.buf.split_to(pos + 1);
-                                        if line.len() < 3 || line[line.len() - 2] != b'\r' {
-                                            break;
-                                        }
-                                        let s = std::str::from_utf8(&line[1..line.len() - 2]).ok();
-                                        let val = s.and_then(|s| {
-                                            let sl = s.to_ascii_lowercase();
-                                            if sl == "inf" {
-                                                Some(f64::INFINITY)
-                                            } else if sl == "-inf" {
-                                                Some(f64::NEG_INFINITY)
-                                            } else if sl == "nan" {
-                                                Some(f64::NAN)
-                                            } else {
-                                                s.parse::<f64>().ok()
-                                            }
-                                        });
-                                        match val {
-                                            Some(v) => RespData::Double(v),
-                                            None => {
-                                                self.out.push_back(Err(RespError::ParseError(
-                                                    "invalid double".into(),
-                                                )));
-                                                break;
-                                            }
-                                        }
-                                    } else {
-                                        break;
-                                    }
-                                }
-                                b'!' => {
-                                    if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
-                                        if nl < 3 || self.buf[nl - 1] != b'\r' {
-                                            break;
-                                        }
-                                        let len = std::str::from_utf8(&self.buf[1..nl - 1])
-                                            .ok()
-                                            .and_then(|s| s.parse::<usize>().ok());
-                                        let len = match len {
-                                            Some(v) => v,
-                                            None => {
-                                                self.out.push_back(Err(RespError::ParseError(
-                                                    "invalid bulk error len".into(),
-                                                )));
-                                                break;
-                                            }
-                                        };
-                                        let need = nl + 1 + len + 2;
-                                        if self.buf.len() < need {
-                                            break;
-                                        }
-                                        let chunk = self.buf.split_to(need);
-                                        if &chunk[nl + 1 + len..need] != b"\r\n" {
-                                            self.out.push_back(Err(RespError::ParseError(
-                                                "invalid bulk error ending".into(),
-                                            )));
-                                            break;
-                                        }
-                                        RespData::BulkError(bytes::Bytes::copy_from_slice(
-                                            &chunk[nl + 1..nl + 1 + len],
-                                        ))
-                                    } else {
-                                        break;
-                                    }
-                                }
-                                _ => break,
-                            };
-                            items.push(val);
-                        }
-                        self.out.push_back(Ok(RespData::Set(items)));
-                        continue;
-                    } else {
-                        break;
-                    }
-                }
-                b'>' => {
-                    // Push: >len\r\n<item>...
-                    if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
-                        if nl < 3 || self.buf[nl - 1] != b'\r' {
-                            break;
-                        }
-                        let len_bytes = &self.buf[1..nl - 1];
-                        let count = match std::str::from_utf8(len_bytes)
-                            .ok()
-                            .and_then(|s| s.parse::<usize>().ok())
-                        {
-                            Some(v) => v,
-                            None => {
-                                self.out.push_back(Err(RespError::ParseError(
-                                    "invalid push len".into(),
-                                )));
-                                break;
-                            }
-                        };
-                        let _ = self.buf.split_to(nl + 1);
-                        let mut items = Vec::with_capacity(count);
-                        for _ in 0..count {
-                            if self.buf.is_empty() {
-                                break;
-                            }
-                            let val = match self.buf[0] {
-                                b'_' => {
-                                    if self.buf.len() < 3 {
-                                        break;
-                                    }
-                                    let _ = self.buf.split_to(3);
-                                    RespData::Null
-                                }
-                                b'#' => {
-                                    if self.buf.len() < 4 {
-                                        break;
-                                    }
-                                    let is_true = self.buf[1] == b't';
-                                    let _ = self.buf.split_to(4);
-                                    if is_true {
-                                        RespData::Boolean(true)
-                                    } else {
-                                        RespData::Boolean(false)
-                                    }
-                                }
-                                b',' => {
-                                    if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
-                                        let line = self.buf.split_to(pos + 1);
-                                        if line.len() < 3 || line[line.len() - 2] != b'\r' {
-                                            break;
-                                        }
-                                        let s = std::str::from_utf8(&line[1..line.len() - 2]).ok();
-                                        let val = s.and_then(|s| {
-                                            let sl = s.to_ascii_lowercase();
-                                            if sl == "inf" {
-                                                Some(f64::INFINITY)
-                                            } else if sl == "-inf" {
-                                                Some(f64::NEG_INFINITY)
-                                            } else if sl == "nan" {
-                                                Some(f64::NAN)
-                                            } else {
-                                                s.parse::<f64>().ok()
-                                            }
-                                        });
-                                        match val {
-                                            Some(v) => RespData::Double(v),
-                                            None => {
-                                                self.out.push_back(Err(RespError::ParseError(
-                                                    "invalid double".into(),
-                                                )));
-                                                break;
-                                            }
-                                        }
-                                    } else {
-                                        break;
-                                    }
-                                }
-                                b'!' => {
-                                    if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
-                                        if nl < 3 || self.buf[nl - 1] != b'\r' {
-                                            break;
-                                        }
-                                        let len = std::str::from_utf8(&self.buf[1..nl - 1])
-                                            .ok()
-                                            .and_then(|s| s.parse::<usize>().ok());
-                                        let len = match len {
-                                            Some(v) => v,
-                                            None => {
-                                                self.out.push_back(Err(RespError::ParseError(
-                                                    "invalid bulk error len".into(),
-                                                )));
-                                                break;
-                                            }
-                                        };
-                                        let need = nl + 1 + len + 2;
-                                        if self.buf.len() < need {
-                                            break;
-                                        }
-                                        let chunk = self.buf.split_to(need);
-                                        if &chunk[nl + 1 + len..need] != b"\r\n" {
-                                            self.out.push_back(Err(RespError::ParseError(
-                                                "invalid bulk error ending".into(),
-                                            )));
-                                            break;
-                                        }
-                                        RespData::BulkError(bytes::Bytes::copy_from_slice(
-                                            &chunk[nl + 1..nl + 1 + len],
-                                        ))
-                                    } else {
-                                        break;
-                                    }
-                                }
-                                _ => break,
-                            };
-                            items.push(val);
-                        }
-                        self.out.push_back(Ok(RespData::Push(items)));
-                        continue;
-                    } else {
-                        break;
-                    }
-                }
-                // Standard RESP types (+, -, :, $, *) - parse directly
-                b'+' => {
-                    // Simple string: +<string>\r\n
-                    if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
-                        let line_len = pos + 1;
-                        let line = &self.buf[..line_len];
-                        if line.len() < 3 || line[line.len() - 2] != b'\r' {
-                            break;
-                        }
-                        let chunk = self.buf.split_to(line_len);
-                        let data = bytes::Bytes::copy_from_slice(&chunk[1..chunk.len() - 2]);
-                        self.out.push_back(Ok(RespData::SimpleString(data)));
-                        continue;
-                    } else {
-                        break;
-                    }
-                }
-                b'-' => {
-                    // Error: -<string>\r\n
-                    if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
-                        let line_len = pos + 1;
-                        let line = &self.buf[..line_len];
-                        if line.len() < 3 || line[line.len() - 2] != b'\r' {
-                            break;
-                        }
-                        let chunk = self.buf.split_to(line_len);
-                        let data = bytes::Bytes::copy_from_slice(&chunk[1..chunk.len() - 2]);
-                        self.out.push_back(Ok(RespData::Error(data)));
-                        continue;
-                    } else {
-                        break;
-                    }
-                }
-                b':' => {
-                    // Integer: :<number>\r\n
-                    if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
-                        let line_len = pos + 1;
-                        let line = &self.buf[..line_len];
-                        if line.len() < 3 || line[line.len() - 2] != b'\r' {
-                            break;
-                        }
-                        let chunk = self.buf.split_to(line_len);
-                        let num_str = &chunk[1..chunk.len() - 2];
-                        match std::str::from_utf8(num_str)
-                            .ok()
-                            .and_then(|s| s.parse::<i64>().ok())
-                        {
-                            Some(n) => {
-                                self.out.push_back(Ok(RespData::Integer(n)));
-                                continue;
-                            }
-                            None => {
-                                self.out.push_back(Err(RespError::ParseError(
-                                    "invalid integer".into(),
-                                )));
-                                break;
-                            }
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                b'$' => {
-                    // Bulk string: $<len>\r\n<data>\r\n or $-1\r\n for null
-                    if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
-                        if nl < 3 || self.buf[nl - 1] != b'\r' {
-                            break;
-                        }
-                        let len_bytes = &self.buf[1..nl - 1];
-                        let len = match std::str::from_utf8(len_bytes)
-                            .ok()
-                            .and_then(|s| s.parse::<i64>().ok())
-                        {
-                            Some(v) => v,
-                            None => {
-                                self.out.push_back(Err(RespError::ParseError(
-                                    "invalid bulk string len".into(),
-                                )));
-                                break;
-                            }
-                        };
-                        if len == -1 {
-                            // Null bulk string
-                            let _ = self.buf.split_to(nl + 1);
-                            self.out.push_back(Ok(RespData::BulkString(None)));
-                            continue;
-                        } else if len >= 0 {
-                            let need = nl + 1 + len as usize + 2;
-                            if self.buf.len() < need {
-                                break;
-                            }
-                            let chunk = self.buf.split_to(need);
-                            if &chunk[nl + 1 + len as usize..need] != b"\r\n" {
-                                self.out.push_back(Err(RespError::ParseError(
-                                    "invalid bulk string ending".into(),
-                                )));
-                                break;
-                            }
-                            let data = bytes::Bytes::copy_from_slice(
-                                &chunk[nl + 1..nl + 1 + len as usize],
-                            );
-                            self.out.push_back(Ok(RespData::BulkString(Some(data))));
-                            continue;
-                        } else {
-                            self.out.push_back(Err(RespError::ParseError(
-                                "negative bulk string len".into(),
-                            )));
-                            break;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                b'*' => {
-                    // Array: *<len>\r\n<item>... or *-1\r\n for null
-                    if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
-                        if nl < 3 || self.buf[nl - 1] != b'\r' {
-                            break;
-                        }
-                        let len_bytes = &self.buf[1..nl - 1];
-                        let len = match std::str::from_utf8(len_bytes)
-                            .ok()
-                            .and_then(|s| s.parse::<i64>().ok())
-                        {
-                            Some(v) => v,
-                            None => {
-                                self.out.push_back(Err(RespError::ParseError(
-                                    "invalid array len".into(),
-                                )));
-                                break;
-                            }
-                        };
-                        if len == -1 {
-                            // Null array
-                            let _ = self.buf.split_to(nl + 1);
-                            self.out.push_back(Ok(RespData::Array(None)));
-                            continue;
-                        } else if len >= 0 {
-                            let _ = self.buf.split_to(nl + 1);
-                            let mut items = Vec::with_capacity(len as usize);
-                            for _ in 0..len {
-                                // Recursively parse each array element
-                                if self.buf.is_empty() {
-                                    break;
-                                }
-                                // This is a simplified approach - in practice, we'd need to handle
-                                // nested structures more carefully
-                                match self.buf[0] {
-                                    b'+' => {
-                                        if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
-                                            let line_len = pos + 1;
-                                            let line = &self.buf[..line_len];
-                                            if line.len() >= 3 && line[line.len() - 2] == b'\r' {
-                                                let chunk = self.buf.split_to(line_len);
-                                                let data = bytes::Bytes::copy_from_slice(
-                                                    &chunk[1..chunk.len() - 2],
-                                                );
-                                                items.push(RespData::SimpleString(data));
-                                            } else {
-                                                break;
-                                            }
-                                        } else {
-                                            break;
-                                        }
-                                    }
-                                    b':' => {
-                                        if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
-                                            let line_len = pos + 1;
-                                            let line = &self.buf[..line_len];
-                                            if line.len() >= 3 && line[line.len() - 2] == b'\r' {
-                                                let chunk = self.buf.split_to(line_len);
-                                                let num_str = &chunk[1..chunk.len() - 2];
-                                                if let Some(n) = std::str::from_utf8(num_str)
-                                                    .ok()
-                                                    .and_then(|s| s.parse::<i64>().ok())
-                                                {
-                                                    items.push(RespData::Integer(n));
-                                                } else {
-                                                    break;
-                                                }
-                                            } else {
-                                                break;
-                                            }
-                                        } else {
-                                            break;
-                                        }
-                                    }
-                                    b'$' => {
-                                        if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
-                                            if nl < 3 || self.buf[nl - 1] != b'\r' {
-                                                break;
-                                            }
-                                            let len_bytes = &self.buf[1..nl - 1];
-                                            let len = match std::str::from_utf8(len_bytes)
-                                                .ok()
-                                                .and_then(|s| s.parse::<i64>().ok())
-                                            {
-                                                Some(v) => v,
-                                                None => break,
-                                            };
-                                            if len == -1 {
-                                                // Null bulk string
-                                                let _ = self.buf.split_to(nl + 1);
-                                                items.push(RespData::BulkString(None));
-                                            } else if len >= 0 {
-                                                let need = nl + 1 + len as usize + 2;
-                                                if self.buf.len() < need {
-                                                    break;
-                                                }
-                                                let chunk = self.buf.split_to(need);
-                                                if &chunk[nl + 1 + len as usize..need] != b"\r\n" {
-                                                    break;
-                                                }
-                                                let data = bytes::Bytes::copy_from_slice(
-                                                    &chunk[nl + 1..nl + 1 + len as usize],
-                                                );
-                                                items.push(RespData::BulkString(Some(data)));
-                                            } else {
-                                                break;
-                                            }
-                                        } else {
-                                            break;
-                                        }
-                                    }
-                                    _ => break,
-                                }
-                            }
-                            self.out.push_back(Ok(RespData::Array(Some(items))));
-                            continue;
-                        } else {
-                            self.out
-                                .push_back(Err(RespError::ParseError("negative array len".into())));
-                            break;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                _ => {
-                    // Unknown prefix - skip this byte and continue
-                    let _ = self.buf.split_to(1);
-                    continue;
-                }
             }
         }
     }

--- a/src/resp/src/resp3/decoder.rs
+++ b/src/resp/src/resp3/decoder.rs
@@ -1,0 +1,696 @@
+use std::collections::VecDeque;
+
+use bytes::Bytes;
+
+use crate::{
+    error::{RespError, RespResult},
+    traits::Decoder,
+    types::{RespData, RespVersion},
+};
+
+#[derive(Default)]
+pub struct Resp3Decoder {
+    out: VecDeque<RespResult<RespData>>,
+    buf: bytes::BytesMut,
+}
+
+impl Decoder for Resp3Decoder {
+    fn push(&mut self, data: Bytes) {
+        // keep empty to avoid unused import warning
+        self.buf.extend_from_slice(&data);
+
+        loop {
+            if self.buf.is_empty() {
+                break;
+            }
+            match self.buf[0] {
+                b'_' => {
+                    if self.buf.len() < 3 {
+                        break;
+                    }
+                    if &self.buf[..3] == b"_\r\n" {
+                        let _ = self.buf.split_to(3);
+                        self.out.push_back(Ok(RespData::Null));
+                        continue;
+                    } else {
+                        self.out
+                            .push_back(Err(RespError::ParseError("invalid RESP3 null".into())));
+                        break;
+                    }
+                }
+                b'#' => {
+                    if self.buf.len() < 4 {
+                        break;
+                    }
+                    // format: #t\r\n or #f\r\n
+                    if &self.buf[..4] == b"#t\r\n" {
+                        let _ = self.buf.split_to(4);
+                        self.out.push_back(Ok(RespData::Boolean(true)));
+                        continue;
+                    }
+                    if &self.buf[..4] == b"#f\r\n" {
+                        let _ = self.buf.split_to(4);
+                        self.out.push_back(Ok(RespData::Boolean(false)));
+                        continue;
+                    }
+                    self.out
+                        .push_back(Err(RespError::ParseError("invalid RESP3 boolean".into())));
+                    break;
+                }
+                b',' => {
+                    // format: ,<double>\r\n
+                    if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
+                        let line_len = pos + 1;
+                        let line = &self.buf[..line_len];
+                        if line.len() < 3 || line[line.len() - 2] != b'\r' {
+                            break;
+                        }
+                        // strip prefix ',' and CRLF
+                        let chunk = self.buf.split_to(line_len);
+                        let body = &chunk[1..chunk.len() - 2];
+                        if let Ok(s) = std::str::from_utf8(body) {
+                            let sl = s.to_ascii_lowercase();
+                            let val = if sl == "inf" {
+                                Some(f64::INFINITY)
+                            } else if sl == "-inf" {
+                                Some(f64::NEG_INFINITY)
+                            } else if sl == "nan" {
+                                Some(f64::NAN)
+                            } else {
+                                s.parse::<f64>().ok()
+                            };
+                            match val {
+                                Some(v) => {
+                                    self.out.push_back(Ok(RespData::Double(v)));
+                                    continue;
+                                }
+                                None => {
+                                    self.out.push_back(Err(RespError::ParseError(
+                                        "invalid RESP3 double".into(),
+                                    )));
+                                    break;
+                                }
+                            }
+                        } else {
+                            self.out.push_back(Err(RespError::ParseError(
+                                "invalid RESP3 double".into(),
+                            )));
+                            break;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                b'!' => {
+                    // Bulk error: !<len>\r\n<data>\r\n
+                    if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
+                        if nl < 3 || self.buf[nl - 1] != b'\r' {
+                            break;
+                        }
+                        let len_bytes = &self.buf[1..nl - 1];
+                        let len = match std::str::from_utf8(len_bytes)
+                            .ok()
+                            .and_then(|s| s.parse::<usize>().ok())
+                        {
+                            Some(v) => v,
+                            None => {
+                                self.out.push_back(Err(RespError::ParseError(
+                                    "invalid bulk error len".into(),
+                                )));
+                                break;
+                            }
+                        };
+                        let need = nl + 1 + len + 2;
+                        if self.buf.len() < need {
+                            break;
+                        }
+                        let chunk = self.buf.split_to(need);
+                        if &chunk[nl + 1 + len..need] != b"\r\n" {
+                            self.out.push_back(Err(RespError::ParseError(
+                                "invalid bulk error ending".into(),
+                            )));
+                            break;
+                        }
+                        let data = bytes::Bytes::copy_from_slice(&chunk[nl + 1..nl + 1 + len]);
+                        self.out.push_back(Ok(RespData::BulkError(data)));
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
+                b'=' => {
+                    // Verbatim string: =<len>\r\n<fmt>:<data>\r\n, fmt is 3 bytes
+                    if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
+                        if nl < 3 || self.buf[nl - 1] != b'\r' {
+                            break;
+                        }
+                        let len_bytes = &self.buf[1..nl - 1];
+                        let len = match std::str::from_utf8(len_bytes)
+                            .ok()
+                            .and_then(|s| s.parse::<usize>().ok())
+                        {
+                            Some(v) => v,
+                            None => {
+                                self.out.push_back(Err(RespError::ParseError(
+                                    "invalid verbatim len".into(),
+                                )));
+                                break;
+                            }
+                        };
+                        let need = nl + 1 + len + 2;
+                        if self.buf.len() < need {
+                            break;
+                        }
+                        let chunk = self.buf.split_to(need);
+                        let content = &chunk[nl + 1..nl + 1 + len];
+                        if content.len() < 4 || content[3] != b':' {
+                            self.out.push_back(Err(RespError::ParseError(
+                                "invalid verbatim header".into(),
+                            )));
+                            break;
+                        }
+                        let mut fmt = [0u8; 3];
+                        fmt.copy_from_slice(&content[0..3]);
+                        let data = bytes::Bytes::copy_from_slice(&content[4..]);
+                        if &chunk[nl + 1 + len..need] != b"\r\n" {
+                            self.out.push_back(Err(RespError::ParseError(
+                                "invalid verbatim ending".into(),
+                            )));
+                            break;
+                        }
+                        self.out
+                            .push_back(Ok(RespData::VerbatimString { format: fmt, data }));
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
+                b'(' => {
+                    // Big number: (<string>)\r\n, we treat contents as string until CRLF
+                    if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
+                        let line_len = pos + 1;
+                        let chunk = self.buf.split_to(line_len);
+                        if chunk.len() < 3 || chunk[chunk.len() - 2] != b'\r' {
+                            break;
+                        }
+                        let body = &chunk[1..chunk.len() - 2];
+                        match std::str::from_utf8(body) {
+                            Ok(s) => {
+                                self.out.push_back(Ok(RespData::BigNumber(s.to_string())));
+                                continue;
+                            }
+                            Err(_) => {
+                                self.out.push_back(Err(RespError::ParseError(
+                                    "invalid big number".into(),
+                                )));
+                                break;
+                            }
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                b'%' => {
+                    // Map: %<len>\r\n<k1><v1>... ; we only support nested scalars implemented so far
+                    if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
+                        if nl < 3 || self.buf[nl - 1] != b'\r' {
+                            break;
+                        }
+                        let len_bytes = &self.buf[1..nl - 1];
+                        let pairs = match std::str::from_utf8(len_bytes)
+                            .ok()
+                            .and_then(|s| s.parse::<usize>().ok())
+                        {
+                            Some(v) => v,
+                            None => {
+                                self.out.push_back(Err(RespError::ParseError(
+                                    "invalid map len".into(),
+                                )));
+                                break;
+                            }
+                        };
+                        let _ = self.buf.split_to(nl + 1);
+                        let mut items = Vec::with_capacity(pairs);
+                        for _ in 0..pairs {
+                            // parse key
+                            let k = if self.buf.is_empty() {
+                                break;
+                            } else {
+                                match self.buf[0] {
+                                    b'_' => {
+                                        if self.buf.len() < 3 {
+                                            break;
+                                        }
+                                        let _ = self.buf.split_to(3);
+                                        RespData::Null
+                                    }
+                                    b'#' => {
+                                        if self.buf.len() < 4 {
+                                            break;
+                                        }
+                                        let is_true = self.buf[1] == b't';
+                                        let _ = self.buf.split_to(4);
+                                        if is_true {
+                                            RespData::Boolean(true)
+                                        } else {
+                                            RespData::Boolean(false)
+                                        }
+                                    }
+                                    b',' => {
+                                        if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
+                                            let line = self.buf.split_to(pos + 1);
+                                            if line.len() < 3 || line[line.len() - 2] != b'\r' {
+                                                break;
+                                            }
+                                            let s =
+                                                std::str::from_utf8(&line[1..line.len() - 2]).ok();
+                                            let val = s.and_then(|s| {
+                                                let sl = s.to_ascii_lowercase();
+                                                if sl == "inf" {
+                                                    Some(f64::INFINITY)
+                                                } else if sl == "-inf" {
+                                                    Some(f64::NEG_INFINITY)
+                                                } else if sl == "nan" {
+                                                    Some(f64::NAN)
+                                                } else {
+                                                    s.parse::<f64>().ok()
+                                                }
+                                            });
+                                            match val {
+                                                Some(v) => RespData::Double(v),
+                                                None => {
+                                                    self.out.push_back(Err(RespError::ParseError(
+                                                        "invalid double".into(),
+                                                    )));
+                                                    break;
+                                                }
+                                            }
+                                        } else {
+                                            break;
+                                        }
+                                    }
+                                    b'!' => {
+                                        if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
+                                            if nl < 3 || self.buf[nl - 1] != b'\r' {
+                                                break;
+                                            }
+                                            let len = std::str::from_utf8(&self.buf[1..nl - 1])
+                                                .ok()
+                                                .and_then(|s| s.parse::<usize>().ok());
+                                            let len = match len {
+                                                Some(v) => v,
+                                                None => {
+                                                    self.out.push_back(Err(RespError::ParseError(
+                                                        "invalid bulk error len".into(),
+                                                    )));
+                                                    break;
+                                                }
+                                            };
+                                            let need = nl + 1 + len + 2;
+                                            if self.buf.len() < need {
+                                                break;
+                                            }
+                                            let chunk = self.buf.split_to(need);
+                                            if &chunk[nl + 1 + len..need] != b"\r\n" {
+                                                self.out.push_back(Err(RespError::ParseError(
+                                                    "invalid bulk error ending".into(),
+                                                )));
+                                                break;
+                                            }
+                                            RespData::BulkError(bytes::Bytes::copy_from_slice(
+                                                &chunk[nl + 1..nl + 1 + len],
+                                            ))
+                                        } else {
+                                            break;
+                                        }
+                                    }
+                                    _ => break,
+                                }
+                            };
+                            // parse value
+                            let v = if self.buf.is_empty() {
+                                break;
+                            } else {
+                                match self.buf[0] {
+                                    b'_' => {
+                                        if self.buf.len() < 3 {
+                                            break;
+                                        }
+                                        let _ = self.buf.split_to(3);
+                                        RespData::Null
+                                    }
+                                    b'#' => {
+                                        if self.buf.len() < 4 {
+                                            break;
+                                        }
+                                        let is_true = self.buf[1] == b't';
+                                        let _ = self.buf.split_to(4);
+                                        if is_true {
+                                            RespData::Boolean(true)
+                                        } else {
+                                            RespData::Boolean(false)
+                                        }
+                                    }
+                                    b',' => {
+                                        if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
+                                            let line = self.buf.split_to(pos + 1);
+                                            if line.len() < 3 || line[line.len() - 2] != b'\r' {
+                                                break;
+                                            }
+                                            let s =
+                                                std::str::from_utf8(&line[1..line.len() - 2]).ok();
+                                            let val = s.and_then(|s| {
+                                                let sl = s.to_ascii_lowercase();
+                                                if sl == "inf" {
+                                                    Some(f64::INFINITY)
+                                                } else if sl == "-inf" {
+                                                    Some(f64::NEG_INFINITY)
+                                                } else if sl == "nan" {
+                                                    Some(f64::NAN)
+                                                } else {
+                                                    s.parse::<f64>().ok()
+                                                }
+                                            });
+                                            match val {
+                                                Some(v) => RespData::Double(v),
+                                                None => {
+                                                    self.out.push_back(Err(RespError::ParseError(
+                                                        "invalid double".into(),
+                                                    )));
+                                                    break;
+                                                }
+                                            }
+                                        } else {
+                                            break;
+                                        }
+                                    }
+                                    b'!' => {
+                                        if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
+                                            if nl < 3 || self.buf[nl - 1] != b'\r' {
+                                                break;
+                                            }
+                                            let len = std::str::from_utf8(&self.buf[1..nl - 1])
+                                                .ok()
+                                                .and_then(|s| s.parse::<usize>().ok());
+                                            let len = match len {
+                                                Some(v) => v,
+                                                None => {
+                                                    self.out.push_back(Err(RespError::ParseError(
+                                                        "invalid bulk error len".into(),
+                                                    )));
+                                                    break;
+                                                }
+                                            };
+                                            let need = nl + 1 + len + 2;
+                                            if self.buf.len() < need {
+                                                break;
+                                            }
+                                            let chunk = self.buf.split_to(need);
+                                            if &chunk[nl + 1 + len..need] != b"\r\n" {
+                                                self.out.push_back(Err(RespError::ParseError(
+                                                    "invalid bulk error ending".into(),
+                                                )));
+                                                break;
+                                            }
+                                            RespData::BulkError(bytes::Bytes::copy_from_slice(
+                                                &chunk[nl + 1..nl + 1 + len],
+                                            ))
+                                        } else {
+                                            break;
+                                        }
+                                    }
+                                    _ => break,
+                                }
+                            };
+                            items.push((k, v));
+                        }
+                        self.out.push_back(Ok(RespData::Map(items)));
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
+                b'~' => {
+                    // Set: ~<len>\r\n<item>...
+                    if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
+                        if nl < 3 || self.buf[nl - 1] != b'\r' {
+                            break;
+                        }
+                        let len_bytes = &self.buf[1..nl - 1];
+                        let count = match std::str::from_utf8(len_bytes)
+                            .ok()
+                            .and_then(|s| s.parse::<usize>().ok())
+                        {
+                            Some(v) => v,
+                            None => {
+                                self.out.push_back(Err(RespError::ParseError(
+                                    "invalid set len".into(),
+                                )));
+                                break;
+                            }
+                        };
+                        let _ = self.buf.split_to(nl + 1);
+                        let mut items = Vec::with_capacity(count);
+                        for _ in 0..count {
+                            if self.buf.is_empty() {
+                                break;
+                            }
+                            let val = match self.buf[0] {
+                                b'_' => {
+                                    if self.buf.len() < 3 {
+                                        break;
+                                    }
+                                    let _ = self.buf.split_to(3);
+                                    RespData::Null
+                                }
+                                b'#' => {
+                                    if self.buf.len() < 4 {
+                                        break;
+                                    }
+                                    let is_true = self.buf[1] == b't';
+                                    let _ = self.buf.split_to(4);
+                                    if is_true {
+                                        RespData::Boolean(true)
+                                    } else {
+                                        RespData::Boolean(false)
+                                    }
+                                }
+                                b',' => {
+                                    if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
+                                        let line = self.buf.split_to(pos + 1);
+                                        if line.len() < 3 || line[line.len() - 2] != b'\r' {
+                                            break;
+                                        }
+                                        let s = std::str::from_utf8(&line[1..line.len() - 2]).ok();
+                                        let val = s.and_then(|s| {
+                                            let sl = s.to_ascii_lowercase();
+                                            if sl == "inf" {
+                                                Some(f64::INFINITY)
+                                            } else if sl == "-inf" {
+                                                Some(f64::NEG_INFINITY)
+                                            } else if sl == "nan" {
+                                                Some(f64::NAN)
+                                            } else {
+                                                s.parse::<f64>().ok()
+                                            }
+                                        });
+                                        match val {
+                                            Some(v) => RespData::Double(v),
+                                            None => {
+                                                self.out.push_back(Err(RespError::ParseError(
+                                                    "invalid double".into(),
+                                                )));
+                                                break;
+                                            }
+                                        }
+                                    } else {
+                                        break;
+                                    }
+                                }
+                                b'!' => {
+                                    if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
+                                        if nl < 3 || self.buf[nl - 1] != b'\r' {
+                                            break;
+                                        }
+                                        let len = std::str::from_utf8(&self.buf[1..nl - 1])
+                                            .ok()
+                                            .and_then(|s| s.parse::<usize>().ok());
+                                        let len = match len {
+                                            Some(v) => v,
+                                            None => {
+                                                self.out.push_back(Err(RespError::ParseError(
+                                                    "invalid bulk error len".into(),
+                                                )));
+                                                break;
+                                            }
+                                        };
+                                        let need = nl + 1 + len + 2;
+                                        if self.buf.len() < need {
+                                            break;
+                                        }
+                                        let chunk = self.buf.split_to(need);
+                                        if &chunk[nl + 1 + len..need] != b"\r\n" {
+                                            self.out.push_back(Err(RespError::ParseError(
+                                                "invalid bulk error ending".into(),
+                                            )));
+                                            break;
+                                        }
+                                        RespData::BulkError(bytes::Bytes::copy_from_slice(
+                                            &chunk[nl + 1..nl + 1 + len],
+                                        ))
+                                    } else {
+                                        break;
+                                    }
+                                }
+                                _ => break,
+                            };
+                            items.push(val);
+                        }
+                        self.out.push_back(Ok(RespData::Set(items)));
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
+                b'>' => {
+                    // Push: >len\r\n<item>...
+                    if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
+                        if nl < 3 || self.buf[nl - 1] != b'\r' {
+                            break;
+                        }
+                        let len_bytes = &self.buf[1..nl - 1];
+                        let count = match std::str::from_utf8(len_bytes)
+                            .ok()
+                            .and_then(|s| s.parse::<usize>().ok())
+                        {
+                            Some(v) => v,
+                            None => {
+                                self.out.push_back(Err(RespError::ParseError(
+                                    "invalid push len".into(),
+                                )));
+                                break;
+                            }
+                        };
+                        let _ = self.buf.split_to(nl + 1);
+                        let mut items = Vec::with_capacity(count);
+                        for _ in 0..count {
+                            if self.buf.is_empty() {
+                                break;
+                            }
+                            let val = match self.buf[0] {
+                                b'_' => {
+                                    if self.buf.len() < 3 {
+                                        break;
+                                    }
+                                    let _ = self.buf.split_to(3);
+                                    RespData::Null
+                                }
+                                b'#' => {
+                                    if self.buf.len() < 4 {
+                                        break;
+                                    }
+                                    let is_true = self.buf[1] == b't';
+                                    let _ = self.buf.split_to(4);
+                                    if is_true {
+                                        RespData::Boolean(true)
+                                    } else {
+                                        RespData::Boolean(false)
+                                    }
+                                }
+                                b',' => {
+                                    if let Some(pos) = memchr::memchr(b'\n', &self.buf) {
+                                        let line = self.buf.split_to(pos + 1);
+                                        if line.len() < 3 || line[line.len() - 2] != b'\r' {
+                                            break;
+                                        }
+                                        let s = std::str::from_utf8(&line[1..line.len() - 2]).ok();
+                                        let val = s.and_then(|s| {
+                                            let sl = s.to_ascii_lowercase();
+                                            if sl == "inf" {
+                                                Some(f64::INFINITY)
+                                            } else if sl == "-inf" {
+                                                Some(f64::NEG_INFINITY)
+                                            } else if sl == "nan" {
+                                                Some(f64::NAN)
+                                            } else {
+                                                s.parse::<f64>().ok()
+                                            }
+                                        });
+                                        match val {
+                                            Some(v) => RespData::Double(v),
+                                            None => {
+                                                self.out.push_back(Err(RespError::ParseError(
+                                                    "invalid double".into(),
+                                                )));
+                                                break;
+                                            }
+                                        }
+                                    } else {
+                                        break;
+                                    }
+                                }
+                                b'!' => {
+                                    if let Some(nl) = memchr::memchr(b'\n', &self.buf) {
+                                        if nl < 3 || self.buf[nl - 1] != b'\r' {
+                                            break;
+                                        }
+                                        let len = std::str::from_utf8(&self.buf[1..nl - 1])
+                                            .ok()
+                                            .and_then(|s| s.parse::<usize>().ok());
+                                        let len = match len {
+                                            Some(v) => v,
+                                            None => {
+                                                self.out.push_back(Err(RespError::ParseError(
+                                                    "invalid bulk error len".into(),
+                                                )));
+                                                break;
+                                            }
+                                        };
+                                        let need = nl + 1 + len + 2;
+                                        if self.buf.len() < need {
+                                            break;
+                                        }
+                                        let chunk = self.buf.split_to(need);
+                                        if &chunk[nl + 1 + len..need] != b"\r\n" {
+                                            self.out.push_back(Err(RespError::ParseError(
+                                                "invalid bulk error ending".into(),
+                                            )));
+                                            break;
+                                        }
+                                        RespData::BulkError(bytes::Bytes::copy_from_slice(
+                                            &chunk[nl + 1..nl + 1 + len],
+                                        ))
+                                    } else {
+                                        break;
+                                    }
+                                }
+                                _ => break,
+                            };
+                            items.push(val);
+                        }
+                        self.out.push_back(Ok(RespData::Push(items)));
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
+                _ => {
+                    break;
+                }
+            }
+        }
+    }
+
+    fn next(&mut self) -> Option<RespResult<RespData>> {
+        self.out.pop_front()
+    }
+
+    fn reset(&mut self) {
+        self.out.clear();
+        self.buf.clear();
+    }
+
+    fn version(&self) -> RespVersion {
+        RespVersion::RESP3
+    }
+}

--- a/src/resp/src/resp3/decoder.rs
+++ b/src/resp/src/resp3/decoder.rs
@@ -453,7 +453,7 @@ impl Resp3Decoder {
                         let data = &chunk[..chunk.len() - 2]; // Remove \r\n
                         let parts: Vec<Bytes> = data
                             .split(|&b| b == b' ')
-                            .map(|s| bytes::Bytes::copy_from_slice(s))
+                            .map(bytes::Bytes::copy_from_slice)
                             .collect();
                         Some(Ok(RespData::Inline(parts)))
                     } else {
@@ -472,21 +472,15 @@ impl Decoder for Resp3Decoder {
         // keep empty to avoid unused import warning
         self.buf.extend_from_slice(&data);
 
-        loop {
-            if let Some(result) = self.parse_single_value() {
-                match result {
-                    Ok(data) => {
-                        self.out.push_back(Ok(data));
-                        continue;
-                    }
-                    Err(e) => {
-                        self.out.push_back(Err(e));
-                        break;
-                    }
+        while let Some(result) = self.parse_single_value() {
+            match result {
+                Ok(data) => {
+                    self.out.push_back(Ok(data));
                 }
-            } else {
-                // Need more data
-                break;
+                Err(e) => {
+                    self.out.push_back(Err(e));
+                    break;
+                }
             }
         }
     }

--- a/src/resp/src/resp3/encoder.rs
+++ b/src/resp/src/resp3/encoder.rs
@@ -1,3 +1,20 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use bytes::{Bytes, BytesMut};
 
 use crate::{

--- a/src/resp/src/resp3/encoder.rs
+++ b/src/resp/src/resp3/encoder.rs
@@ -1,0 +1,100 @@
+use bytes::{Bytes, BytesMut};
+
+use crate::{
+    error::{RespError, RespResult},
+    traits::Encoder,
+    types::{RespData, RespVersion},
+};
+
+#[derive(Default)]
+pub struct Resp3Encoder;
+
+impl Encoder for Resp3Encoder {
+    fn encode_one(&mut self, data: &RespData) -> RespResult<Bytes> {
+        let mut buf = BytesMut::new();
+        self.encode_into(data, &mut buf)?;
+        Ok(buf.freeze())
+    }
+
+    fn encode_into(&mut self, data: &RespData, out: &mut BytesMut) -> RespResult<()> {
+        match data {
+            RespData::Null => {
+                out.extend_from_slice(b"_\r\n");
+            }
+            RespData::Boolean(true) => {
+                out.extend_from_slice(b"#t\r\n");
+            }
+            RespData::Boolean(false) => {
+                out.extend_from_slice(b"#f\r\n");
+            }
+            RespData::Double(v) => {
+                out.extend_from_slice(b",");
+                if v.is_infinite() {
+                    if v.is_sign_positive() {
+                        out.extend_from_slice(b"inf");
+                    } else {
+                        out.extend_from_slice(b"-inf");
+                    }
+                } else if v.is_nan() {
+                    out.extend_from_slice(b"nan");
+                } else {
+                    use core::fmt::Write as _;
+                    let mut s = String::new();
+                    let _ = write!(&mut s, "{}", v);
+                    out.extend_from_slice(s.as_bytes());
+                }
+                out.extend_from_slice(b"\r\n");
+            }
+            RespData::BulkError(b) => {
+                use core::fmt::Write as _;
+                let len = b.len();
+                let _ = write!(out, "!{}\r\n", len);
+                out.extend_from_slice(b);
+                out.extend_from_slice(b"\r\n");
+            }
+            RespData::VerbatimString { format, data } => {
+                use core::fmt::Write as _;
+                // fmt: exactly 3 bytes
+                let payload_len = 3 + 1 + data.len();
+                let _ = write!(out, "={}\r\n", payload_len);
+                out.extend_from_slice(format);
+                out.extend_from_slice(b":");
+                out.extend_from_slice(data);
+                out.extend_from_slice(b"\r\n");
+            }
+            RespData::BigNumber(s) => {
+                out.extend_from_slice(b"(");
+                out.extend_from_slice(s.as_bytes());
+                out.extend_from_slice(b"\r\n");
+            }
+            RespData::Map(entries) => {
+                use core::fmt::Write as _;
+                let _ = write!(out, "%{}\r\n", entries.len());
+                for (k, v) in entries {
+                    self.encode_into(k, out)?;
+                    self.encode_into(v, out)?;
+                }
+            }
+            RespData::Set(items) => {
+                use core::fmt::Write as _;
+                let _ = write!(out, "~{}\r\n", items.len());
+                for it in items {
+                    self.encode_into(it, out)?;
+                }
+            }
+            RespData::Push(items) => {
+                use core::fmt::Write as _;
+                let _ = write!(out, ">{}\r\n", items.len());
+                for it in items {
+                    self.encode_into(it, out)?;
+                }
+            }
+            _ => return Err(RespError::UnsupportedType),
+        }
+        Ok(())
+    }
+
+    fn version(&self) -> RespVersion {
+        RespVersion::RESP3
+    }
+}

--- a/src/resp/src/resp3/mod.rs
+++ b/src/resp/src/resp3/mod.rs
@@ -1,0 +1,2 @@
+pub mod decoder;
+pub mod encoder;

--- a/src/resp/src/resp3/mod.rs
+++ b/src/resp/src/resp3/mod.rs
@@ -1,2 +1,19 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub mod decoder;
 pub mod encoder;

--- a/src/resp/src/traits.rs
+++ b/src/resp/src/traits.rs
@@ -22,15 +22,49 @@ use crate::{
     types::{RespData, RespVersion},
 };
 
+/// Trait for decoding RESP protocol messages from byte streams.
+/// 
+/// This trait provides a streaming interface for parsing RESP messages incrementally.
+/// Implementations should handle incomplete data gracefully and maintain parsing state.
 pub trait Decoder {
+    /// Push new data into the decoder's internal buffer.
+    /// 
+    /// This method should be called when new bytes are available for parsing.
+    /// The decoder will accumulate data until a complete RESP message can be parsed.
     fn push(&mut self, data: Bytes);
+    
+    /// Attempt to parse the next complete RESP message from the buffer.
+    /// 
+    /// Returns `Some(Ok(data))` if a complete message was parsed,
+    /// `Some(Err(error))` if parsing failed, or `None` if more data is needed.
     fn next(&mut self) -> Option<RespResult<RespData>>;
+    
+    /// Reset the decoder's internal state.
+    /// 
+    /// This clears any buffered data and resets the parser to its initial state.
     fn reset(&mut self);
+    
+    /// Get the RESP version this decoder supports.
     fn version(&self) -> RespVersion;
 }
 
+/// Trait for encoding RESP protocol messages to byte streams.
+/// 
+/// This trait provides methods for converting `RespData` into RESP-formatted bytes.
+/// Implementations should handle version-specific encoding rules and downlevel compatibility.
 pub trait Encoder {
+    /// Encode a single RESP message into a `Bytes` buffer.
+    /// 
+    /// This method creates a new buffer and encodes the given data into it.
+    /// For RESP3 types being encoded to older versions, downlevel conversion is applied.
     fn encode_one(&mut self, data: &RespData) -> RespResult<Bytes>;
+    
+    /// Encode a RESP message into an existing `BytesMut` buffer.
+    /// 
+    /// This method appends the encoded data to the provided buffer.
+    /// Useful for building larger messages or implementing streaming encoders.
     fn encode_into(&mut self, data: &RespData, out: &mut BytesMut) -> RespResult<()>;
+    
+    /// Get the RESP version this encoder supports.
     fn version(&self) -> RespVersion;
 }

--- a/src/resp/src/traits.rs
+++ b/src/resp/src/traits.rs
@@ -23,48 +23,48 @@ use crate::{
 };
 
 /// Trait for decoding RESP protocol messages from byte streams.
-/// 
+///
 /// This trait provides a streaming interface for parsing RESP messages incrementally.
 /// Implementations should handle incomplete data gracefully and maintain parsing state.
 pub trait Decoder {
     /// Push new data into the decoder's internal buffer.
-    /// 
+    ///
     /// This method should be called when new bytes are available for parsing.
     /// The decoder will accumulate data until a complete RESP message can be parsed.
     fn push(&mut self, data: Bytes);
-    
+
     /// Attempt to parse the next complete RESP message from the buffer.
-    /// 
+    ///
     /// Returns `Some(Ok(data))` if a complete message was parsed,
     /// `Some(Err(error))` if parsing failed, or `None` if more data is needed.
     fn next(&mut self) -> Option<RespResult<RespData>>;
-    
+
     /// Reset the decoder's internal state.
-    /// 
+    ///
     /// This clears any buffered data and resets the parser to its initial state.
     fn reset(&mut self);
-    
+
     /// Get the RESP version this decoder supports.
     fn version(&self) -> RespVersion;
 }
 
 /// Trait for encoding RESP protocol messages to byte streams.
-/// 
+///
 /// This trait provides methods for converting `RespData` into RESP-formatted bytes.
 /// Implementations should handle version-specific encoding rules and downlevel compatibility.
 pub trait Encoder {
     /// Encode a single RESP message into a `Bytes` buffer.
-    /// 
+    ///
     /// This method creates a new buffer and encodes the given data into it.
     /// For RESP3 types being encoded to older versions, downlevel conversion is applied.
     fn encode_one(&mut self, data: &RespData) -> RespResult<Bytes>;
-    
+
     /// Encode a RESP message into an existing `BytesMut` buffer.
-    /// 
+    ///
     /// This method appends the encoded data to the provided buffer.
     /// Useful for building larger messages or implementing streaming encoders.
     fn encode_into(&mut self, data: &RespData, out: &mut BytesMut) -> RespResult<()>;
-    
+
     /// Get the RESP version this encoder supports.
     fn version(&self) -> RespVersion;
 }

--- a/src/resp/src/traits.rs
+++ b/src/resp/src/traits.rs
@@ -15,31 +15,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod command;
-pub mod compat;
-pub mod encode;
-pub mod error;
-pub mod parse;
-pub mod types;
+use bytes::{Bytes, BytesMut};
 
-// Versioned modules
-pub mod resp1;
-pub mod resp2;
-pub mod resp3;
+use crate::{
+    error::RespResult,
+    types::{RespData, RespVersion},
+};
 
-// Unified traits and helpers
-pub mod factory;
-pub mod multi;
-pub mod traits;
+pub trait Decoder {
+    fn push(&mut self, data: Bytes);
+    fn next(&mut self) -> Option<RespResult<RespData>>;
+    fn reset(&mut self);
+    fn version(&self) -> RespVersion;
+}
 
-pub use command::{Command, CommandType, RespCommand};
-pub use compat::{BooleanMode, DoubleMode, DownlevelPolicy, MapMode};
-pub use encode::{CmdRes, RespEncode};
-pub use error::{RespError, RespResult};
-pub use factory::{new_decoder, new_encoder, new_encoder_with_policy};
-pub use multi::{decode_many, encode_many};
-pub use parse::{Parse, RespParse, RespParseResult};
-pub use traits::{Decoder, Encoder};
-pub use types::{RespData, RespType, RespVersion};
-
-pub const CRLF: &str = "\r\n";
+pub trait Encoder {
+    fn encode_one(&mut self, data: &RespData) -> RespResult<Bytes>;
+    fn encode_into(&mut self, data: &RespData, out: &mut BytesMut) -> RespResult<()>;
+    fn version(&self) -> RespVersion;
+}

--- a/src/resp/src/types.rs
+++ b/src/resp/src/types.rs
@@ -225,7 +225,7 @@ impl fmt::Debug for RespData {
             }
             RespData::VerbatimString { format, data } => {
                 if let Ok(s) = std::str::from_utf8(data) {
-                    let fmt = std::str::from_utf8(format).unwrap_or("???");
+                    let fmt = std::str::from_utf8(&format[..]).unwrap_or("???");
                     write!(f, "VerbatimString({fmt}:{s})")
                 } else {
                     write!(f, "VerbatimString({:?}:{:?})", format, data)

--- a/src/resp/tests/factory_selection.rs
+++ b/src/resp/tests/factory_selection.rs
@@ -1,0 +1,27 @@
+use bytes::Bytes;
+use resp::{RespVersion, new_decoder, new_encoder};
+
+#[test]
+fn selects_resp1_impl() {
+    let mut dec = new_decoder(RespVersion::RESP1);
+    let enc = new_encoder(RespVersion::RESP1);
+    assert_eq!(dec.version(), RespVersion::RESP1);
+    assert_eq!(enc.version(), RespVersion::RESP1);
+
+    // minimal smoke: inline ping
+    dec.push(Bytes::from("PING\r\n"));
+    // even if command extraction differs, API shape should not panic
+    let _ = dec.next();
+}
+
+#[test]
+fn selects_resp2_impl() {
+    let mut dec = new_decoder(RespVersion::RESP2);
+    let enc = new_encoder(RespVersion::RESP2);
+    assert_eq!(dec.version(), RespVersion::RESP2);
+    assert_eq!(enc.version(), RespVersion::RESP2);
+
+    // minimal smoke: +OK\r\n
+    dec.push(Bytes::from("+OK\r\n"));
+    let _ = dec.next();
+}

--- a/src/resp/tests/factory_selection.rs
+++ b/src/resp/tests/factory_selection.rs
@@ -1,3 +1,20 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use bytes::Bytes;
 use resp::{RespVersion, new_decoder, new_encoder};
 

--- a/src/resp/tests/incremental_parsing.rs
+++ b/src/resp/tests/incremental_parsing.rs
@@ -15,7 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bytes::Bytes;
 use resp::{RespData, RespVersion, new_decoder};
 
 #[test]

--- a/src/resp/tests/incremental_parsing.rs
+++ b/src/resp/tests/incremental_parsing.rs
@@ -1,0 +1,175 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use resp::{RespData, RespVersion, new_decoder};
+
+#[test]
+fn incremental_array_parsing() {
+    let mut decoder = new_decoder(RespVersion::RESP3);
+
+    // First chunk: "*2\r\n+foo\r\n"
+    decoder.push("*2\r\n+foo\r\n".into());
+    let result = decoder.next();
+    assert!(result.is_none(), "Should need more data for complete array");
+
+    // Second chunk: "+bar\r\n"
+    decoder.push("+bar\r\n".into());
+    let result = decoder.next();
+    assert!(result.is_some(), "Should have complete array now");
+
+    match result.unwrap() {
+        Ok(RespData::Array(Some(items))) => {
+            assert_eq!(items.len(), 2);
+            match &items[0] {
+                RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"foo"),
+                _ => panic!("Expected SimpleString 'foo'"),
+            }
+            match &items[1] {
+                RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"bar"),
+                _ => panic!("Expected SimpleString 'bar'"),
+            }
+        }
+        other => panic!("Expected Array with 2 items, got {:?}", other),
+    }
+}
+
+#[test]
+fn incremental_map_parsing() {
+    let mut decoder = new_decoder(RespVersion::RESP3);
+
+    // First chunk: "%1\r\n+key\r\n"
+    decoder.push("%1\r\n+key\r\n".into());
+    let result = decoder.next();
+    assert!(result.is_none(), "Should need more data for complete map");
+
+    // Second chunk: "+value\r\n"
+    decoder.push("+value\r\n".into());
+    let result = decoder.next();
+    assert!(result.is_some(), "Should have complete map now");
+
+    match result.unwrap() {
+        Ok(RespData::Map(items)) => {
+            assert_eq!(items.len(), 1);
+            match &items[0] {
+                (RespData::SimpleString(k), RespData::SimpleString(v)) => {
+                    assert_eq!(k.as_ref(), b"key");
+                    assert_eq!(v.as_ref(), b"value");
+                }
+                _ => panic!("Expected (SimpleString, SimpleString) pair"),
+            }
+        }
+        other => panic!("Expected Map with 1 pair, got {:?}", other),
+    }
+}
+
+#[test]
+fn incremental_set_parsing() {
+    let mut decoder = new_decoder(RespVersion::RESP3);
+
+    // First chunk: "~2\r\n+item1\r\n"
+    decoder.push("~2\r\n+item1\r\n".into());
+    let result = decoder.next();
+    assert!(result.is_none(), "Should need more data for complete set");
+
+    // Second chunk: "+item2\r\n"
+    decoder.push("+item2\r\n".into());
+    let result = decoder.next();
+    assert!(result.is_some(), "Should have complete set now");
+
+    match result.unwrap() {
+        Ok(RespData::Set(items)) => {
+            assert_eq!(items.len(), 2);
+            match &items[0] {
+                RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"item1"),
+                _ => panic!("Expected SimpleString 'item1'"),
+            }
+            match &items[1] {
+                RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"item2"),
+                _ => panic!("Expected SimpleString 'item2'"),
+            }
+        }
+        other => panic!("Expected Set with 2 items, got {:?}", other),
+    }
+}
+
+#[test]
+fn incremental_push_parsing() {
+    let mut decoder = new_decoder(RespVersion::RESP3);
+
+    // First chunk: ">2\r\n+msg1\r\n"
+    decoder.push(">2\r\n+msg1\r\n".into());
+    let result = decoder.next();
+    assert!(result.is_none(), "Should need more data for complete push");
+
+    // Second chunk: "+msg2\r\n"
+    decoder.push("+msg2\r\n".into());
+    let result = decoder.next();
+    assert!(result.is_some(), "Should have complete push now");
+
+    match result.unwrap() {
+        Ok(RespData::Push(items)) => {
+            assert_eq!(items.len(), 2);
+            match &items[0] {
+                RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"msg1"),
+                _ => panic!("Expected SimpleString 'msg1'"),
+            }
+            match &items[1] {
+                RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"msg2"),
+                _ => panic!("Expected SimpleString 'msg2'"),
+            }
+        }
+        other => panic!("Expected Push with 2 items, got {:?}", other),
+    }
+}
+
+#[test]
+fn multiple_incremental_messages() {
+    let mut decoder = new_decoder(RespVersion::RESP3);
+
+    // First chunk: "*1\r\n+hello\r\n*1\r\n"
+    decoder.push("*1\r\n+hello\r\n*1\r\n".into());
+    let result = decoder.next();
+    assert!(result.is_some(), "Should have first complete array");
+
+    match result.unwrap() {
+        Ok(RespData::Array(Some(items))) => {
+            assert_eq!(items.len(), 1);
+            match &items[0] {
+                RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"hello"),
+                _ => panic!("Expected SimpleString 'hello'"),
+            }
+        }
+        other => panic!("Expected Array with 1 item, got {:?}", other),
+    }
+
+    // Second chunk: "+world\r\n"
+    decoder.push("+world\r\n".into());
+    let result = decoder.next();
+    assert!(result.is_some(), "Should have second complete array");
+
+    match result.unwrap() {
+        Ok(RespData::Array(Some(items))) => {
+            assert_eq!(items.len(), 1);
+            match &items[0] {
+                RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"world"),
+                _ => panic!("Expected SimpleString 'world'"),
+            }
+        }
+        other => panic!("Expected Array with 1 item, got {:?}", other),
+    }
+}

--- a/src/resp/tests/nested_incremental.rs
+++ b/src/resp/tests/nested_incremental.rs
@@ -1,0 +1,233 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use resp::{RespData, RespVersion, new_decoder};
+
+#[test]
+fn nested_array_incremental() {
+    let mut decoder = new_decoder(RespVersion::RESP3);
+
+    // First chunk: outer array with incomplete inner array
+    decoder.push("*2\r\n*1\r\n".into());
+    let result1 = decoder.next();
+    assert!(result1.is_none(), "Should need more data for nested array");
+
+    // Second chunk: complete inner array + second element
+    decoder.push("+foo\r\n+bar\r\n".into());
+    let result2 = decoder.next();
+
+    match result2 {
+        Some(Ok(RespData::Array(Some(items)))) => {
+            assert_eq!(items.len(), 2, "Outer array should have 2 elements");
+            match &items[0] {
+                RespData::Array(Some(inner)) => {
+                    assert_eq!(inner.len(), 1);
+                    match &inner[0] {
+                        RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"foo"),
+                        _ => panic!("Inner array should contain SimpleString 'foo'"),
+                    }
+                }
+                _ => panic!("First element should be an array"),
+            }
+            match &items[1] {
+                RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"bar"),
+                _ => panic!("Second element should be SimpleString 'bar'"),
+            }
+        }
+        other => panic!("Expected nested array, got {:?}", other),
+    }
+}
+
+#[test]
+fn deeply_nested_arrays() {
+    let mut decoder = new_decoder(RespVersion::RESP3);
+
+    // First chunk: deeply nested arrays
+    decoder.push("*2\r\n*1\r\n*1\r\n".into());
+    let result1 = decoder.next();
+    assert!(
+        result1.is_none(),
+        "Should need more data for deeply nested arrays"
+    );
+
+    // Second chunk: complete the deepest level
+    decoder.push("+deep\r\n".into());
+    let result2 = decoder.next();
+    println!("After second chunk: {:?}", result2);
+    assert!(result2.is_none(), "Should still need more data");
+
+    // Third chunk: complete middle level
+    decoder.push("+middle\r\n".into());
+    let result3 = decoder.next();
+    println!("After third chunk: {:?}", result3);
+
+    // The parsing should be complete after the third chunk
+    match result3 {
+        Some(Ok(RespData::Array(Some(items)))) => {
+            assert_eq!(items.len(), 2);
+
+            // First element: [["deep"]]
+            match &items[0] {
+                RespData::Array(Some(level1)) => {
+                    assert_eq!(level1.len(), 1);
+                    match &level1[0] {
+                        RespData::Array(Some(level2)) => {
+                            assert_eq!(level2.len(), 1);
+                            match &level2[0] {
+                                RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"deep"),
+                                _ => panic!("Deepest level should contain 'deep'"),
+                            }
+                        }
+                        _ => panic!("Level 1 should contain an array"),
+                    }
+                }
+                _ => panic!("First element should be an array"),
+            }
+
+            // Second element: "middle" (not "outer" as originally expected)
+            match &items[1] {
+                RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"middle"),
+                _ => panic!("Second element should be 'middle'"),
+            }
+        }
+        other => panic!("Expected deeply nested array, got {:?}", other),
+    }
+}
+
+#[test]
+fn nested_map_incremental() {
+    let mut decoder = new_decoder(RespVersion::RESP3);
+
+    // First chunk: outer map with incomplete inner map
+    decoder.push("%1\r\n+key1\r\n%1\r\n".into());
+    let result1 = decoder.next();
+    assert!(result1.is_none(), "Should need more data for nested map");
+
+    // Second chunk: complete inner map + outer map value
+    decoder.push("+inner_key\r\n+inner_value\r\n+outer_value\r\n".into());
+    let result2 = decoder.next();
+
+    match result2 {
+        Some(Ok(RespData::Map(items))) => {
+            assert_eq!(items.len(), 1);
+            match &items[0] {
+                (RespData::SimpleString(key), RespData::Map(inner_map)) => {
+                    assert_eq!(key.as_ref(), b"key1");
+                    assert_eq!(inner_map.len(), 1);
+                    match &inner_map[0] {
+                        (RespData::SimpleString(ik), RespData::SimpleString(iv)) => {
+                            assert_eq!(ik.as_ref(), b"inner_key");
+                            assert_eq!(iv.as_ref(), b"inner_value");
+                        }
+                        _ => panic!("Inner map should contain key-value pair"),
+                    }
+                }
+                _ => panic!("Outer map should contain key1 -> inner map"),
+            }
+        }
+        other => panic!("Expected nested map, got {:?}", other),
+    }
+}
+
+#[test]
+fn mixed_nested_collections() {
+    let mut decoder = new_decoder(RespVersion::RESP3);
+
+    // First chunk: array containing map containing set
+    decoder.push("*1\r\n%1\r\n+map_key\r\n~1\r\n".into());
+    let result1 = decoder.next();
+    assert!(
+        result1.is_none(),
+        "Should need more data for mixed nested collections"
+    );
+
+    // Second chunk: complete the set + map value
+    decoder.push("+set_item\r\n+map_value\r\n".into());
+    let result2 = decoder.next();
+
+    match result2 {
+        Some(Ok(RespData::Array(Some(items)))) => {
+            assert_eq!(items.len(), 1);
+            match &items[0] {
+                RespData::Map(map_items) => {
+                    assert_eq!(map_items.len(), 1);
+                    match &map_items[0] {
+                        (RespData::SimpleString(key), RespData::Set(set_items)) => {
+                            assert_eq!(key.as_ref(), b"map_key");
+                            assert_eq!(set_items.len(), 1);
+                            match &set_items[0] {
+                                RespData::SimpleString(si) => {
+                                    assert_eq!(si.as_ref(), b"set_item");
+                                }
+                                _ => panic!("Set should contain 'set_item'"),
+                            }
+                        }
+                        _ => panic!("Map should contain map_key -> set"),
+                    }
+                }
+                _ => panic!("Array should contain a map"),
+            }
+        }
+        other => panic!("Expected mixed nested collections, got {:?}", other),
+    }
+}
+
+#[test]
+fn multiple_nested_messages() {
+    let mut decoder = new_decoder(RespVersion::RESP3);
+
+    // First chunk: two nested messages
+    decoder.push("*1\r\n*1\r\n+first\r\n*1\r\n".into());
+    let result1 = decoder.next();
+    println!("After first chunk: {:?}", result1);
+    assert!(result1.is_some(), "Should have first complete message");
+
+    // Second chunk: complete second message
+    decoder.push("+second\r\n".into());
+    let result2 = decoder.next();
+    assert!(result2.is_some(), "Should have second complete message");
+
+    // Verify first message
+    match result1.unwrap() {
+        Ok(RespData::Array(Some(items))) => {
+            assert_eq!(items.len(), 1);
+            match &items[0] {
+                RespData::Array(Some(inner)) => {
+                    assert_eq!(inner.len(), 1);
+                    match &inner[0] {
+                        RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"first"),
+                        _ => panic!("First message should contain 'first'"),
+                    }
+                }
+                _ => panic!("First message should be nested array"),
+            }
+        }
+        other => panic!("Expected first message to be array, got {:?}", other),
+    }
+
+    // Verify second message
+    match result2.unwrap() {
+        Ok(RespData::Array(Some(items))) => {
+            assert_eq!(items.len(), 1);
+            match &items[0] {
+                RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"second"),
+                _ => panic!("Second message should contain 'second'"),
+            }
+        }
+        other => panic!("Expected second message to be array, got {:?}", other),
+    }
+}

--- a/src/resp/tests/nested_incremental.rs
+++ b/src/resp/tests/nested_incremental.rs
@@ -67,13 +67,11 @@ fn deeply_nested_arrays() {
     // Second chunk: complete the deepest level
     decoder.push("+deep\r\n".into());
     let result2 = decoder.next();
-    println!("After second chunk: {:?}", result2);
     assert!(result2.is_none(), "Should still need more data");
 
     // Third chunk: complete middle level
     decoder.push("+middle\r\n".into());
     let result3 = decoder.next();
-    println!("After third chunk: {:?}", result3);
 
     // The parsing should be complete after the third chunk
     match result3 {
@@ -117,8 +115,8 @@ fn nested_map_incremental() {
     let result1 = decoder.next();
     assert!(result1.is_none(), "Should need more data for nested map");
 
-    // Second chunk: complete inner map + outer map value
-    decoder.push("+inner_key\r\n+inner_value\r\n+outer_value\r\n".into());
+    // Second chunk: complete inner map
+    decoder.push("+inner_key\r\n+inner_value\r\n".into());
     let result2 = decoder.next();
 
     match result2 {
@@ -155,8 +153,8 @@ fn mixed_nested_collections() {
         "Should need more data for mixed nested collections"
     );
 
-    // Second chunk: complete the set + map value
-    decoder.push("+set_item\r\n+map_value\r\n".into());
+    // Second chunk: complete the set
+    decoder.push("+set_item\r\n".into());
     let result2 = decoder.next();
 
     match result2 {
@@ -193,7 +191,6 @@ fn multiple_nested_messages() {
     // First chunk: two nested messages
     decoder.push("*1\r\n*1\r\n+first\r\n*1\r\n".into());
     let result1 = decoder.next();
-    println!("After first chunk: {:?}", result1);
     assert!(result1.is_some(), "Should have first complete message");
 
     // Second chunk: complete second message

--- a/src/resp/tests/policy_downlevel.rs
+++ b/src/resp/tests/policy_downlevel.rs
@@ -1,3 +1,20 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use resp::{
     BooleanMode, DoubleMode, DownlevelPolicy, MapMode, RespData, RespVersion,
     new_encoder_with_policy,

--- a/src/resp/tests/policy_downlevel.rs
+++ b/src/resp/tests/policy_downlevel.rs
@@ -1,0 +1,49 @@
+use resp::{
+    BooleanMode, DoubleMode, DownlevelPolicy, MapMode, RespData, RespVersion,
+    new_encoder_with_policy,
+};
+
+#[test]
+fn boolean_as_simplestring() {
+    let policy = DownlevelPolicy {
+        boolean_mode: BooleanMode::SimpleString,
+        ..Default::default()
+    };
+    let mut enc = new_encoder_with_policy(RespVersion::RESP2, policy);
+    let bytes = resp::encode_many(&mut *enc, &[
+        RespData::Boolean(true),
+        RespData::Boolean(false),
+    ])
+    .unwrap();
+    let s = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(s.contains("+OK\r\n"));
+    assert!(s.contains("+ERR\r\n"));
+}
+
+#[test]
+fn double_as_integer_if_whole() {
+    let policy = DownlevelPolicy {
+        double_mode: DoubleMode::IntegerIfWhole,
+        ..Default::default()
+    };
+    let mut enc = new_encoder_with_policy(RespVersion::RESP1, policy);
+    let bytes =
+        resp::encode_many(&mut *enc, &[RespData::Double(2.0), RespData::Double(2.5)]).unwrap();
+    let s = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(s.contains(":2\r\n"));
+    assert!(s.contains("2.5"));
+}
+
+#[test]
+fn map_as_array_of_pairs() {
+    let policy = DownlevelPolicy {
+        map_mode: MapMode::ArrayOfPairs,
+        ..Default::default()
+    };
+    let mut enc = new_encoder_with_policy(RespVersion::RESP2, policy);
+    let data = RespData::Map(vec![(RespData::Boolean(true), RespData::Boolean(false))]);
+    let bytes = resp::encode_many(&mut *enc, &[data]).unwrap();
+    let s = String::from_utf8(bytes.to_vec()).unwrap();
+    // *1\r\n*2\r\n:1\r\n:0\r\n (or simple string, depends on boolean_mode default)
+    assert!(s.starts_with("*1\r\n"));
+}

--- a/src/resp/tests/resp1_basic.rs
+++ b/src/resp/tests/resp1_basic.rs
@@ -1,0 +1,21 @@
+use bytes::Bytes;
+use resp::{RespData, RespVersion, decode_many, new_decoder};
+
+#[test]
+fn inline_ping() {
+    let mut dec = new_decoder(RespVersion::RESP1);
+    let out = decode_many(&mut *dec, Bytes::from("PING\r\n"));
+    // Not required to convert to command, just verify no crash and produces a frame
+    assert!(out.len() >= 1);
+}
+
+#[test]
+fn simple_string_ok() {
+    let mut dec = new_decoder(RespVersion::RESP1);
+    let out = decode_many(&mut *dec, Bytes::from("+OK\r\n"));
+    let v = out[0].as_ref().unwrap();
+    match v {
+        RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"OK"),
+        _ => panic!(),
+    }
+}

--- a/src/resp/tests/resp1_basic.rs
+++ b/src/resp/tests/resp1_basic.rs
@@ -1,3 +1,20 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use bytes::Bytes;
 use resp::{RespData, RespVersion, decode_many, new_decoder};
 

--- a/src/resp/tests/resp2_compat.rs
+++ b/src/resp/tests/resp2_compat.rs
@@ -22,11 +22,11 @@ use resp::{RespData, RespVersion, decode_many, new_decoder};
 fn parse_simple_string_ok() {
     let mut dec = new_decoder(RespVersion::RESP2);
     let out = decode_many(&mut *dec, Bytes::from("+OK\r\n"));
-    assert!(out.len() >= 1);
+    assert_eq!(out.len(), 1);
     let v = out[0].as_ref().unwrap();
     match v {
         RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"OK"),
-        _ => panic!(),
+        other => panic!("Expected SimpleString, got {:?}", other),
     }
 }
 
@@ -37,7 +37,7 @@ fn parse_integer() {
     let v = out[0].as_ref().unwrap();
     match v {
         RespData::Integer(n) => assert_eq!(*n, 1000),
-        _ => panic!(),
+        other => panic!("Expected Integer, got {:?}", other),
     }
 }
 
@@ -50,6 +50,6 @@ fn parse_bulk_and_array() {
         RespData::Array(Some(items)) => {
             assert_eq!(items.len(), 2);
         }
-        _ => panic!(),
+        other => panic!("Expected Array, got {:?}", other),
     }
 }

--- a/src/resp/tests/resp2_compat.rs
+++ b/src/resp/tests/resp2_compat.rs
@@ -1,0 +1,38 @@
+use bytes::Bytes;
+use resp::{RespData, RespVersion, decode_many, new_decoder};
+
+#[test]
+fn parse_simple_string_ok() {
+    let mut dec = new_decoder(RespVersion::RESP2);
+    let out = decode_many(&mut *dec, Bytes::from("+OK\r\n"));
+    assert!(out.len() >= 1);
+    let v = out[0].as_ref().unwrap();
+    match v {
+        RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"OK"),
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn parse_integer() {
+    let mut dec = new_decoder(RespVersion::RESP2);
+    let out = decode_many(&mut *dec, Bytes::from(":1000\r\n"));
+    let v = out[0].as_ref().unwrap();
+    match v {
+        RespData::Integer(n) => assert_eq!(*n, 1000),
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn parse_bulk_and_array() {
+    let mut dec = new_decoder(RespVersion::RESP2);
+    let out = decode_many(&mut *dec, Bytes::from("*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"));
+    let v = out[0].as_ref().unwrap();
+    match v {
+        RespData::Array(Some(items)) => {
+            assert_eq!(items.len(), 2);
+        }
+        _ => panic!(),
+    }
+}

--- a/src/resp/tests/resp2_compat.rs
+++ b/src/resp/tests/resp2_compat.rs
@@ -1,3 +1,20 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use bytes::Bytes;
 use resp::{RespData, RespVersion, decode_many, new_decoder};
 

--- a/src/resp/tests/resp3_basic.rs
+++ b/src/resp/tests/resp3_basic.rs
@@ -21,8 +21,9 @@ use resp::{RespData, RespVersion, decode_many, new_decoder, new_encoder};
 #[test]
 fn resp3_null_boolean_double_decode() {
     let mut dec = new_decoder(RespVersion::RESP3);
-    let out = decode_many(&mut *dec, Bytes::from("_\r\n#t\r\n,f1.5\r\n"));
-    assert!(out.len() >= 2);
+    // Use separate inputs for clarity
+    let out = decode_many(&mut *dec, Bytes::from("_\r\n#t\r\n,1.5\r\n"));
+    assert_eq!(out.len(), 3, "Expected three decoded frames");
     match out[0].as_ref().unwrap() {
         RespData::Null => {}
         _ => panic!("expected Null"),
@@ -31,7 +32,10 @@ fn resp3_null_boolean_double_decode() {
         RespData::Boolean(true) => {}
         _ => panic!("expected Boolean(true)"),
     }
-    // third may be invalid until double formatting chosen; skip if parse failed
+    match out[2].as_ref().unwrap() {
+        RespData::Double(v) if (*v - 1.5).abs() < f64::EPSILON => {}
+        _ => panic!("expected Double(1.5)"),
+    }
 }
 
 #[test]

--- a/src/resp/tests/resp3_basic.rs
+++ b/src/resp/tests/resp3_basic.rs
@@ -1,3 +1,20 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use bytes::Bytes;
 use resp::{RespData, RespVersion, decode_many, new_decoder, new_encoder};
 

--- a/src/resp/tests/resp3_basic.rs
+++ b/src/resp/tests/resp3_basic.rs
@@ -1,0 +1,33 @@
+use bytes::Bytes;
+use resp::{RespData, RespVersion, decode_many, new_decoder, new_encoder};
+
+#[test]
+fn resp3_null_boolean_double_decode() {
+    let mut dec = new_decoder(RespVersion::RESP3);
+    let out = decode_many(&mut *dec, Bytes::from("_\r\n#t\r\n,f1.5\r\n"));
+    assert!(out.len() >= 2);
+    match out[0].as_ref().unwrap() {
+        RespData::Null => {}
+        _ => panic!("expected Null"),
+    }
+    match out[1].as_ref().unwrap() {
+        RespData::Boolean(true) => {}
+        _ => panic!("expected Boolean(true)"),
+    }
+    // third may be invalid until double formatting chosen; skip if parse failed
+}
+
+#[test]
+fn resp3_null_boolean_double_encode() {
+    let mut enc = new_encoder(RespVersion::RESP3);
+    let items = [
+        RespData::Null,
+        RespData::Boolean(true),
+        RespData::Double(1.5),
+    ];
+    let bytes = resp::encode_many(&mut *enc, &items).unwrap();
+    let s = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(s.contains("_\r\n"));
+    assert!(s.contains("#t\r\n"));
+    assert!(s.contains(",1.5\r\n") || s.contains(",1.5"));
+}

--- a/src/resp/tests/resp3_collections.rs
+++ b/src/resp/tests/resp3_collections.rs
@@ -31,7 +31,7 @@ fn set_roundtrip() {
     let out = decode_many(&mut *dec, bytes);
     match out[0].as_ref().unwrap() {
         RespData::Set(items) => assert_eq!(items.len(), 3),
-        _ => panic!(),
+        other => panic!("Expected Set, got {:?}", other),
     }
 }
 
@@ -47,7 +47,7 @@ fn map_roundtrip() {
     let out = decode_many(&mut *dec, bytes);
     match out[0].as_ref().unwrap() {
         RespData::Map(entries) => assert_eq!(entries.len(), 2),
-        _ => panic!(),
+        other => panic!("Expected Map, got {:?}", other),
     }
 }
 
@@ -60,6 +60,6 @@ fn push_roundtrip() {
     let out = decode_many(&mut *dec, bytes);
     match out[0].as_ref().unwrap() {
         RespData::Push(items) => assert_eq!(items.len(), 2),
-        _ => panic!(),
+        other => panic!("Expected Push, got {:?}", other),
     }
 }

--- a/src/resp/tests/resp3_collections.rs
+++ b/src/resp/tests/resp3_collections.rs
@@ -1,0 +1,48 @@
+use bytes::Bytes;
+use resp::{RespData, RespVersion, decode_many, encode_many, new_decoder, new_encoder};
+
+#[test]
+fn set_roundtrip() {
+    let mut enc = new_encoder(RespVersion::RESP3);
+    let data = RespData::Set(vec![
+        RespData::Boolean(true),
+        RespData::Null,
+        RespData::Double(2.5),
+    ]);
+    let bytes = encode_many(&mut *enc, &[data]).unwrap();
+    let mut dec = new_decoder(RespVersion::RESP3);
+    let out = decode_many(&mut *dec, bytes);
+    match out[0].as_ref().unwrap() {
+        RespData::Set(items) => assert_eq!(items.len(), 3),
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn map_roundtrip() {
+    let mut enc = new_encoder(RespVersion::RESP3);
+    let data = RespData::Map(vec![
+        (RespData::Boolean(true), RespData::Double(1.0)),
+        (RespData::Null, RespData::BulkError(Bytes::from("ERR x"))),
+    ]);
+    let bytes = encode_many(&mut *enc, &[data]).unwrap();
+    let mut dec = new_decoder(RespVersion::RESP3);
+    let out = decode_many(&mut *dec, bytes);
+    match out[0].as_ref().unwrap() {
+        RespData::Map(entries) => assert_eq!(entries.len(), 2),
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn push_roundtrip() {
+    let mut enc = new_encoder(RespVersion::RESP3);
+    let data = RespData::Push(vec![RespData::Boolean(false), RespData::Double(3.14)]);
+    let bytes = encode_many(&mut *enc, &[data]).unwrap();
+    let mut dec = new_decoder(RespVersion::RESP3);
+    let out = decode_many(&mut *dec, bytes);
+    match out[0].as_ref().unwrap() {
+        RespData::Push(items) => assert_eq!(items.len(), 2),
+        _ => panic!(),
+    }
+}

--- a/src/resp/tests/resp3_collections.rs
+++ b/src/resp/tests/resp3_collections.rs
@@ -1,3 +1,20 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use bytes::Bytes;
 use resp::{RespData, RespVersion, decode_many, encode_many, new_decoder, new_encoder};
 

--- a/src/resp/tests/resp3_collections_comprehensive.rs
+++ b/src/resp/tests/resp3_collections_comprehensive.rs
@@ -1,0 +1,156 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use resp::{RespData, RespVersion, decode_many, encode_many, new_decoder, new_encoder};
+
+#[test]
+fn map_with_standard_resp_types() {
+    let mut enc = new_encoder(RespVersion::RESP3);
+    let data = RespData::Map(vec![
+        (RespData::SimpleString("key1".into()), RespData::Integer(42)),
+        (
+            RespData::BulkString(Some("key2".into())),
+            RespData::SimpleString("value2".into()),
+        ),
+    ]);
+    let bytes = encode_many(&mut *enc, &[data]).unwrap();
+    let mut dec = new_decoder(RespVersion::RESP3);
+    let out = decode_many(&mut *dec, bytes);
+
+    assert_eq!(out.len(), 1, "Expected 1 result");
+    match out[0].as_ref().unwrap() {
+        RespData::Map(entries) => {
+            assert_eq!(entries.len(), 2, "Expected 2 map entries");
+            // Verify first entry
+            match &entries[0] {
+                (RespData::SimpleString(k), RespData::Integer(v)) => {
+                    assert_eq!(k.as_ref(), b"key1");
+                    assert_eq!(*v, 42);
+                }
+                _ => panic!("Expected (SimpleString, Integer) for first entry"),
+            }
+            // Verify second entry
+            match &entries[1] {
+                (RespData::BulkString(Some(k)), RespData::SimpleString(v)) => {
+                    assert_eq!(k.as_ref(), b"key2");
+                    assert_eq!(v.as_ref(), b"value2");
+                }
+                _ => panic!("Expected (BulkString, SimpleString) for second entry"),
+            }
+        }
+        other => panic!("Expected Map, got {:?}", other),
+    }
+}
+
+#[test]
+fn set_with_standard_resp_types() {
+    let mut enc = new_encoder(RespVersion::RESP3);
+    let data = RespData::Set(vec![
+        RespData::SimpleString("item1".into()),
+        RespData::Integer(123),
+        RespData::BulkString(Some("item3".into())),
+    ]);
+    let bytes = encode_many(&mut *enc, &[data]).unwrap();
+    let mut dec = new_decoder(RespVersion::RESP3);
+    let out = decode_many(&mut *dec, bytes);
+
+    assert_eq!(out.len(), 1, "Expected 1 result");
+    match out[0].as_ref().unwrap() {
+        RespData::Set(items) => {
+            assert_eq!(items.len(), 3, "Expected 3 set items");
+            // Check that all expected types are present
+            let mut found_simple = false;
+            let mut found_integer = false;
+            let mut found_bulk = false;
+
+            for item in items {
+                match item {
+                    RespData::SimpleString(s) if s.as_ref() == b"item1" => found_simple = true,
+                    RespData::Integer(i) if *i == 123 => found_integer = true,
+                    RespData::BulkString(Some(s)) if s.as_ref() == b"item3" => found_bulk = true,
+                    _ => {}
+                }
+            }
+
+            assert!(found_simple, "Expected SimpleString 'item1' in set");
+            assert!(found_integer, "Expected Integer 123 in set");
+            assert!(found_bulk, "Expected BulkString 'item3' in set");
+        }
+        other => panic!("Expected Set, got {:?}", other),
+    }
+}
+
+#[test]
+fn push_with_standard_resp_types() {
+    let mut enc = new_encoder(RespVersion::RESP3);
+    let data = RespData::Push(vec![
+        RespData::SimpleString("PUSH".into()),
+        RespData::Integer(1),
+        RespData::BulkString(Some("message".into())),
+    ]);
+    let bytes = encode_many(&mut *enc, &[data]).unwrap();
+    let mut dec = new_decoder(RespVersion::RESP3);
+    let out = decode_many(&mut *dec, bytes);
+
+    assert_eq!(out.len(), 1, "Expected 1 result");
+    match out[0].as_ref().unwrap() {
+        RespData::Push(items) => {
+            assert_eq!(items.len(), 3, "Expected 3 push items");
+            // Verify each item
+            match &items[0] {
+                RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"PUSH"),
+                _ => panic!("Expected SimpleString 'PUSH' as first item"),
+            }
+            match &items[1] {
+                RespData::Integer(i) => assert_eq!(*i, 1),
+                _ => panic!("Expected Integer 1 as second item"),
+            }
+            match &items[2] {
+                RespData::BulkString(Some(s)) => assert_eq!(s.as_ref(), b"message"),
+                _ => panic!("Expected BulkString 'message' as third item"),
+            }
+        }
+        other => panic!("Expected Push, got {:?}", other),
+    }
+}
+
+#[test]
+fn map_with_mixed_types() {
+    let mut enc = new_encoder(RespVersion::RESP3);
+    let data = RespData::Map(vec![
+        (
+            RespData::SimpleString("key".into()),
+            RespData::Boolean(true),
+        ),
+        (
+            RespData::Integer(1),
+            RespData::BulkString(Some("value".into())),
+        ),
+        (RespData::Null, RespData::Double(3.14)),
+    ]);
+    let bytes = encode_many(&mut *enc, &[data]).unwrap();
+    let mut dec = new_decoder(RespVersion::RESP3);
+    let out = decode_many(&mut *dec, bytes);
+
+    assert_eq!(out.len(), 1, "Expected 1 result");
+    match out[0].as_ref().unwrap() {
+        RespData::Map(entries) => {
+            assert_eq!(entries.len(), 3, "Expected 3 map entries");
+        }
+        other => panic!("Expected Map, got {:?}", other),
+    }
+}

--- a/src/resp/tests/resp3_encoder_comprehensive.rs
+++ b/src/resp/tests/resp3_encoder_comprehensive.rs
@@ -1,0 +1,103 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use resp::{RespData, RespVersion, new_encoder};
+
+#[test]
+fn resp3_encoder_all_types() {
+    let mut enc = new_encoder(RespVersion::RESP3);
+    
+    // Test all RESP3 types
+    let tests = vec![
+        (RespData::Null, b"_\r\n" as &[u8]),
+        (RespData::Boolean(true), b"#t\r\n" as &[u8]),
+        (RespData::Boolean(false), b"#f\r\n" as &[u8]),
+        (RespData::Double(3.14), b",3.14\r\n" as &[u8]),
+        (RespData::Double(f64::INFINITY), b",inf\r\n" as &[u8]),
+        (RespData::Double(f64::NEG_INFINITY), b",-inf\r\n" as &[u8]),
+        (RespData::Double(f64::NAN), b",nan\r\n" as &[u8]),
+        (RespData::BulkError(Bytes::from("ERR something")), b"!13\r\nERR something\r\n" as &[u8]),
+        (RespData::VerbatimString { format: *b"txt", data: Bytes::from("hello") }, b"=9\r\ntxt:hello\r\n" as &[u8]),
+        (RespData::BigNumber("12345678901234567890".into()), b"(12345678901234567890\r\n" as &[u8]),
+    ];
+    
+    for (data, expected) in tests {
+        let result = enc.encode_one(&data);
+        assert!(result.is_ok(), "Failed to encode {:?}", data);
+        let bytes = result.unwrap();
+        assert_eq!(bytes.as_ref(), expected, "Wrong encoding for {:?}", data);
+    }
+}
+
+#[test]
+fn resp3_encoder_standard_resp_types() {
+    let mut enc = new_encoder(RespVersion::RESP3);
+    
+    // Test standard RESP types
+    let tests = vec![
+        (RespData::SimpleString("OK".into()), b"+OK\r\n" as &[u8]),
+        (RespData::Error("ERR something".into()), b"-ERR something\r\n" as &[u8]),
+        (RespData::Integer(42), b":42\r\n" as &[u8]),
+        (RespData::BulkString(Some("hello".into())), b"$5\r\nhello\r\n" as &[u8]),
+        (RespData::BulkString(None), b"$-1\r\n" as &[u8]),
+        (RespData::Array(Some(vec![RespData::SimpleString("OK".into())])), b"*1\r\n+OK\r\n" as &[u8]),
+        (RespData::Array(None), b"*-1\r\n" as &[u8]),
+        (RespData::Inline(vec!["PING".into()]), b"PING\r\n" as &[u8]),
+    ];
+    
+    for (data, expected) in tests {
+        let result = enc.encode_one(&data);
+        assert!(result.is_ok(), "Failed to encode {:?}", data);
+        let bytes = result.unwrap();
+        assert_eq!(bytes.as_ref(), expected, "Wrong encoding for {:?}", data);
+    }
+}
+
+#[test]
+fn resp3_encoder_collections() {
+    let mut enc = new_encoder(RespVersion::RESP3);
+    
+    // Test collection types
+    let set_data = RespData::Set(vec![
+        RespData::Boolean(true),
+        RespData::Null,
+        RespData::Double(2.5),
+    ]);
+    let set_result = enc.encode_one(&set_data);
+    assert!(set_result.is_ok());
+    let set_bytes = set_result.unwrap();
+    assert!(set_bytes.starts_with(b"~3\r\n"));
+    
+    let map_data = RespData::Map(vec![
+        (RespData::Boolean(true), RespData::Double(1.0)),
+        (RespData::Null, RespData::BulkError(Bytes::from("ERR x"))),
+    ]);
+    let map_result = enc.encode_one(&map_data);
+    assert!(map_result.is_ok());
+    let map_bytes = map_result.unwrap();
+    assert!(map_bytes.starts_with(b"%2\r\n"));
+    
+    let push_data = RespData::Push(vec![
+        RespData::Boolean(false),
+        RespData::Double(3.14),
+    ]);
+    let push_result = enc.encode_one(&push_data);
+    assert!(push_result.is_ok());
+    let push_bytes = push_result.unwrap();
+    assert!(push_bytes.starts_with(b">2\r\n"));
+}

--- a/src/resp/tests/resp3_encoder_comprehensive.rs
+++ b/src/resp/tests/resp3_encoder_comprehensive.rs
@@ -21,7 +21,7 @@ use resp::{RespData, RespVersion, new_encoder};
 #[test]
 fn resp3_encoder_all_types() {
     let mut enc = new_encoder(RespVersion::RESP3);
-    
+
     // Test all RESP3 types
     let tests = vec![
         (RespData::Null, b"_\r\n" as &[u8]),
@@ -31,11 +31,23 @@ fn resp3_encoder_all_types() {
         (RespData::Double(f64::INFINITY), b",inf\r\n" as &[u8]),
         (RespData::Double(f64::NEG_INFINITY), b",-inf\r\n" as &[u8]),
         (RespData::Double(f64::NAN), b",nan\r\n" as &[u8]),
-        (RespData::BulkError(Bytes::from("ERR something")), b"!13\r\nERR something\r\n" as &[u8]),
-        (RespData::VerbatimString { format: *b"txt", data: Bytes::from("hello") }, b"=9\r\ntxt:hello\r\n" as &[u8]),
-        (RespData::BigNumber("12345678901234567890".into()), b"(12345678901234567890\r\n" as &[u8]),
+        (
+            RespData::BulkError(Bytes::from("ERR something")),
+            b"!13\r\nERR something\r\n" as &[u8],
+        ),
+        (
+            RespData::VerbatimString {
+                format: *b"txt",
+                data: Bytes::from("hello"),
+            },
+            b"=9\r\ntxt:hello\r\n" as &[u8],
+        ),
+        (
+            RespData::BigNumber("12345678901234567890".into()),
+            b"(12345678901234567890\r\n" as &[u8],
+        ),
     ];
-    
+
     for (data, expected) in tests {
         let result = enc.encode_one(&data);
         assert!(result.is_ok(), "Failed to encode {:?}", data);
@@ -47,19 +59,28 @@ fn resp3_encoder_all_types() {
 #[test]
 fn resp3_encoder_standard_resp_types() {
     let mut enc = new_encoder(RespVersion::RESP3);
-    
+
     // Test standard RESP types
     let tests = vec![
         (RespData::SimpleString("OK".into()), b"+OK\r\n" as &[u8]),
-        (RespData::Error("ERR something".into()), b"-ERR something\r\n" as &[u8]),
+        (
+            RespData::Error("ERR something".into()),
+            b"-ERR something\r\n" as &[u8],
+        ),
         (RespData::Integer(42), b":42\r\n" as &[u8]),
-        (RespData::BulkString(Some("hello".into())), b"$5\r\nhello\r\n" as &[u8]),
+        (
+            RespData::BulkString(Some("hello".into())),
+            b"$5\r\nhello\r\n" as &[u8],
+        ),
         (RespData::BulkString(None), b"$-1\r\n" as &[u8]),
-        (RespData::Array(Some(vec![RespData::SimpleString("OK".into())])), b"*1\r\n+OK\r\n" as &[u8]),
+        (
+            RespData::Array(Some(vec![RespData::SimpleString("OK".into())])),
+            b"*1\r\n+OK\r\n" as &[u8],
+        ),
         (RespData::Array(None), b"*-1\r\n" as &[u8]),
         (RespData::Inline(vec!["PING".into()]), b"PING\r\n" as &[u8]),
     ];
-    
+
     for (data, expected) in tests {
         let result = enc.encode_one(&data);
         assert!(result.is_ok(), "Failed to encode {:?}", data);
@@ -71,7 +92,7 @@ fn resp3_encoder_standard_resp_types() {
 #[test]
 fn resp3_encoder_collections() {
     let mut enc = new_encoder(RespVersion::RESP3);
-    
+
     // Test collection types
     let set_data = RespData::Set(vec![
         RespData::Boolean(true),
@@ -82,7 +103,7 @@ fn resp3_encoder_collections() {
     assert!(set_result.is_ok());
     let set_bytes = set_result.unwrap();
     assert!(set_bytes.starts_with(b"~3\r\n"));
-    
+
     let map_data = RespData::Map(vec![
         (RespData::Boolean(true), RespData::Double(1.0)),
         (RespData::Null, RespData::BulkError(Bytes::from("ERR x"))),
@@ -91,11 +112,8 @@ fn resp3_encoder_collections() {
     assert!(map_result.is_ok());
     let map_bytes = map_result.unwrap();
     assert!(map_bytes.starts_with(b"%2\r\n"));
-    
-    let push_data = RespData::Push(vec![
-        RespData::Boolean(false),
-        RespData::Double(3.14),
-    ]);
+
+    let push_data = RespData::Push(vec![RespData::Boolean(false), RespData::Double(3.14)]);
     let push_result = enc.encode_one(&push_data);
     assert!(push_result.is_ok());
     let push_bytes = push_result.unwrap();

--- a/src/resp/tests/resp3_more.rs
+++ b/src/resp/tests/resp3_more.rs
@@ -1,0 +1,47 @@
+use bytes::Bytes;
+use resp::{RespData, RespVersion, decode_many, encode_many, new_decoder, new_encoder};
+
+#[test]
+fn bulk_error_roundtrip() {
+    let mut enc = new_encoder(RespVersion::RESP3);
+    let data = RespData::BulkError(Bytes::from("ERR something"));
+    let bytes = encode_many(&mut *enc, &[data.clone()]).unwrap();
+    let mut dec = new_decoder(RespVersion::RESP3);
+    let out = decode_many(&mut *dec, bytes);
+    match out[0].as_ref().unwrap() {
+        RespData::BulkError(s) => assert_eq!(s.as_ref(), b"ERR something"),
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn verbatim_string_roundtrip() {
+    let mut enc = new_encoder(RespVersion::RESP3);
+    let data = RespData::VerbatimString {
+        format: *b"txt",
+        data: Bytes::from("hello"),
+    };
+    let bytes = encode_many(&mut *enc, &[data]).unwrap();
+    let mut dec = new_decoder(RespVersion::RESP3);
+    let out = decode_many(&mut *dec, bytes);
+    match out[0].as_ref().unwrap() {
+        RespData::VerbatimString { format, data } => {
+            assert_eq!(format, b"txt");
+            assert_eq!(data.as_ref(), b"hello");
+        }
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn bignumber_roundtrip() {
+    let mut enc = new_encoder(RespVersion::RESP3);
+    let data = RespData::BigNumber("12345678901234567890".into());
+    let bytes = encode_many(&mut *enc, &[data.clone()]).unwrap();
+    let mut dec = new_decoder(RespVersion::RESP3);
+    let out = decode_many(&mut *dec, bytes);
+    match out[0].as_ref().unwrap() {
+        RespData::BigNumber(s) => assert_eq!(s, "12345678901234567890"),
+        _ => panic!(),
+    }
+}

--- a/src/resp/tests/resp3_more.rs
+++ b/src/resp/tests/resp3_more.rs
@@ -27,7 +27,7 @@ fn bulk_error_roundtrip() {
     let out = decode_many(&mut *dec, bytes);
     match out[0].as_ref().unwrap() {
         RespData::BulkError(s) => assert_eq!(s.as_ref(), b"ERR something"),
-        _ => panic!(),
+        other => panic!("Expected BulkError, got {:?}", other),
     }
 }
 
@@ -46,7 +46,7 @@ fn verbatim_string_roundtrip() {
             assert_eq!(format, b"txt");
             assert_eq!(data.as_ref(), b"hello");
         }
-        _ => panic!(),
+        other => panic!("Expected VerbatimString, got {:?}", other),
     }
 }
 
@@ -59,6 +59,6 @@ fn bignumber_roundtrip() {
     let out = decode_many(&mut *dec, bytes);
     match out[0].as_ref().unwrap() {
         RespData::BigNumber(s) => assert_eq!(s, "12345678901234567890"),
-        _ => panic!(),
+        other => panic!("Expected BigNumber, got {:?}", other),
     }
 }

--- a/src/resp/tests/resp3_more.rs
+++ b/src/resp/tests/resp3_more.rs
@@ -1,3 +1,20 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use bytes::Bytes;
 use resp::{RespData, RespVersion, decode_many, encode_many, new_decoder, new_encoder};
 

--- a/src/resp/tests/resp3_scaffold.rs
+++ b/src/resp/tests/resp3_scaffold.rs
@@ -1,0 +1,23 @@
+use bytes::Bytes;
+use resp::{RespData, RespVersion, new_decoder};
+
+#[test]
+fn resp3_boolean_and_null() {
+    let mut dec = new_decoder(RespVersion::RESP3);
+    dec.push(Bytes::from("#t\r\n"));
+    dec.push(Bytes::from("_\r\n"));
+    
+    // Verify Boolean(true) parsing
+    let result1 = dec.next().unwrap().unwrap();
+    match result1 {
+        RespData::Boolean(true) => {},
+        _ => panic!("expected Boolean(true), got {:?}", result1),
+    }
+    
+    // Verify Null parsing
+    let result2 = dec.next().unwrap().unwrap();
+    match result2 {
+        RespData::Null => {},
+        _ => panic!("expected Null, got {:?}", result2),
+    }
+}

--- a/src/resp/tests/resp3_scaffold.rs
+++ b/src/resp/tests/resp3_scaffold.rs
@@ -1,3 +1,20 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use bytes::Bytes;
 use resp::{RespData, RespVersion, new_decoder};
 

--- a/src/resp/tests/resp3_scaffold.rs
+++ b/src/resp/tests/resp3_scaffold.rs
@@ -6,18 +6,18 @@ fn resp3_boolean_and_null() {
     let mut dec = new_decoder(RespVersion::RESP3);
     dec.push(Bytes::from("#t\r\n"));
     dec.push(Bytes::from("_\r\n"));
-    
+
     // Verify Boolean(true) parsing
     let result1 = dec.next().unwrap().unwrap();
     match result1 {
-        RespData::Boolean(true) => {},
+        RespData::Boolean(true) => {}
         _ => panic!("expected Boolean(true), got {:?}", result1),
     }
-    
+
     // Verify Null parsing
     let result2 = dec.next().unwrap().unwrap();
     match result2 {
-        RespData::Null => {},
+        RespData::Null => {}
         _ => panic!("expected Null, got {:?}", result2),
     }
 }

--- a/src/resp/tests/resp3_standard_types.rs
+++ b/src/resp/tests/resp3_standard_types.rs
@@ -1,0 +1,131 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use resp::{RespData, RespVersion, decode_many, new_decoder, new_encoder};
+
+#[test]
+fn resp3_decodes_standard_resp_types() {
+    // Test simple string
+    let mut dec1 = new_decoder(RespVersion::RESP3);
+    let out1 = decode_many(&mut *dec1, Bytes::from("+OK\r\n"));
+    assert_eq!(out1.len(), 1);
+    match out1[0].as_ref().unwrap() {
+        RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"OK"),
+        other => panic!("Expected SimpleString, got {:?}", other),
+    }
+
+    // Test integer
+    let mut dec2 = new_decoder(RespVersion::RESP3);
+    let out2 = decode_many(&mut *dec2, Bytes::from(":42\r\n"));
+    assert_eq!(out2.len(), 1);
+    match out2[0].as_ref().unwrap() {
+        RespData::Integer(n) => assert_eq!(*n, 42),
+        other => panic!("Expected Integer, got {:?}", other),
+    }
+
+    // Test bulk string
+    let mut dec3 = new_decoder(RespVersion::RESP3);
+    let out3 = decode_many(&mut *dec3, Bytes::from("$5\r\nhello\r\n"));
+    assert_eq!(out3.len(), 1);
+    match out3[0].as_ref().unwrap() {
+        RespData::BulkString(Some(s)) => assert_eq!(s.as_ref(), b"hello"),
+        other => panic!("Expected BulkString, got {:?}", other),
+    }
+
+    // Test array
+    let mut dec4 = new_decoder(RespVersion::RESP3);
+    let out4 = decode_many(&mut *dec4, Bytes::from("*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"));
+    assert_eq!(out4.len(), 1);
+    match out4[0].as_ref().unwrap() {
+        RespData::Array(Some(items)) => {
+            assert_eq!(items.len(), 2);
+            match &items[0] {
+                RespData::BulkString(Some(s)) => assert_eq!(s.as_ref(), b"foo"),
+                other => panic!("Expected BulkString 'foo', got {:?}", other),
+            }
+            match &items[1] {
+                RespData::BulkString(Some(s)) => assert_eq!(s.as_ref(), b"bar"),
+                other => panic!("Expected BulkString 'bar', got {:?}", other),
+            }
+        }
+        other => panic!("Expected Array, got {:?}", other),
+    }
+}
+
+#[test]
+fn resp3_encodes_standard_resp_types() {
+    let mut enc = new_encoder(RespVersion::RESP3);
+
+    // Test simple string
+    let data1 = RespData::SimpleString("OK".into());
+    let bytes1 = enc.encode_one(&data1).unwrap();
+    assert_eq!(bytes1.as_ref(), b"+OK\r\n");
+
+    // Test integer
+    let data2 = RespData::Integer(42);
+    let bytes2 = enc.encode_one(&data2).unwrap();
+    assert_eq!(bytes2.as_ref(), b":42\r\n");
+
+    // Test bulk string
+    let data3 = RespData::BulkString(Some("hello".into()));
+    let bytes3 = enc.encode_one(&data3).unwrap();
+    assert_eq!(bytes3.as_ref(), b"$5\r\nhello\r\n");
+
+    // Test array
+    let data4 = RespData::Array(Some(vec![
+        RespData::BulkString(Some("foo".into())),
+        RespData::BulkString(Some("bar".into())),
+    ]));
+    let bytes4 = enc.encode_one(&data4).unwrap();
+    assert_eq!(bytes4.as_ref(), b"*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n");
+}
+
+#[test]
+fn resp3_mixed_resp2_and_resp3_types() {
+    let mut dec = new_decoder(RespVersion::RESP3);
+
+    // Mix RESP2 and RESP3 types in one input
+    let input = Bytes::from("+OK\r\n#t\r\n:42\r\n_\r\n");
+    let out = decode_many(&mut *dec, input);
+
+    assert_eq!(out.len(), 4);
+
+    // Simple string
+    match out[0].as_ref().unwrap() {
+        RespData::SimpleString(s) => assert_eq!(s.as_ref(), b"OK"),
+        other => panic!("Expected SimpleString, got {:?}", other),
+    }
+
+    // Boolean
+    match out[1].as_ref().unwrap() {
+        RespData::Boolean(true) => {}
+        other => panic!("Expected Boolean(true), got {:?}", other),
+    }
+
+    // Integer
+    match out[2].as_ref().unwrap() {
+        RespData::Integer(n) => assert_eq!(*n, 42),
+        other => panic!("Expected Integer, got {:?}", other),
+    }
+
+    // Null
+    match out[3].as_ref().unwrap() {
+        RespData::Null => {}
+        other => panic!("Expected Null, got {:?}", other),
+    }
+}

--- a/src/resp/tests/security_limits.rs
+++ b/src/resp/tests/security_limits.rs
@@ -20,88 +20,103 @@ use resp::{RespVersion, new_decoder};
 #[test]
 fn bulk_string_length_limit() {
     let mut decoder = new_decoder(RespVersion::RESP3);
-    
+
     // Test bulk string exceeding 512MB limit
     let oversized_len = 512 * 1024 * 1024 + 1; // 512MB + 1 byte
     let oversized_message = format!("${}\r\n", oversized_len);
-    
+
     decoder.push(oversized_message.into());
     let result = decoder.next();
-    
+
     assert!(result.is_some(), "Should return an error");
-    assert!(result.unwrap().is_err(), "Should return parse error for oversized bulk string");
+    assert!(
+        result.unwrap().is_err(),
+        "Should return parse error for oversized bulk string"
+    );
 }
 
 #[test]
 fn array_length_limit() {
     let mut decoder = new_decoder(RespVersion::RESP3);
-    
+
     // Test array exceeding 1M elements limit
     let oversized_len = 1024 * 1024 + 1; // 1M + 1 elements
     let oversized_message = format!("*{}\r\n", oversized_len);
-    
+
     decoder.push(oversized_message.into());
     let result = decoder.next();
-    
+
     assert!(result.is_some(), "Should return an error");
-    assert!(result.unwrap().is_err(), "Should return parse error for oversized array");
+    assert!(
+        result.unwrap().is_err(),
+        "Should return parse error for oversized array"
+    );
 }
 
 #[test]
 fn map_pairs_limit() {
     let mut decoder = new_decoder(RespVersion::RESP3);
-    
+
     // Test map exceeding 1M pairs limit
     let oversized_pairs = 1024 * 1024 + 1; // 1M + 1 pairs
     let oversized_message = format!("%{}\r\n", oversized_pairs);
-    
+
     decoder.push(oversized_message.into());
     let result = decoder.next();
-    
+
     assert!(result.is_some(), "Should return an error");
-    assert!(result.unwrap().is_err(), "Should return parse error for oversized map");
+    assert!(
+        result.unwrap().is_err(),
+        "Should return parse error for oversized map"
+    );
 }
 
 #[test]
 fn set_length_limit() {
     let mut decoder = new_decoder(RespVersion::RESP3);
-    
+
     // Test set exceeding 1M elements limit
     let oversized_len = 1024 * 1024 + 1; // 1M + 1 elements
     let oversized_message = format!("~{}\r\n", oversized_len);
-    
+
     decoder.push(oversized_message.into());
     let result = decoder.next();
-    
+
     assert!(result.is_some(), "Should return an error");
-    assert!(result.unwrap().is_err(), "Should return parse error for oversized set");
+    assert!(
+        result.unwrap().is_err(),
+        "Should return parse error for oversized set"
+    );
 }
 
 #[test]
 fn push_length_limit() {
     let mut decoder = new_decoder(RespVersion::RESP3);
-    
+
     // Test push exceeding 1M elements limit
     let oversized_len = 1024 * 1024 + 1; // 1M + 1 elements
     let oversized_message = format!(">{}\r\n", oversized_len);
-    
+
     decoder.push(oversized_message.into());
     let result = decoder.next();
-    
+
     assert!(result.is_some(), "Should return an error");
-    assert!(result.unwrap().is_err(), "Should return parse error for oversized push");
+    assert!(
+        result.unwrap().is_err(),
+        "Should return parse error for oversized push"
+    );
 }
 
 #[test]
 fn within_limits_should_work() {
     let mut decoder = new_decoder(RespVersion::RESP3);
-    
+
     // Test that values within limits work correctly
     let normal_message = "*2\r\n+hello\r\n+world\r\n";
-    
+
     decoder.push(normal_message.into());
     let result = decoder.next();
-    
+
     assert!(result.is_some(), "Should parse successfully");
     assert!(result.unwrap().is_ok(), "Should parse without error");
 }

--- a/src/resp/tests/security_limits.rs
+++ b/src/resp/tests/security_limits.rs
@@ -1,0 +1,107 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use resp::{RespVersion, new_decoder};
+
+#[test]
+fn bulk_string_length_limit() {
+    let mut decoder = new_decoder(RespVersion::RESP3);
+    
+    // Test bulk string exceeding 512MB limit
+    let oversized_len = 512 * 1024 * 1024 + 1; // 512MB + 1 byte
+    let oversized_message = format!("${}\r\n", oversized_len);
+    
+    decoder.push(oversized_message.into());
+    let result = decoder.next();
+    
+    assert!(result.is_some(), "Should return an error");
+    assert!(result.unwrap().is_err(), "Should return parse error for oversized bulk string");
+}
+
+#[test]
+fn array_length_limit() {
+    let mut decoder = new_decoder(RespVersion::RESP3);
+    
+    // Test array exceeding 1M elements limit
+    let oversized_len = 1024 * 1024 + 1; // 1M + 1 elements
+    let oversized_message = format!("*{}\r\n", oversized_len);
+    
+    decoder.push(oversized_message.into());
+    let result = decoder.next();
+    
+    assert!(result.is_some(), "Should return an error");
+    assert!(result.unwrap().is_err(), "Should return parse error for oversized array");
+}
+
+#[test]
+fn map_pairs_limit() {
+    let mut decoder = new_decoder(RespVersion::RESP3);
+    
+    // Test map exceeding 1M pairs limit
+    let oversized_pairs = 1024 * 1024 + 1; // 1M + 1 pairs
+    let oversized_message = format!("%{}\r\n", oversized_pairs);
+    
+    decoder.push(oversized_message.into());
+    let result = decoder.next();
+    
+    assert!(result.is_some(), "Should return an error");
+    assert!(result.unwrap().is_err(), "Should return parse error for oversized map");
+}
+
+#[test]
+fn set_length_limit() {
+    let mut decoder = new_decoder(RespVersion::RESP3);
+    
+    // Test set exceeding 1M elements limit
+    let oversized_len = 1024 * 1024 + 1; // 1M + 1 elements
+    let oversized_message = format!("~{}\r\n", oversized_len);
+    
+    decoder.push(oversized_message.into());
+    let result = decoder.next();
+    
+    assert!(result.is_some(), "Should return an error");
+    assert!(result.unwrap().is_err(), "Should return parse error for oversized set");
+}
+
+#[test]
+fn push_length_limit() {
+    let mut decoder = new_decoder(RespVersion::RESP3);
+    
+    // Test push exceeding 1M elements limit
+    let oversized_len = 1024 * 1024 + 1; // 1M + 1 elements
+    let oversized_message = format!(">{}\r\n", oversized_len);
+    
+    decoder.push(oversized_message.into());
+    let result = decoder.next();
+    
+    assert!(result.is_some(), "Should return an error");
+    assert!(result.unwrap().is_err(), "Should return parse error for oversized push");
+}
+
+#[test]
+fn within_limits_should_work() {
+    let mut decoder = new_decoder(RespVersion::RESP3);
+    
+    // Test that values within limits work correctly
+    let normal_message = "*2\r\n+hello\r\n+world\r\n";
+    
+    decoder.push(normal_message.into());
+    let result = decoder.next();
+    
+    assert!(result.is_some(), "Should parse successfully");
+    assert!(result.unwrap().is_ok(), "Should parse without error");
+}


### PR DESCRIPTION
- Add RESP1/RESP2/RESP3 versioned encoders/decoders
- Introduce unified RespData enum covering all RESP types
- Implement factory pattern for version selection
- Add downlevel compatibility policies for RESP3→RESP2/RESP1
- Support all RESP3 types: Null, Boolean, Double, BulkError, VerbatimString, BigNumber, Map, Set, Push
- Add comprehensive test suite (26 tests, 100% core coverage)
- Maintain backward compatibility with existing RESP2 implementation
- Add multi-message encode/decode utilities for pipelining

Architecture:
- Modular design with resp1/, resp2/, resp3/ submodules
- Trait-based Encoder/Decoder interfaces
- Configurable DownlevelPolicy for type conversion
- Zero-copy streaming parsing with Bytes/BytesMut
- Factory functions for version-specific implementations

Tests:
- Factory selection validation
- RESP1 basic functionality
- RESP2 compatibility regression
- RESP3 comprehensive type coverage
- Downlevel policy verification
- All tests passing (26/26)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Full RESP3 support (Null, Boolean, Double, Bulk Error, Verbatim String, BigNumber, Map, Set, Push).
  - Versioned RESP1/RESP2/RESP3 encoders & decoders, configurable downlevel encoding policies, factory constructors, and batch encode/decode helpers.
  - Public streaming Encoder/Decoder interfaces.

- **Bug Fixes**
  - Encoder match made exhaustive with a safe fallback for unhandled variants.

- **Tests**
  - Extensive unit tests for RESP1/RESP2/RESP3, policies, incremental/nested parsing, security limits, and round-trips.

- **Breaking Changes**
  - Some public enums no longer derive Eq (now PartialEq only).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->