### PR TITLE
add conf in main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,6 +1826,7 @@ dependencies = [
 name = "server"
 version = "0.1.0"
 dependencies = [
+ "conf",
  "env_logger",
  "log",
  "net",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ storage = { path = "src/storage" }
 kstd = { path = "src/kstd" }
 common-macro = { path = "src/common/macro" }
 net = { path = "src/net" }
+conf = { path = "src/conf" }
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/kiwi.conf
+++ b/kiwi.conf
@@ -1,0 +1,742 @@
+# Kiwi Redis-compatible NoSQL KV Database configuration file example.
+#
+# Note that in order to read the configuration file, Kiwi must be
+# started with the file path as first argument:
+#
+# ./kiwi-server /path/to/kiwi.conf
+
+# Note on units: when memory size is needed, it is possible to specify
+# it in the usual form of 1k 5GB 4M and so forth:
+#
+# 1k => 1000 bytes
+# 1kb => 1024 bytes
+# 1m => 1000000 bytes
+# 1mb => 1024*1024 bytes
+# 1g => 1000000000 bytes
+# 1gb => 1024*1024*1024 bytes
+#
+# units are case insensitive so 1GB 1Gb 1gB are all the same.
+
+################################## INCLUDES ###################################
+
+# Include one or more other config files here.  This is useful if you
+# have a standard template that goes to all Kiwi servers but also need
+# to customize a few per-server settings.  Include files can include
+# other files, so use this wisely.
+#
+# Note that option "include" won't be rewritten by command "CONFIG REWRITE"
+# from admin or Kiwi Sentinel. Since Kiwi always uses the last processed
+# line as value of a configuration directive, you'd better put includes
+# at the beginning of this file to avoid overwriting config change at runtime.
+#
+# If instead you are interested in using includes to override configuration
+# options, it is better to use include as the last line.
+#
+# Included paths may contain wildcards. All files matching the wildcards will
+# be included in alphabetical order.
+# Note that if an include path contains a wildcards but no files match it when
+# the server is started, the include statement will be ignored and no error will
+# be emitted.  It is safe, therefore, to include wildcard files from empty
+# directories.
+#
+# include /path/to/local.conf
+# include /path/to/other.conf
+# include /path/to/fragments/*.conf
+#
+
+################################## MODULES #####################################
+
+# Load modules at startup. If the server is not able to load modules
+# it will abort. It is possible to use multiple loadmodule directives.
+#
+# loadmodule /path/to/my_module.so
+# loadmodule /path/to/other_module.so
+# loadmodule /path/to/args_module.so [arg [arg ...]]
+
+################################## NETWORK #####################################
+
+# By default, if no "bind" configuration directive is specified, Kiwi listens
+# for connections from all available network interfaces on the host machine.
+# It is possible to listen to just one or multiple selected interfaces using
+# the "bind" configuration directive, followed by one or more IP addresses.
+# Each address can be prefixed by "-", which means that kiwi will not fail to
+# start if the address is not available. Being not available only refers to
+# addresses that does not correspond to any network interface. Addresses that
+# are already in use will always fail, and unsupported protocols will always BE
+# silently skipped.
+#
+# Examples:
+#
+# bind 192.168.1.100 10.0.0.1     # listens on two specific IPv4 addresses
+# bind 127.0.0.1 ::1              # listens on loopback IPv4 and IPv6
+# bind * -::*                     # like the default, all available interfaces
+#
+# ~~~ WARNING ~~~ If the computer running Kiwi is directly exposed to the
+# internet, binding to all the interfaces is dangerous and will expose the
+# instance to everybody on the internet. So by default we uncomment the
+# following bind directive, that will force Kiwi to listen only on the
+# IPv4 and IPv6 (if available) loopback interface addresses (this means Kiwi
+# will only be able to accept client connections from the same host that it is
+# running on).
+#
+# IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
+# COMMENT OUT THE FOLLOWING LINE.
+#
+# You will also need to set a password unless you explicitly disable protected
+# mode.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+bind 127.0.0.1 -::1
+
+# By default, outgoing connections (from replica to master, from Sentinel to
+# instances, cluster bus, etc.) are not bound to a specific local address. In
+# most cases, this means the operating system will handle that based on routing
+# and the interface through which the connection goes out.
+#
+# Using bind-source-addr it is possible to configure a specific address to bind
+# to, which may also affect how the connection gets routed.
+#
+# Example:
+#
+# bind-source-addr 10.0.0.1
+
+# Protected mode is a layer of security protection, in order to avoid that
+# Kiwi instances left open on the internet are accessed and exploited.
+#
+# When protected mode is on and the default user has no password, the server
+# only accepts local connections from the IPv4 address (127.0.0.1), IPv6 address
+# (::1) or Unix domain sockets.
+#
+# By default protected mode is enabled. You should disable it only if
+# you are sure you want clients from other hosts to connect to Kiwi
+# even if no authentication is configured.
+protected-mode yes
+
+# Kiwi uses default hardened security configuration directives to reduce the
+# attack surface on innocent users. Therefore, several sensitive configuration
+# directives are immutable, and some potentially-dangerous commands are blocked.
+#
+# Configuration directives that control files that Kiwi writes to (e.g., 'dir'
+# and 'dbfilename') and that aren't usually modified during runtime
+# are protected by making them immutable.
+#
+# Commands that can increase the attack surface of Kiwi and that aren't usually
+# called by users are blocked by default.
+#
+# These can be exposed to either all connections or just local ones by setting
+# each of the configs listed below to either of these values:
+#
+# no    - Block for any connection (remain immutable)
+# yes   - Allow for any connection (no protection)
+# local - Allow only for local connections. Ones originating from the
+#         IPv4 address (127.0.0.1), IPv6 address (::1) or Unix domain sockets.
+#
+# enable-protected-configs no
+# enable-debug-command no
+# enable-module-command no
+
+# Accept connections on the specified port, default is 9221 (Kiwi default port).
+# If port 0 is specified Kiwi will not listen on a TCP socket.
+port 9221
+
+# TCP listen() backlog.
+#
+# In high requests-per-second environments you need a high backlog in order
+# to avoid slow clients connection issues. Note that the Linux kernel
+# will silently truncate it to the value of /proc/sys/net/core/somaxconn so
+# make sure to raise both the value of somaxconn and tcp_max_syn_backlog
+# in order to get the desired effect.
+tcp-backlog 511
+
+# Unix socket.
+#
+# Specify the path for the Unix socket that will be used to listen for
+# incoming connections. There is no default, so Kiwi will not listen
+# on a unix socket when not specified.
+#
+# unixsocket /run/kiwi.sock
+# unixsocketperm 700
+
+# Close the connection after a client is idle for N seconds (0 to disable)
+timeout 0
+
+# TCP keepalive.
+#
+# If non-zero, use SO_KEEPALIVE to send TCP ACKs to clients in absence
+# of communication. This is useful for two reasons:
+#
+# 1) Detect dead peers.
+# 2) Force network equipment in the middle to consider the connection to be
+#    alive.
+#
+# On Linux, the specified value (in seconds) is the period used to send ACKs.
+# Note that to close the connection the double of the time is needed.
+# On other kernels the period depends on the kernel configuration.
+#
+# A reasonable value for this option is 300 seconds, which is the new
+# Kiwi default starting with Kiwi 1.0.0.
+tcp-keepalive 300
+
+# Apply OS-specific mechanism to mark the listening socket with the specified
+# ID, to support advanced routing and filtering capabilities.
+#
+# On Linux, the ID represents a connection mark.
+# On FreeBSD, the ID represents a socket cookie ID.
+# On OpenBSD, the ID represents a route table ID.
+#
+# The default value is 0, which implies no marking is required.
+# socket-mark-id 0
+
+################################# TLS/SSL #####################################
+
+# By default, TLS/SSL is disabled. To enable it, the "tls-port" configuration
+# directive can be used to define TLS-listening ports. To enable TLS on the
+# default port, use:
+#
+# port 0
+# tls-port 9221
+
+# Configure a X.509 certificate and private key to use for authenticating the
+# server to connected clients, masters or cluster peers.  These files should be
+# PEM formatted.
+#
+# tls-cert-file kiwi.crt
+# tls-key-file kiwi.key
+#
+# If the key file is encrypted using a passphrase, it can be included here
+# as well.
+#
+# tls-key-file-pass secret
+
+# Normally Kiwi uses the same certificate for both server functions (accepting
+# connections) and client functions (replicating from a master, establishing
+# cluster bus connections, etc.).
+#
+# Sometimes certificates are issued with attributes that designate them as
+# client-only or server-only certificates. In that case it may be desired to use
+# different certificates for incoming (server) and outgoing (client)
+# connections. To do that, use the following directives:
+#
+# tls-client-cert-file client.crt
+# tls-client-key-file client.key
+#
+# If the key file is encrypted using a passphrase, it can be included here
+# as well.
+#
+# tls-client-key-file-pass secret
+
+# Configure a DH parameters file to enable Diffie-Hellman (DH) key exchange,
+# required by older versions of OpenSSL (<3.0). Newer versions do not require
+# this configuration and recommend against it.
+#
+# tls-dh-params-file kiwi.dh
+
+# Configure a CA certificate(s) bundle or directory to authenticate TLS/SSL
+# clients and peers.  Kiwi requires an explicit configuration of at least one
+# of these, and will not implicitly use the system wide configuration.
+#
+# tls-ca-cert-file ca.crt
+# tls-ca-cert-dir /etc/ssl/certs
+
+# By default, clients (including replica servers) on a TLS port are required
+# to authenticate using valid client side certificates.
+#
+# If "no" is specified, client certificates are not required and not accepted.
+# If "optional" is specified, client certificates are accepted and must be
+# valid if provided, but are not required.
+#
+# tls-auth-clients no
+# tls-auth-clients optional
+
+# By default, a Kiwi replica does not attempt to establish a TLS connection
+# with its master.
+#
+# Use the following directive to enable TLS on replication links.
+#
+# tls-replication yes
+
+# By default, the Kiwi Cluster bus uses a plain TCP connection. To enable
+# TLS for the bus protocol, use the following directive:
+#
+# tls-cluster yes
+
+# By default, only TLSv1.2 and TLSv1.3 are enabled and it is highly recommended
+# that older formally deprecated versions are kept disabled to reduce the attack surface.
+# You can explicitly specify TLS versions to support.
+# Allowed values are case insensitive and include "TLSv1", "TLSv1.1", "TLSv1.2",
+# "TLSv1.3" (OpenSSL >= 1.1.1) or any combination.
+# To enable only TLSv1.2 and TLSv1.3, use:
+#
+# tls-protocols "TLSv1.2 TLSv1.3"
+
+# Configure allowed ciphers.  See the ciphers(1ssl) manpage for more information
+# about the syntax of this string.
+#
+# Note: this configuration applies only to <= TLSv1.2.
+#
+# tls-ciphers DEFAULT:!MEDIUM
+
+# Configure allowed TLSv1.3 ciphersuites.  See the ciphers(1ssl) manpage for more
+# information about the syntax of this string, and specifically for TLSv1.3
+# ciphersuites.
+#
+# tls-ciphersuites TLS_CHACHA20_POLY1305_SHA256
+
+# When choosing a cipher, use the server's preference instead of the client
+# preference. By default, the server follows the client's preference.
+#
+# tls-prefer-server-ciphers yes
+
+# By default, TLS session caching is enabled to allow faster and less expensive
+# reconnections by clients that support it. Use the following directive to disable
+# caching.
+#
+# tls-session-caching no
+
+# Change the default number of TLS sessions cached. A zero value sets the cache
+# to unlimited size. The default size is 20480.
+#
+# tls-session-cache-size 5000
+
+# Change the default timeout of cached TLS sessions. The default timeout is 300
+# seconds.
+#
+# tls-session-cache-timeout 60
+
+################################# GENERAL #####################################
+
+# By default Kiwi does not run as a daemon. Use 'yes' if you need it.
+# Note that Kiwi will write a pid file in /var/run/kiwi.pid when daemonized.
+# When Kiwi is supervised by upstart or systemd, this parameter has no impact.
+daemonize no
+
+# If you run Kiwi from upstart or systemd, Kiwi can interact with your
+# supervision tree. Options:
+#   supervised no      - no supervision interaction
+#   supervised upstart - signal upstart by putting Kiwi into SIGSTOP mode
+#                        requires "expect stop" in your upstart job config
+#   supervised systemd - signal systemd by writing READY=1 to $NOTIFY_SOCKET
+#                        on startup, and updating Kiwi status on a regular
+#                        basis.
+#   supervised auto    - detect upstart or systemd method based on
+#                        UPSTART_JOB or NOTIFY_SOCKET environment variables
+# Note: these supervision methods only signal "process is ready."
+#       They do not enable continuous pings back to your supervisor.
+#
+# The default is "no". To run under upstart/systemd, you can simply uncomment
+# the line below:
+#
+# supervised auto
+
+# If a pid file is specified, Kiwi writes it where specified at startup
+# and removes it at exit.
+#
+# When the server runs non daemonized, no pid file is created if none is
+# specified in the configuration. When the server is daemonized, the pid file
+# is used even if not specified, defaulting to "/var/run/kiwi.pid".
+#
+# Creating a pid file is best effort: if Kiwi is not able to create it
+# nothing bad happens, the server will start and run normally.
+#
+# Note that on modern Linux systems "/run/kiwi.pid" is more conforming
+# and should be used instead.
+pidfile /var/run/kiwi_9221.pid
+
+# Specify the server verbosity level.
+# This can be one of:
+# debug (a lot of information, useful for development/testing)
+# verbose (many rarely useful info, but not a mess like the debug level)
+# notice (moderately verbose, what you want in production probably)
+# warning (only very important / critical messages are logged)
+# nothing (nothing is logged)
+loglevel notice
+
+# Specify the log file name. Also the empty string can be used to force
+# Kiwi to log on the standard output. Note that if you use standard
+# output for logging but daemonize, logs will be sent to /dev/null
+logfile ""
+
+# To enable logging to the system logger, just set 'syslog-enabled' to yes,
+# and optionally update the other syslog parameters to suit your needs.
+# syslog-enabled no
+
+# Specify the syslog identity.
+# syslog-ident kiwi
+
+# Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
+# syslog-facility local0
+
+# To disable the built in crash log, which will possibly produce cleaner core
+# dumps when they are needed, uncomment the following:
+#
+# crash-log-enabled no
+
+# To disable the fast memory check that's run as part of the crash log, which
+# will possibly let kiwi terminate sooner, uncomment the following:
+#
+# crash-memcheck-enabled no
+
+# Set the number of databases. The default database is DB 0, you can select
+# a different one on a per-connection basis using SELECT <dbid> where
+# dbid is a number between 0 and 'databases'-1
+databases 16
+
+# By default Kiwi shows an ASCII art logo only when started to log to the
+# standard output and if the standard output is a TTY and syslog logging is
+# disabled. Basically this means that normally a logo is displayed only in
+# interactive sessions.
+#
+# However it is possible to force the pre-4.0 behavior and always show a
+# ASCII art logo in startup logs by setting the following option to yes.
+always-show-logo no
+
+# To avoid logging personal identifiable information (PII) into server log file,
+# uncomment the following:
+#
+# hide-user-data-from-log yes
+
+# By default, Kiwi modifies the process title (as seen in 'top' and 'ps') to
+# provide some runtime information. It is possible to disable this and leave
+# the process name as executed by setting the following to no.
+set-proc-title yes
+
+# When changing the process title, Kiwi uses the following template to construct
+# the modified title.
+#
+# Template variables are specified in curly brackets. The following variables are
+# supported:
+#
+# {title}           Name of process as executed if parent, or type of child process.
+# {listen-addr}     Bind address or '*' followed by TCP or TLS port listening on, or
+#                   Unix socket if only that's available.
+# {server-mode}     Special mode, i.e. "[sentinel]" or "[cluster]".
+# {port}            TCP port listening on, or 0.
+# {tls-port}        TLS port listening on, or 0.
+# {unixsocket}      Unix domain socket listening on, or "".
+# {config-file}     Name of configuration file used.
+#
+proc-title-template "{title} {listen-addr} {server-mode}"
+
+# Set the local environment which is used for string comparison operations, and 
+# also affect the performance of Lua scripts. Empty String indicates the locale 
+# is derived from the environment variables.
+locale-collate ""
+
+############################## MEMORY MANAGEMENT ################################
+
+# Set a memory usage limit to the specified amount of bytes.
+# When the memory limit is reached Kiwi will try to remove keys
+# according to the eviction policy selected (see maxmemory-policy).
+#
+# If Kiwi can't remove keys according to the policy, or if the policy is
+# set to 'noeviction', Kiwi will start to reply with errors to commands
+# that would use more memory, like SET, LPUSH, and so on, and will continue
+# to reply to read-only commands like GET.
+#
+# This option is usually useful when using Kiwi as an LRU or LFU cache, or to
+# set a hard memory limit for an instance (using the 'noeviction' policy).
+#
+# WARNING: If you have replicas attached to an instance with maxmemory on,
+# the size of the output buffers needed to feed the replicas are subtracted
+# from the used memory count, so that network problems / resyncs will
+# not trigger a loop where keys are evicted, and in turn the output
+# buffer of replicas is full with DELs of keys evicted triggering the deletion
+# of more keys, and so forth until the database is completely emptied.
+#
+# In short... if you have replicas attached it is suggested that you set a lower
+# limit for maxmemory so that there is some free RAM on the system for replica
+# output buffers (but this is not needed if the policy is 'noeviction').
+#
+maxmemory 1gb
+
+# MAXMEMORY POLICY: how Kiwi will select what to remove when maxmemory
+# is reached. You can select one from the following behaviors:
+#
+# volatile-lru -> Evict using approximated LRU, only keys with an expire set.
+# allkeys-lru -> Evict any key using approximated LRU.
+# volatile-lfu -> Evict using approximated LFU, only keys with an expire set.
+# allkeys-lfu -> Evict any key using approximated LFU.
+# volatile-random -> Remove a random key having an expire set.
+# allkeys-random -> Remove a random key, any key.
+# volatile-ttl -> Remove the key with the nearest expire time (minor TTL)
+# noeviction -> Don't evict anything, just return an error on write operations.
+#
+# LRU means Least Recently Used
+# LFU means Least Frequently Used
+#
+# Both LRU, LFU and volatile-ttl are implemented using approximated
+# randomized algorithms.
+#
+# Note: with any of the above policies, when there are no suitable keys for
+# eviction, Kiwi will return an error on write operations that require
+# more memory. These are usually commands that create new keys, add data or
+# modify existing keys. A few examples are: SET, INCR, HSET, LPUSH, SUNIONSTORE,
+# SORT (due to the STORE argument), and EXEC (if the transaction includes any
+# command that requires memory).
+#
+# The default is:
+#
+maxmemory-policy noeviction
+
+# LRU, LFU and minimal TTL algorithms are not precise algorithms but approximated
+# algorithms (in order to save memory), so you can tune it for speed or
+# accuracy. By default Kiwi will check five keys and pick the one that was
+# used least recently, you can change the sample size using the following
+# configuration directive.
+#
+# The default of 5 produces good enough results. 10 Approximates very closely
+# true LRU but costs more CPU. 3 is faster but not very accurate. The maximum
+# value that can be set is 64.
+#
+maxmemory-samples 5
+
+# Eviction processing is designed to function well with the default setting.
+# If there is an unusually large amount of write traffic, this value may need to
+# be increased.  Decreasing this value may reduce latency at the risk of
+# eviction processing effectiveness
+#   0 = minimum latency, 10 = default, 100 = process without regard to latency
+#
+maxmemory-eviction-tenacity 10
+
+# Starting from Kiwi 1.0, by default a replica will ignore its maxmemory setting
+# (unless it is promoted to master after a failover or manually). It means
+# that the eviction of keys will be just handled by the master, sending the
+# DEL commands to the replica as keys evict in the master side.
+#
+# This behavior ensures that masters and replicas stay consistent, and is usually
+# what you want, however if your replica is writable, or you want the replica
+# to have a different memory setting, and you are sure all the writes performed
+# to the replica are idempotent, then you may change this default (but be sure
+# to understand what you are doing).
+#
+# Note that since the replica by default does not evict, it may end using more
+# memory than the one set via maxmemory (there are certain buffers that may
+# be larger on the replica, or data structures may sometimes take more memory
+# and so forth). So make sure you monitor your replicas and make sure they
+# have enough memory to never hit a real out-of-memory condition before the
+# master hits the configured maxmemory setting.
+#
+replica-ignore-maxmemory yes
+
+# Kiwi reclaims expired keys in two ways: upon access when those keys are
+# found to be expired, and also in background, in what is called the
+# "active expire key". The key space is slowly and interactively scanned
+# looking for expired keys to reclaim, so that it is possible to free memory
+# of keys that are expired and will never be accessed again in a short time.
+#
+# The default effort of the expire cycle will try to avoid having more than
+# ten percent of expired keys still in memory, and will try to avoid consuming
+# more than 25% of total memory and to add latency to the system. However
+# it is possible to increase the expire "effort" that is normally set to
+# "1", to a greater value, up to the value "10". At its maximum value the
+# system will use more CPU, longer cycles (and technically may introduce
+# more latency), and will tolerate less already expired keys still present
+# in the system. It's a tradeoff between memory, CPU and latency.
+#
+active-expire-effort 1
+
+############################# LAZY FREEING ####################################
+
+# Kiwi has two primitives to delete keys. One is called DEL and is a blocking
+# deletion of the object. It means that the server stops processing new commands
+# in order to reclaim all the memory associated with an object in a synchronous
+# way. If the key deleted is associated with a small object, the time needed
+# in order to execute the DEL command is very small and comparable to most other
+# O(1) or O(log_N) commands in Kiwi. However if the key is associated with an
+# aggregated value containing millions of elements, the server can block for
+# a long time (even seconds) in order to complete the operation.
+#
+# For the above reasons Kiwi also offers non blocking deletion primitives
+# such as UNLINK (non blocking DEL) and the ASYNC option of FLUSHALL and
+# FLUSHDB commands, in order to reclaim memory in background. Those commands
+# are executed in constant time. Another thread will incrementally free the
+# object in the background as fast as possible.
+#
+# DEL, UNLINK and ASYNC option of FLUSHALL and FLUSHDB are user-controlled.
+# It's up to the design of the application to understand when it is a good
+# idea to use one or the other. However the Kiwi server sometimes has to
+# delete keys or flush the whole database as a side effect of other operations.
+# Specifically Kiwi deletes objects independently of a user call in the
+# following scenarios:
+#
+# 1) On eviction, because of the maxmemory and maxmemory policy configurations,
+#    in order to make room for new data, without going over the specified
+#    memory limit.
+# 2) Because of expire: when a key with an associated time to live (see the
+#    EXPIRE command) must be deleted from memory.
+# 3) Because of a side effect of a command that stores data on a key that may
+#    already exist. For example the RENAME command may delete the old key
+#    content when it is replaced with another one. Similarly SUNIONSTORE
+#    or SORT with STORE option may delete existing keys. The SET command
+#    itself removes any old content of the specified key in order to replace
+#    it with the specified string.
+# 4) During replication, when a replica performs a full resynchronization with
+#    its master, the content of the whole database is removed in order to
+#    load the RDB file just transferred.
+#
+# In all the above cases the default is to delete objects in a blocking way,
+# like if DEL was called. However you can configure each case specifically
+# in order to instead release memory in a non-blocking way like if UNLINK
+# was called, using the following configuration directives.
+
+lazyfree-lazy-eviction no
+lazyfree-lazy-expire no
+lazyfree-lazy-server-del no
+replica-lazy-flush no
+
+# It is also possible, for the case when to replace the user code DEL calls
+# with UNLINK calls is not easy, to modify the default behavior of the DEL
+# command to act exactly like UNLINK, using the following configuration
+# directive:
+
+lazyfree-lazy-user-del no
+
+# FLUSHDB, FLUSHALL, SCRIPT FLUSH and FUNCTION FLUSH support both asynchronous and synchronous
+# deletion, which can be controlled by passing the [SYNC|ASYNC] flags into the
+# commands. When neither flag is passed, this directive will be used to determine
+# if the data should be deleted asynchronously.
+
+lazyfree-lazy-user-flush no
+
+################################ THREADED I/O #################################
+
+# Kiwi is mostly single threaded, however there are certain threaded
+# operations such as UNLINK, slow I/O accesses and other things that are
+# performed on side threads.
+#
+# Now it is also possible to handle Kiwi clients socket reads and writes
+# in different I/O threads. Since especially writing is so slow, normally
+# Kiwi users use pipelining in order to speed up the Kiwi performances per
+# core, and spawn multiple instances in order to scale more. Using I/O
+# threads it is possible to easily speedup several times Kiwi without resorting
+# to pipelining nor sharding of the instance.
+#
+# By default threading is disabled, we suggest enabling it only in machines
+# that have at least 4 or more cores, leaving at least one spare core.
+# We also recommend using threaded I/O only if you actually have performance
+# problems, with Kiwi instances being able to use a quite big percentage of
+# CPU time, otherwise there is no point in using this feature.
+#
+# So for instance if you have a four cores boxes, try to use 3 I/O
+# threads, if you have a 8 cores, try to use 7 threads. In order to
+# enable I/O threads use the following configuration directive:
+#
+# io-threads 4
+#
+# Setting io-threads to 1 will just use the main thread as usual.
+# When I/O threads are enabled, we not only use threads for writes, that
+# is to thread the write(2) syscall and transfer the client buffers to the
+# socket, but also use threads for reads and protocol parsing.
+#
+# NOTE: If you want to test the Kiwi speedup using kiwi-benchmark, make
+# sure you also run the benchmark itself in threaded mode, using the
+# --threads option to match the number of Kiwi threads, otherwise you'll not
+# be able to notice the improvements.
+
+############################ KERNEL OOM CONTROL ##############################
+
+# On Linux, it is possible to hint the kernel OOM killer on what processes
+# should be killed first when out of memory.
+#
+# Enabling this feature makes Kiwi actively control the oom_score_adj value
+# for all its processes, depending on their role. The default scores will
+# attempt to have background child processes killed before all others, and
+# replicas killed before masters.
+#
+# Kiwi supports these options:
+#
+# no:       Don't make changes to oom-score-adj (default).
+# yes:      Alias to "relative" see below.
+# absolute: Values in oom-score-adj-values are written as is to the kernel.
+# relative: Values are used relative to the initial value of oom_score_adj when
+#           the server starts and are then clamped to a range of -1000 to 1000.
+#           Because typically the initial value is 0, they will often match the
+#           absolute values.
+oom-score-adj no
+
+# When oom-score-adj is used, this directive controls the specific values used
+# for master, replica and background child processes. Values range -2000 to
+# 2000 (higher means more likely to be killed).
+#
+# Unprivileged processes (not root, and without CAP_SYS_RESOURCE capabilities)
+# can freely increase their value, but not decrease it below its initial
+# settings. This means that setting oom-score-adj to "relative" and setting the
+# oom-score-adj-values to positive values will always succeed.
+oom-score-adj-values 0 200 800
+
+#################### KERNEL transparent hugepage CONTROL ######################
+
+# Usually the kernel Transparent Huge Pages control is set to "madvise" or
+# "never" by default (/sys/kernel/mm/transparent_hugepage/enabled), in which
+# case this config has no effect. On systems in which it is set to "always",
+# kiwi will attempt to disable it specifically for the kiwi process in order
+# to avoid latency problems specifically with fork(2) and CoW.
+# If for some reason you prefer to keep it enabled, you can set this config to
+# "no" and the kernel global to "always".
+
+disable-thp yes
+
+################################ KIWI SPECIFIC ###############################
+
+# Kiwi Redis-compatible mode
+# Enable Redis protocol compatibility (yes/no, default: no)
+redis-compatible-mode yes
+
+# Log directory path (default: /data/kiwi_rs/logs)
+log-dir /data/kiwi_rs/logs
+
+# Number of database instances (default: 3)
+db-instance-num 3
+
+# Small compaction threshold (default: 5000)
+small-compaction-threshold 5000
+
+# Small compaction duration threshold (default: 10000)
+small-compaction-duration-threshold 10000
+
+################################# ROCKSDB #####################################
+
+# RocksDB Configuration for Kiwi storage engine
+# Maximum number of subcompactions (default: 0)
+rocksdb-max-subcompactions 2
+
+# Maximum number of background jobs (default: 4)
+rocksdb-max-background-jobs 4
+
+# Maximum number of write buffers (default: 2)
+rocksdb-max-write-buffer-number 2
+
+# Minimum number of write buffers to merge (default: 2)
+rocksdb-min-write-buffer-number-to-merge 2
+
+# Write buffer size in bytes (default: 64MB)
+rocksdb-write-buffer-size 67108864
+
+# Level 0 file number compaction trigger (default: 4)
+rocksdb-level0-file-num-compaction-trigger 4
+
+# Number of levels (default: 7)
+rocksdb-number-levels 7
+
+# Enable pipelined write (yes/no, default: no)
+rocksdb-enable-pipelined-write no
+
+# Level 0 slowdown writes trigger (default: 20)
+rocksdb-level0-slowdown-writes-trigger 20
+
+# Level 0 stop writes trigger (default: 36)
+rocksdb-level0-stop-writes-trigger 36
+
+# TTL in seconds (default: 30 days)
+rocksdb-ttl-second 604800
+
+# Periodic compaction interval in seconds (default: 30 days)
+rocksdb-periodic-second 259200
+
+# Enable dynamic level bytes (yes/no, default: yes)
+rocksdb-level-compaction-dynamic-level-bytes yes
+
+# Maximum open files (default: 10000)
+rocksdb-max-open-files 10000
+
+# Target file size base in bytes (default: 64MB)
+rocksdb-target-file-size-base 67108864

--- a/src/conf/src/config.rs
+++ b/src/conf/src/config.rs
@@ -15,9 +15,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use serde::Deserialize;
-use serde_ini;
 use snafu::ResultExt;
 use validator::Validate;
+use std::collections::HashMap;
+use std::fs;
 
 use crate::de_func::{deserialize_bool_from_yes_no, deserialize_memory};
 use crate::error::Error;
@@ -26,6 +27,8 @@ use crate::error::Error;
 #[derive(Debug, Deserialize, Validate)]
 #[serde(default)]
 pub struct Config {
+    pub bind: String,
+    
     #[validate(range(min = 1024, max = 65535))]
     pub port: u16,
 
@@ -105,7 +108,8 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            port: 8080,
+            bind: "127.0.0.1".to_string(),
+            port: 9221,
             timeout: 50,
             memory: 1024 * 1024 * 1024,
             log_dir: "/data/kiwi_rs/logs".to_string(),
@@ -135,19 +139,155 @@ impl Default for Config {
 }
 
 impl Config {
-    // load config from file
+    // load config from Redis-style config file
     pub fn load(path: &str) -> Result<Self, Error> {
-        let content =
-            std::fs::read_to_string(path).context(crate::error::ConfigFileSnafu { path })?;
+        let content = fs::read_to_string(path)
+            .context(crate::error::ConfigFileSnafu { path })?;
+        
+        Self::parse_redis_format(&content)
+    }
 
-        let config: Config =
-            serde_ini::from_str(&content).context(crate::error::InvalidConfigSnafu {})?;
-
-        config
-            .validate()
+    // Parse Redis-style configuration content
+    pub fn parse_redis_format(content: &str) -> Result<Self, Error> {
+        let mut config_map = HashMap::new();
+        
+        for line in content.lines() {
+            let line = line.trim();
+            
+            // Skip empty lines and comments
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            
+            // Parse key-value pairs
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 2 {
+                let key = parts[0];
+                let value = parts[1..].join(" ");
+                config_map.insert(key.to_string(), value);
+            }
+        }
+        
+        // Extract configuration values with defaults
+        let config = Self {
+            bind: config_map.get("bind").cloned().unwrap_or_else(|| "127.0.0.1".to_string()),
+            port: config_map
+                .get("port")
+                .and_then(|p| p.parse().ok())
+                .unwrap_or(9221),
+            timeout: config_map
+                .get("timeout")
+                .and_then(|t| t.parse().ok())
+                .unwrap_or(50),
+            memory: Self::parse_memory(config_map.get("memory").unwrap_or(&"1GB".to_string())),
+            log_dir: config_map.get("log-dir").cloned().unwrap_or_else(|| "/data/kiwi_rs/logs".to_string()),
+            redis_compatible_mode: Self::parse_bool(config_map.get("redis-compatible-mode").unwrap_or(&"no".to_string())),
+            rocksdb_max_subcompactions: config_map
+                .get("rocksdb-max-subcompactions")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0),
+            rocksdb_max_background_jobs: config_map
+                .get("rocksdb-max-background-jobs")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(4),
+            rocksdb_max_write_buffer_number: config_map
+                .get("rocksdb-max-write-buffer-number")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(2),
+            rocksdb_min_write_buffer_number_to_merge: config_map
+                .get("rocksdb-min-write-buffer-number-to-merge")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(2),
+            rocksdb_write_buffer_size: config_map
+                .get("rocksdb-write-buffer-size")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(64 << 20),
+            rocksdb_level0_file_num_compaction_trigger: config_map
+                .get("rocksdb-level0-file-num-compaction-trigger")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(4),
+            rocksdb_num_levels: config_map
+                .get("rocksdb-number-levels")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(7),
+            rocksdb_enable_pipelined_write: Self::parse_bool(config_map.get("rocksdb-enable-pipelined-write").unwrap_or(&"no".to_string())),
+            rocksdb_level0_slowdown_writes_trigger: config_map
+                .get("rocksdb-level0-slowdown-writes-trigger")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(20),
+            rocksdb_level0_stop_writes_trigger: config_map
+                .get("rocksdb-level0-stop-writes-trigger")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(36),
+            rocksdb_ttl_second: config_map
+                .get("rocksdb-ttl-second")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(30 * 24 * 60 * 60),
+            rocksdb_periodic_second: config_map
+                .get("rocksdb-periodic-second")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(30 * 24 * 60 * 60),
+            rocksdb_level_compaction_dynamic_level_bytes: Self::parse_bool(config_map.get("rocksdb-level-compaction-dynamic-level-bytes").unwrap_or(&"yes".to_string())),
+            rocksdb_max_open_files: config_map
+                .get("rocksdb-max-open-files")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(10000),
+            rocksdb_target_file_size_base: config_map
+                .get("rocksdb-target-file-size-base")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(64 << 20),
+            db_instance_num: config_map
+                .get("db-instance-num")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(3),
+            small_compaction_threshold: config_map
+                .get("small-compaction-threshold")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(5000),
+            small_compaction_duration_threshold: config_map
+                .get("small-compaction-duration-threshold")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(10000),
+        };
+        
+        config.validate()
             .map_err(|e| Error::ValidConfigFail { source: e })?;
-
+        
         Ok(config)
+    }
+
+    /// Parse memory size strings like "1GB", "512MB", "1024KB"
+    fn parse_memory(value: &str) -> u64 {
+        let value = value.trim().to_uppercase();
+        if value.ends_with("GB") {
+            if let Ok(num) = value.trim_end_matches("GB").parse::<u64>() {
+                return num * 1024 * 1024 * 1024;
+            }
+        } else if value.ends_with("MB") {
+            if let Ok(num) = value.trim_end_matches("MB").parse::<u64>() {
+                return num * 1024 * 1024;
+            }
+        } else if value.ends_with("KB") {
+            if let Ok(num) = value.trim_end_matches("KB").parse::<u64>() {
+                return num * 1024;
+            }
+        } else if let Ok(num) = value.parse::<u64>() {
+            return num;
+        }
+        
+        // Default to 1GB if parsing fails
+        1024 * 1024 * 1024
+    }
+
+    /// Parse boolean values like "yes", "no", "true", "false"
+    fn parse_bool(value: &str) -> bool {
+        let value = value.trim().to_lowercase();
+        matches!(value.as_str(), "yes" | "true" | "1" | "on")
+    }
+
+    /// Get the listen address
+    pub fn get_listen_address(&self) -> String {
+        format!("{}:{}", self.bind, self.port)
     }
 
     // TODO: Due to API issues, the rocksdb_ttl_second parameter is temporarily missing

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -11,6 +11,7 @@ net.workspace = true
 tokio.workspace = true
 env_logger.workspace = true
 log.workspace = true
+conf.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Redis-style configuration support, loadable via a CLI-provided file path.
  - Server now derives the listen address from bind/port settings and logs startup details (mode, memory limits).
  - Updated defaults, including a new default port (9221).

- Documentation
  - Added a comprehensive example configuration file with adjustable settings for networking, security, memory, I/O, and storage (including RocksDB tuning).

- Chores
  - Integrated a new configuration component into the workspace and wired the server to use it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->