### PR TITLE
fix(cmd): add argvs check

### DIFF
--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -101,6 +101,16 @@ pub trait Cmd: Send + Sync {
 
     fn execute(&self, client: &Client, storage: Arc<Storage>) {
         debug!("execute command: {:?}", client.cmd_name());
+        if !self.check_arg(client.argv().len()) {
+            client.set_reply(RespData::Error(
+                format!(
+                    "ERR wrong number of arguments for '{}' command",
+                    String::from_utf8_lossy(client.cmd_name().as_slice()),
+                )
+                .into(),
+            ));
+            return;
+        }
         if self.do_initial(client) {
             self.do_cmd(client, storage);
         }


### PR DESCRIPTION
https://github.com/arana-db/kiwi/issues/151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced argument validation for commands. The system now validates the number of arguments before executing any command. If the argument count is incorrect, a clear error message is displayed indicating proper usage. This prevents execution of malformed commands and improves overall system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->