### PR TITLE
feat: add string strlen command

### DIFF
--- a/src/cmd/src/append.rs
+++ b/src/cmd/src/append.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use client::Client;
+use resp::RespData;
+use storage::storage::Storage;
+
+use crate::{AclCategory, Cmd, CmdFlags, CmdMeta};
+use crate::{impl_cmd_clone_box, impl_cmd_meta};
+
+#[derive(Clone, Default)]
+pub struct AppendCmd {
+    meta: CmdMeta,
+}
+
+impl AppendCmd {
+    pub fn new() -> Self {
+        Self {
+            meta: CmdMeta {
+                name: "append".to_string(),
+                arity: 3, // APPEND key value
+                flags: CmdFlags::WRITE,
+                acl_category: AclCategory::STRING | AclCategory::WRITE,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl Cmd for AppendCmd {
+    impl_cmd_meta!();
+    impl_cmd_clone_box!();
+
+    /// APPEND key value
+    fn do_initial(&self, client: &Client) -> bool {
+        let argv = client.argv();
+        let key = argv[1].clone();
+        client.set_key(&key);
+        true
+    }
+
+    fn do_cmd(&self, client: &Client, storage: Arc<Storage>) {
+        let key = client.key();
+        let value = &client.argv()[2];
+
+        let result = storage.append(&key, value);
+
+        match result {
+            Ok(new_len) => {
+                client.set_reply(RespData::Integer(new_len as i64));
+            }
+            Err(e) => match e {
+                storage::error::Error::RedisErr { ref message, .. }
+                    if message.starts_with("WRONGTYPE") =>
+                {
+                    // RedisErr already contains the formatted message
+                    client.set_reply(RespData::Error(message.clone().into()));
+                }
+                _ => {
+                    client.set_reply(RespData::Error(format!("ERR {e}").into()));
+                }
+            },
+        }
+    }
+}

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod append;
 mod decr;
 mod decrby;
 pub mod get;

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -23,6 +23,7 @@ pub mod group_client;
 pub mod incr;
 mod incrby;
 pub mod set;
+mod strlen;
 pub mod table;
 
 use std::collections::HashMap;

--- a/src/cmd/src/strlen.rs
+++ b/src/cmd/src/strlen.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use client::Client;
+use resp::RespData;
+use storage::storage::Storage;
+
+use crate::{AclCategory, Cmd, CmdFlags, CmdMeta};
+use crate::{impl_cmd_clone_box, impl_cmd_meta};
+
+#[derive(Clone, Default)]
+pub struct StrlenCmd {
+    meta: CmdMeta,
+}
+
+impl StrlenCmd {
+    pub fn new() -> Self {
+        Self {
+            meta: CmdMeta {
+                name: "strlen".to_string(),
+                arity: 2, // STRLEN key
+                flags: CmdFlags::READONLY,
+                acl_category: AclCategory::STRING | AclCategory::READ,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl Cmd for StrlenCmd {
+    impl_cmd_meta!();
+    impl_cmd_clone_box!();
+
+    /// STRLEN key
+    fn do_initial(&self, client: &Client) -> bool {
+        let argv = client.argv();
+        let key = argv[1].clone();
+        client.set_key(&key);
+        true
+    }
+
+    fn do_cmd(&self, client: &Client, storage: Arc<Storage>) {
+        let key = client.key();
+
+        let result = storage.strlen(&key);
+
+        match result {
+            Ok(len) => {
+                client.set_reply(RespData::Integer(len as i64));
+            }
+            Err(e) => match e {
+                storage::error::Error::RedisErr { ref message, .. }
+                    if message.starts_with("WRONGTYPE") =>
+                {
+                    // RedisErr already contains the formatted message
+                    client.set_reply(RespData::Error(message.clone().into()));
+                }
+                _ => {
+                    client.set_reply(RespData::Error(format!("ERR {e}").into()));
+                }
+            },
+        }
+    }
+}

--- a/src/cmd/src/table.rs
+++ b/src/cmd/src/table.rs
@@ -61,6 +61,7 @@ pub fn create_command_table() -> CmdTable {
         crate::incrby::IncrbyCmd,
         crate::decr::DecrCmd,
         crate::decrby::DecrbyCmd,
+        crate::strlen::StrlenCmd,
         // TODO: add more commands...
     );
 

--- a/src/cmd/src/table.rs
+++ b/src/cmd/src/table.rs
@@ -54,6 +54,7 @@ pub fn create_command_table() -> CmdTable {
 
     register_cmd!(
         cmd_table,
+        crate::append::AppendCmd,
         crate::set::SetCmd,
         crate::get::GetCmd,
         crate::incr::IncrCmd,

--- a/src/storage/src/storage_impl.rs
+++ b/src/storage/src/storage_impl.rs
@@ -52,6 +52,12 @@ impl Storage {
         self.insts[instance_id].append(key, value)
     }
 
+    pub fn strlen(&self, key: &[u8]) -> Result<i32> {
+        let slot_id = key_to_slot_id(key);
+        let instance_id = self.slot_indexer.get_instance_id(slot_id);
+        self.insts[instance_id].strlen(key)
+    }
+
     // // Atomically sets key to value and returns the old value stored at key
     // // Returns an error when key exists but does not hold a string value.
     // pub fn get_set(&self, key: &[u8], value: &[u8], old_value: &mut String) -> Status {

--- a/src/storage/src/storage_impl.rs
+++ b/src/storage/src/storage_impl.rs
@@ -46,6 +46,12 @@ impl Storage {
         self.insts[instance_id].incr_decr(key, incr)
     }
 
+    pub fn append(&self, key: &[u8], value: &[u8]) -> Result<i32> {
+        let slot_id = key_to_slot_id(key);
+        let instance_id = self.slot_indexer.get_instance_id(slot_id);
+        self.insts[instance_id].append(key, value)
+    }
+
     // // Atomically sets key to value and returns the old value stored at key
     // // Returns an error when key exists but does not hold a string value.
     // pub fn get_set(&self, key: &[u8], value: &[u8], old_value: &mut String) -> Status {

--- a/src/storage/tests/redis_string_test.rs
+++ b/src/storage/tests/redis_string_test.rs
@@ -847,40 +847,56 @@ mod redis_string_test {
         let key = b"nonexistent_key";
         let result = redis.strlen(key);
         assert!(result.is_ok(), "strlen should succeed for non-existing key");
-        assert_eq!(result.unwrap(), 0, "strlen should return 0 for non-existing key");
+        assert_eq!(
+            result.unwrap(),
+            0,
+            "strlen should return 0 for non-existing key"
+        );
 
         // Test 2: Set a value and get its length
         let key = b"test_key";
         let value = b"Hello, World!";
         redis.set(key, value).unwrap();
-        
+
         let result = redis.strlen(key);
         assert!(result.is_ok(), "strlen should succeed");
-        assert_eq!(result.unwrap(), 13, "strlen should return 13 for 'Hello, World!'");
+        assert_eq!(
+            result.unwrap(),
+            13,
+            "strlen should return 13 for 'Hello, World!'"
+        );
 
         // Test 3: Empty string
         let key = b"empty_key";
         let value = b"";
         redis.set(key, value).unwrap();
-        
+
         let result = redis.strlen(key);
         assert!(result.is_ok(), "strlen should succeed for empty string");
-        assert_eq!(result.unwrap(), 0, "strlen should return 0 for empty string");
+        assert_eq!(
+            result.unwrap(),
+            0,
+            "strlen should return 0 for empty string"
+        );
 
         // Test 4: UTF-8 multi-byte characters (should count bytes, not characters)
         let key = b"utf8_key";
         let value = "你好世界".as_bytes(); // 12 bytes (3 bytes per character)
         redis.set(key, value).unwrap();
-        
+
         let result = redis.strlen(key);
         assert!(result.is_ok(), "strlen should succeed for UTF-8 string");
-        assert_eq!(result.unwrap(), 12, "strlen should return byte count, not character count");
+        assert_eq!(
+            result.unwrap(),
+            12,
+            "strlen should return byte count, not character count"
+        );
 
         // Test 5: Large string
         let key = b"large_key";
         let value = vec![b'x'; 10000];
         redis.set(key, &value).unwrap();
-        
+
         let result = redis.strlen(key);
         assert!(result.is_ok(), "strlen should succeed for large string");
         assert_eq!(result.unwrap(), 10000);
@@ -918,9 +934,11 @@ mod redis_string_test {
         // Try to get strlen of a hash key (should return RedisErr)
         let result = redis.strlen(key);
         assert!(result.is_err(), "strlen should fail for non-string type");
-        
+
         match result.unwrap_err() {
-            storage::error::Error::RedisErr { ref message, .. } if message.starts_with("WRONGTYPE") => {
+            storage::error::Error::RedisErr { ref message, .. }
+                if message.starts_with("WRONGTYPE") =>
+            {
                 // Expected error type
             }
             e => panic!("Expected WRONGTYPE RedisErr, got: {:?}", e),
@@ -954,12 +972,12 @@ mod redis_string_test {
         let key = b"ttl_key";
         let value = b"test_value";
         redis.set(key, value).unwrap();
-        
+
         // Check strlen
         let result = redis.strlen(key);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 10);
-        
+
         // Note: We skip the TTL test as expire() might not be available in this test context
         // In real Redis, expired keys would return 0 from strlen
 
@@ -1004,7 +1022,7 @@ mod redis_string_test {
                 for i in 0..100 {
                     let key = format!("concurrent_key_{}", i).into_bytes();
                     let expected_len = format!("value_{}", i).len() as i32;
-                    
+
                     let result = redis_clone.strlen(&key);
                     assert!(
                         result.is_ok(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added APPEND command to append values to string keys and return the new byte length; handles appending to non-existing keys and wrong-type errors.
  * Added STRLEN command to return the byte length of string values, returning 0 for missing/expired keys and reporting wrong-type errors.

* **Tests**
  * Added comprehensive tests for APPEND and STRLEN covering edge cases, concurrency, TTL behavior, size limits, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->