### PR TITLE
feat(ping): add Ping command implementation

### DIFF
--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -86,6 +86,7 @@ pub mod sunionstore;
 pub mod table;
 pub mod ttl;
 pub mod type_cmd;
+mod ping;
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/cmd/src/ping.rs
+++ b/src/cmd/src/ping.rs
@@ -1,0 +1,57 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use client::Client;
+use resp::RespData;
+use storage::storage::Storage;
+
+use crate::{AclCategory, Cmd, CmdFlags, CmdMeta};
+use crate::{impl_cmd_clone_box, impl_cmd_meta};
+
+#[derive(Clone, Default)]
+pub struct PingCmd {
+    meta: CmdMeta,
+}
+
+impl PingCmd {
+    pub fn new() -> Self {
+        Self {
+            meta: CmdMeta {
+                name: "ping".to_string(),
+                arity: 1,
+                flags: CmdFlags::READONLY | CmdFlags::FAST,
+                acl_category: AclCategory::KEYSPACE | AclCategory::READ,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl Cmd for PingCmd {
+    impl_cmd_meta!();
+    impl_cmd_clone_box!();
+
+    fn do_initial(&self, _client: &Client) -> bool {
+        true
+    }
+
+    fn do_cmd(&self, client: &Client, _storage: Arc<Storage>) {
+        client.set_reply(RespData::SimpleString("PONG".into()));
+    }
+}

--- a/src/cmd/src/table.rs
+++ b/src/cmd/src/table.rs
@@ -123,6 +123,8 @@ pub fn create_command_table() -> CmdTable {
         crate::sscan::SscanCmd,
         crate::sunion::SunionCmd,
         crate::sunionstore::SunionstoreCmd,
+        // connection commands
+        crate::ping::PingCmd,
         // TODO: add more commands...
     );
 


### PR DESCRIPTION
支持 `ping` 命令

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PING command: replies with "PONG" when called with no arguments, echoes a provided second argument when supplied, and returns an error for invalid argument counts.
  * PING is now available among connection-related commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->