### PR TITLE
fix:change tool chain to newest stable version issue/226 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly-2025-08-20
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Run fmt
@@ -50,7 +50,7 @@ jobs:
       - name: Setup toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly-2025-08-20
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Install protoc (Linux)
@@ -92,7 +92,7 @@ jobs:
       - name: Setup toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly-2025-08-20
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Install protoc (Linux)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: nightly-2025-08-20
+        toolchain: stable
         components: rustfmt, clippy
 
     - name: Install protoc (Linux)
@@ -64,7 +64,7 @@ jobs:
     - name: Setup Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: nightly-2025-08-20
+        toolchain: stable
         components: rustfmt, clippy
 
     - name: Install protoc (Windows)
@@ -93,7 +93,7 @@ jobs:
     - name: Setup Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: nightly-2025-08-20
+        toolchain: stable
         components: rustfmt, clippy
 
     - name: Install protoc (macOS)
@@ -116,7 +116,7 @@ jobs:
     - name: Setup Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: nightly-2025-08-20
+        toolchain: stable
         components: rustfmt, clippy
 
     - name: Install protoc (Linux)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,5 +16,5 @@
 # limitations under the License.
 
 [toolchain]
-channel = "nightly-2025-08-20"
+channel = "stable"
 components = ["rustfmt", "clippy", "rust-src", "miri", "rust-analyzer"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Transitioned Rust toolchain from nightly-2025-08-20 to stable channel across all CI and build configurations.

* **Tests**
  * Updated performance benchmarks with improved consistency mechanisms for key/value generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->