### PR TITLE
feat(parse): refactor inline parsing

### DIFF
--- a/src/resp/src/command.rs
+++ b/src/resp/src/command.rs
@@ -552,18 +552,6 @@ impl Command for RespData {
 
                 Ok(RespCommand::new(command_type, args, false))
             }
-            RespData::Inline(parts) if !parts.is_empty() => {
-                let command_name = std::str::from_utf8(&parts[0]).map_err(|_| {
-                    RespError::InvalidData("Command name must be a valid UTF-8 string".to_string())
-                })?;
-
-                let command_type =
-                    CommandType::from_str(command_name).unwrap_or(CommandType::Unknown);
-
-                let args = parts.iter().skip(1).cloned().collect();
-
-                Ok(RespCommand::new(command_type, args, false))
-            }
             _ => Err(RespError::InvalidData("Invalid command format".to_string())),
         }
     }

--- a/src/resp/src/encode.rs
+++ b/src/resp/src/encode.rs
@@ -384,15 +384,6 @@ impl RespEncode for RespEncoder {
                 self
             }
             RespData::Array(None) => self.set_array_len(-1),
-            RespData::Inline(parts) => {
-                for (i, part) in parts.iter().enumerate() {
-                    if i > 0 {
-                        self.buffer.extend_from_slice(b" ");
-                    }
-                    self.buffer.extend_from_slice(part);
-                }
-                self.append_crlf()
-            }
             // RESP3 types
             RespData::Null => {
                 self.buffer.extend_from_slice(b"_");

--- a/src/resp/src/negotiation.rs
+++ b/src/resp/src/negotiation.rs
@@ -248,8 +248,7 @@ impl ProtocolNegotiator {
             RespData::SimpleString(_)
             | RespData::Error(_)
             | RespData::Integer(_)
-            | RespData::BulkString(_)
-            | RespData::Inline(_) => data.clone(),
+            | RespData::BulkString(_) => data.clone(),
             RespData::Array(Some(items)) => {
                 // Recursively convert array items
                 let converted_items: Vec<_> = items.iter().map(Self::convert_to_resp2).collect();

--- a/src/resp/src/parse.rs
+++ b/src/resp/src/parse.rs
@@ -22,10 +22,9 @@ use bytes::{Buf, Bytes, BytesMut};
 use nom::Parser;
 use nom::{
     IResult,
-    bytes::streaming::{take, take_while1},
-    character::streaming::{char, digit1, line_ending, not_line_ending, space1},
-    combinator::{map, map_res, opt, recognize},
-    multi::separated_list0,
+    bytes::streaming::take,
+    character::streaming::{char, digit1, line_ending, not_line_ending},
+    combinator::{map_res, opt, recognize},
     sequence::terminated,
 };
 
@@ -106,17 +105,13 @@ impl RespParse {
     }
 
     fn parse_inline(input: &[u8]) -> IResult<&[u8], RespData> {
-        let mut parse_parts = separated_list0(
-            space1,
-            map(
-                take_while1(|c| c != b' ' && c != b'\r' && c != b'\n'),
-                |s: &[u8]| Bytes::copy_from_slice(s),
-            ),
-        );
+        let (input, line) = terminated(not_line_ending, line_ending).parse(input)?;
 
-        let (input, parts) = parse_parts.parse(input)?;
-
-        let (input, _) = line_ending(input)?;
+        let parts = line
+            .split(|byte| byte.is_ascii_whitespace())
+            .filter(|part| !part.is_empty())
+            .map(Bytes::copy_from_slice)
+            .collect::<Vec<_>>();
 
         if parts.is_empty() {
             return Err(nom::Err::Error(nom::error::Error::new(
@@ -125,7 +120,27 @@ impl RespParse {
             )));
         }
 
-        Ok((input, RespData::Inline(parts)))
+        Ok((
+            input,
+            RespData::Array(Some(
+                parts
+                    .into_iter()
+                    .map(|part| RespData::BulkString(Some(part)))
+                    .collect(),
+            )),
+        ))
+    }
+
+    fn skip_empty_lines(&mut self) {
+        loop {
+            if self.buffer.starts_with(b"\r\n") {
+                self.buffer.advance(2);
+            } else if self.buffer.starts_with(b"\n") {
+                self.buffer.advance(1);
+            } else {
+                break;
+            }
+        }
     }
 
     fn parse_simple_string(input: &[u8]) -> IResult<&[u8], RespData> {
@@ -432,6 +447,8 @@ impl RespParse {
     }
 
     fn process_buffer(&mut self) -> RespParseResult {
+        self.skip_empty_lines();
+
         if self.buffer.is_empty() {
             return RespParseResult::Incomplete;
         }
@@ -497,6 +514,8 @@ impl Drop for RespParse {
 #[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod tests {
+    use crate::command::CommandType;
+
     use super::Bytes;
     use super::{Parse, RespData, RespParse, RespParseResult, RespVersion};
 
@@ -533,37 +552,78 @@ mod tests {
         let res = parser.parse(Bytes::from("ping\r\n"));
         assert_eq!(
             res,
-            RespParseResult::Complete(RespData::Inline(vec![Bytes::from("ping")]))
+            RespParseResult::Complete(RespData::Array(Some(vec![RespData::BulkString(Some(
+                Bytes::from("ping"),
+            ))])))
         );
         parser.reset();
 
         let res = parser.parse(Bytes::from("PING\r\n\r\n"));
         assert_eq!(
             res,
-            RespParseResult::Complete(RespData::Inline(vec![Bytes::from("PING")]))
+            RespParseResult::Complete(RespData::Array(Some(vec![RespData::BulkString(Some(
+                Bytes::from("PING"),
+            ))])))
         );
         parser.reset();
 
         let res = parser.parse(Bytes::from("PING\n"));
         assert_eq!(
             res,
-            RespParseResult::Complete(RespData::Inline(vec![Bytes::from("PING")]))
+            RespParseResult::Complete(RespData::Array(Some(vec![RespData::BulkString(Some(
+                Bytes::from("PING"),
+            ))])))
         );
         parser.reset();
 
         let res = parser.parse(Bytes::from("PING\n\n"));
         assert_eq!(
             res,
-            RespParseResult::Complete(RespData::Inline(vec![Bytes::from("PING")]))
+            RespParseResult::Complete(RespData::Array(Some(vec![RespData::BulkString(Some(
+                Bytes::from("PING"),
+            ))])))
         );
         parser.reset();
 
         let res = parser.parse(Bytes::from("PING\r\n\n"));
         assert_eq!(
             res,
-            RespParseResult::Complete(RespData::Inline(vec![Bytes::from("PING")]))
+            RespParseResult::Complete(RespData::Array(Some(vec![RespData::BulkString(Some(
+                Bytes::from("PING"),
+            ))])))
         );
         parser.reset();
+    }
+
+    #[test]
+    fn test_parse_inline_info_command() {
+        let mut parser = RespParse::new(RespVersion::RESP2);
+        let res = parser.parse(Bytes::from("info\r\n"));
+        assert_eq!(
+            res,
+            RespParseResult::Complete(RespData::Array(Some(vec![RespData::BulkString(Some(
+                Bytes::from("info"),
+            ))])))
+        );
+
+        let command = parser.next_command().unwrap().unwrap();
+        assert_eq!(command.command_type, CommandType::Info);
+        assert!(command.args.is_empty());
+    }
+
+    #[test]
+    fn test_parse_inline_with_surrounding_whitespace() {
+        let mut parser = RespParse::new(RespVersion::RESP2);
+        let res = parser.parse(Bytes::from(" \tinfo \t\r\n"));
+        assert_eq!(
+            res,
+            RespParseResult::Complete(RespData::Array(Some(vec![RespData::BulkString(Some(
+                Bytes::from("info"),
+            ))])))
+        );
+
+        let command = parser.next_command().unwrap().unwrap();
+        assert_eq!(command.command_type, CommandType::Info);
     }
 
     #[test]
@@ -572,13 +632,13 @@ mod tests {
         let res = parser.parse(Bytes::from("hmget fruit apple banana watermelon\r\n"));
         assert_eq!(
             res,
-            RespParseResult::Complete(RespData::Inline(vec![
-                Bytes::from("hmget"),
-                Bytes::from("fruit"),
-                Bytes::from("apple"),
-                Bytes::from("banana"),
-                Bytes::from("watermelon")
-            ]))
+            RespParseResult::Complete(RespData::Array(Some(vec![
+                RespData::BulkString(Some(Bytes::from("hmget"))),
+                RespData::BulkString(Some(Bytes::from("fruit"))),
+                RespData::BulkString(Some(Bytes::from("apple"))),
+                RespData::BulkString(Some(Bytes::from("banana"))),
+                RespData::BulkString(Some(Bytes::from("watermelon"))),
+            ])))
         );
     }
 
@@ -591,20 +651,49 @@ mod tests {
         ));
         assert_eq!(
             res,
-            RespParseResult::Complete(RespData::Inline(vec![Bytes::from("ping")]))
+            RespParseResult::Complete(RespData::Array(Some(vec![RespData::BulkString(Some(
+                Bytes::from("ping"),
+            ))])))
         );
 
         let res = parser.parse(Bytes::new());
         assert_eq!(
             res,
-            RespParseResult::Complete(RespData::Inline(vec![
-                Bytes::from("hmget"),
-                Bytes::from("fruit"),
-                Bytes::from("apple"),
-                Bytes::from("banana"),
-                Bytes::from("watermelon")
-            ]))
+            RespParseResult::Complete(RespData::Array(Some(vec![
+                RespData::BulkString(Some(Bytes::from("hmget"))),
+                RespData::BulkString(Some(Bytes::from("fruit"))),
+                RespData::BulkString(Some(Bytes::from("apple"))),
+                RespData::BulkString(Some(Bytes::from("banana"))),
+                RespData::BulkString(Some(Bytes::from("watermelon"))),
+            ])))
         );
+    }
+
+    #[test]
+    fn test_parse_multiple_inline_with_blank_lines() {
+        let mut parser = RespParse::new(RespVersion::RESP2);
+
+        let res = parser.parse(Bytes::from("ping\r\n\r\ninfo\r\n"));
+        assert_eq!(
+            res,
+            RespParseResult::Complete(RespData::Array(Some(vec![RespData::BulkString(Some(
+                Bytes::from("ping"),
+            ))])))
+        );
+
+        let res = parser.parse(Bytes::new());
+        assert_eq!(
+            res,
+            RespParseResult::Complete(RespData::Array(Some(vec![RespData::BulkString(Some(
+                Bytes::from("info"),
+            ))])))
+        );
+
+        let command = parser.next_command().unwrap().unwrap();
+        assert_eq!(command.command_type, CommandType::Ping);
+
+        let command = parser.next_command().unwrap().unwrap();
+        assert_eq!(command.command_type, CommandType::Info);
     }
 
     #[test]

--- a/src/resp/src/parse.rs
+++ b/src/resp/src/parse.rs
@@ -612,6 +612,24 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_inline_command_with_args() {
+        let mut parser = RespParse::new(RespVersion::RESP2);
+        let res = parser.parse(Bytes::from("ping hello\r\n"));
+        assert_eq!(
+            res,
+            RespParseResult::Complete(RespData::Array(Some(vec![
+                RespData::BulkString(Some(Bytes::from("ping"))),
+                RespData::BulkString(Some(Bytes::from("hello"))),
+            ])))
+        );
+
+        let command = parser.next_command().unwrap().unwrap();
+        assert_eq!(command.command_type, CommandType::Ping);
+        assert_eq!(command.arg_count(), 1);
+        assert_eq!(command.arg(0), Some(&Bytes::from("hello")));
+    }
+
+    #[test]
     fn test_parse_inline_with_surrounding_whitespace() {
         let mut parser = RespParse::new(RespVersion::RESP2);
         let res = parser.parse(Bytes::from(" \tinfo \t\r\n"));

--- a/src/resp/src/types.rs
+++ b/src/resp/src/types.rs
@@ -34,7 +34,6 @@ pub enum RespType {
     Integer,
     BulkString,
     Array,
-    Inline,
     // RESP3 types
     Null,
     Boolean,
@@ -76,7 +75,6 @@ impl RespType {
             RespType::Integer => Some(b':'),
             RespType::BulkString => Some(b'$'),
             RespType::Array => Some(b'*'),
-            RespType::Inline => None,
             // RESP3 types
             RespType::Null => Some(b'_'),
             RespType::Boolean => Some(b'#'),
@@ -98,7 +96,6 @@ pub enum RespData {
     Integer(i64),
     BulkString(Option<Bytes>),
     Array(Option<Vec<RespData>>),
-    Inline(Vec<Bytes>),
     // RESP3 types
     Null,
     Boolean(bool),
@@ -125,7 +122,6 @@ impl RespData {
             RespData::Integer(_) => RespType::Integer,
             RespData::BulkString(_) => RespType::BulkString,
             RespData::Array(_) => RespType::Array,
-            RespData::Inline(_) => RespType::Inline,
             // RESP3 types
             RespData::Null => RespType::Null,
             RespData::Boolean(_) => RespType::Boolean,
@@ -146,9 +142,6 @@ impl RespData {
             RespData::Integer(num) => Some(num.to_string()),
             RespData::BulkString(Some(bytes)) => String::from_utf8(bytes.to_vec()).ok(),
             RespData::BulkString(None) => None,
-            RespData::Inline(parts) if !parts.is_empty() => {
-                String::from_utf8(parts[0].to_vec()).ok()
-            }
             // RESP3 types
             RespData::Null => None,
             RespData::Boolean(b) => Some(b.to_string()),
@@ -167,7 +160,6 @@ impl RespData {
             RespData::Integer(num) => Some(Bytes::from(num.to_string())),
             RespData::BulkString(Some(bytes)) => Some(bytes.clone()),
             RespData::BulkString(None) => None,
-            RespData::Inline(parts) if !parts.is_empty() => Some(parts[0].clone()),
             // RESP3 types
             RespData::Null => None,
             RespData::Boolean(b) => Some(Bytes::from(b.to_string())),
@@ -306,15 +298,6 @@ impl fmt::Debug for RespData {
             RespData::BulkString(None) => write!(f, "BulkString(nil)"),
             RespData::Array(Some(array)) => write!(f, "Array({array:?})"),
             RespData::Array(None) => write!(f, "Array(nil)"),
-            RespData::Inline(parts) => {
-                write!(f, "Inline(")?;
-                let parts_str: Vec<_> = parts
-                    .iter()
-                    .filter_map(|b| std::str::from_utf8(b).ok())
-                    .collect();
-                write!(f, "{parts_str:?}")?;
-                write!(f, ")")
-            }
             // RESP3 types
             RespData::Null => write!(f, "Null"),
             RespData::Boolean(b) => write!(f, "Boolean({b})"),


### PR DESCRIPTION
支持 resp协议中,inline命令解析,执行

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inline commands are now tokenized by ASCII whitespace, skip leading blank lines, and handle whitespace-padded commands correctly.
* **Refactor**
  * Inline-style RESP values are normalized to array/bulk-string form across parsing, encoding, and protocol negotiation.
* **Tests**
  * Expanded coverage for multi-word inline commands, info command, and multiple commands separated by blank lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->