### PR TITLE
fix: reorder type checks after stale validation and fix zset store destination handling

### DIFF
--- a/src/storage/src/redis_sets.rs
+++ b/src/storage/src/redis_sets.rs
@@ -79,11 +79,7 @@ impl Redis {
         let meta_get = db.get_cf(&cf, &base_meta_key).context(RocksSnafu)?;
         let (mut set_meta_value, version, is_new_set) = match meta_get {
             Some(val) => {
-                // Type check
-                self.check_type(&val, DataType::Set)?;
-                let set_meta_value = ParsedSetsMetaValue::new(&val[..])?;
-                // Check if expired
-                if set_meta_value.is_stale() {
+                if self.is_stale(&val)? {
                     // Create new set if expired
                     let count_bytes = 0u64.to_le_bytes().to_vec();
                     let mut new_meta = BaseMetaValue::new(Bytes::from(count_bytes));
@@ -93,6 +89,8 @@ impl Redis {
                     let version = new_set_meta.initial_meta_value();
                     (new_set_meta, version, true)
                 } else {
+                    self.check_type(&val, DataType::Set)?;
+                    let set_meta_value = ParsedSetsMetaValue::new(&val[..])?;
                     let version = set_meta_value.version();
                     (set_meta_value, version, false)
                 }
@@ -186,16 +184,14 @@ impl Redis {
 
         match db.get_cf(&cf, &base_meta_key).context(RocksSnafu)? {
             Some(val) => {
-                // Type check
-                self.check_type(&val, DataType::Set)?;
-                let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-                // Validity check (not expired and count > 0)
-                if !set_meta.is_valid() {
+                if self.is_stale(&val)? {
                     return KeyNotFoundSnafu {
                         key: String::from_utf8_lossy(key).to_string(),
                     }
                     .fail();
                 }
+                self.check_type(&val, DataType::Set)?;
+                let set_meta = ParsedSetsMetaValue::new(&val[..])?;
                 Ok(set_meta.count() as i32)
             }
             None => KeyNotFoundSnafu {
@@ -231,15 +227,12 @@ impl Redis {
             return Ok(Vec::new());
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
-
-        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-        // Validity check (not expired and count > 0)
-        if !set_meta.is_valid() {
+        if self.is_stale(&val)? {
             // Redis SMEMBERS returns empty array for expired/invalid keys
             return Ok(Vec::new());
         }
+        self.check_type(&val, DataType::Set)?;
+        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
         let version = set_meta.version();
 
         // Iterate from prefix and collect members until prefix no longer matches
@@ -290,15 +283,12 @@ impl Redis {
             return Ok(false);
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
-
-        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-        // Validity check (not expired and count > 0)
-        if !set_meta.is_valid() {
+        if self.is_stale(&val)? {
             // Redis SISMEMBER returns 0 for expired/invalid keys
             return Ok(false);
         }
+        self.check_type(&val, DataType::Set)?;
+        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
         let version = set_meta.version();
 
         // Check if member exists
@@ -337,15 +327,12 @@ impl Redis {
             return Ok(Vec::new());
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
-
-        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-        // Validity check (not expired and count > 0)
-        if !set_meta.is_valid() {
+        if self.is_stale(&val)? {
             // Redis SRANDMEMBER returns empty array for expired/invalid keys
             return Ok(Vec::new());
         }
+        self.check_type(&val, DataType::Set)?;
+        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
 
         let version = set_meta.version();
         let set_size = set_meta.count() as usize;
@@ -459,15 +446,12 @@ impl Redis {
             return Ok(0);
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
-
-        let mut set_meta = ParsedSetsMetaValue::new(&val[..])?;
-        // Validity check (not expired and count > 0)
-        if !set_meta.is_valid() {
+        if self.is_stale(&val)? {
             // Redis SREM returns 0 for expired/invalid keys
             return Ok(0);
         }
+        self.check_type(&val, DataType::Set)?;
+        let mut set_meta = ParsedSetsMetaValue::new(&val[..])?;
 
         let version = set_meta.version();
         let mut removed_count = 0i32;
@@ -554,15 +538,12 @@ impl Redis {
             return Ok(Vec::new());
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
-
-        let mut set_meta = ParsedSetsMetaValue::new(&val[..])?;
-        // Validity check (not expired and count > 0)
-        if !set_meta.is_valid() {
+        if self.is_stale(&val)? {
             // Redis SPOP returns empty array for expired/invalid keys
             return Ok(Vec::new());
         }
+        self.check_type(&val, DataType::Set)?;
+        let mut set_meta = ParsedSetsMetaValue::new(&val[..])?;
 
         let version = set_meta.version();
         let set_size = set_meta.count() as usize;
@@ -712,14 +693,12 @@ impl Redis {
             return Ok(false);
         };
 
-        // Type check for source
-        self.check_type(&source_val, DataType::Set)?;
-
-        let mut source_meta = ParsedSetsMetaValue::new(&source_val[..])?;
-        if !source_meta.is_valid() {
+        if self.is_stale(&source_val)? {
             // Source set is expired/invalid
             return Ok(false);
         }
+        self.check_type(&source_val, DataType::Set)?;
+        let mut source_meta = ParsedSetsMetaValue::new(&source_val[..])?;
 
         let source_version = source_meta.version();
 
@@ -749,15 +728,13 @@ impl Redis {
         // Handle destination set
         let dest_meta_val = db.get_cf(&cf_meta, &dest_meta_key).context(RocksSnafu)?;
         let (mut dest_meta, dest_version, dest_exists) = if let Some(dest_val) = dest_meta_val {
-            // Type check for destination
-            self.check_type(&dest_val, DataType::Set)?;
-
             let mut meta = ParsedSetsMetaValue::new(&dest_val[..])?;
-            let version = if meta.is_valid() {
-                meta.version()
-            } else {
+            let version = if self.is_stale(&dest_val)? {
                 // Destination set is expired, create new version
                 meta.initial_meta_value()
+            } else {
+                self.check_type(&dest_val, DataType::Set)?;
+                meta.version()
             };
             (meta, version, true)
         } else {
@@ -1987,15 +1964,12 @@ impl Redis {
             return Ok(result);
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
-
-        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-        // Validity check (not expired and count > 0)
-        if !set_meta.is_valid() {
+        if self.is_stale(&val)? {
             // Return empty result for expired/invalid keys
             return Ok(result);
         }
+        self.check_type(&val, DataType::Set)?;
+        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
 
         let version = set_meta.version();
 
@@ -2081,14 +2055,12 @@ impl Redis {
             }
 
             let val = meta_val.expect("meta_val checked non-None above");
-            // Type check
-            self.check_type(&val, DataType::Set)?;
-
-            let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-            if !set_meta.is_valid() {
+            if self.is_stale(&val)? {
                 // If any set is expired/invalid, intersection is empty
                 return Ok(result);
             }
+            self.check_type(&val, DataType::Set)?;
+            let set_meta = ParsedSetsMetaValue::new(&val[..])?;
 
             let count = set_meta.count() as i32;
             if count < smallest_size {
@@ -2156,11 +2128,8 @@ impl Redis {
             let meta_val = db.get_cf(&cf_meta, &base_meta_key).context(RocksSnafu)?;
 
             if let Some(val) = meta_val {
-                // Type check
-                self.check_type(&val, DataType::Set)?;
-
-                let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-                if set_meta.is_valid() {
+                if !self.is_stale(&val)? {
+                    self.check_type(&val, DataType::Set)?;
                     // Get all members of this set and add to union
                     let members = self.smembers(key)?;
                     for member in members {
@@ -2383,15 +2352,12 @@ impl Redis {
             return Ok((0, Vec::new()));
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
-
-        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-        // Validity check (not expired and count > 0)
-        if !set_meta.is_valid() {
+        if self.is_stale(&val)? {
             // Return empty result with cursor 0 for expired/invalid keys
             return Ok((0, Vec::new()));
         }
+        self.check_type(&val, DataType::Set)?;
+        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
 
         let version = set_meta.version();
         let _set_size = set_meta.count() as usize;

--- a/src/storage/src/redis_sets.rs
+++ b/src/storage/src/redis_sets.rs
@@ -695,6 +695,7 @@ impl Redis {
 
         // Build source member key
         let source_member_key = MemberDataKey::new(source, source_version, member).encode()?;
+
         // Check if member exists in source
         if db
             .get_cf(&cf_data, &source_member_key)
@@ -705,18 +706,26 @@ impl Redis {
             return Ok(false);
         }
 
-        // Handle destination set
+        // Handle destination set. Gate on staleness and type *before* parsing,
+        // so a non-Set value (e.g. a short string whose buffer is too small for
+        // the Set meta layout) returns WRONGTYPE rather than InvalidFormat, and
+        // a stale value of any prior type is rewritten as a fresh Set meta.
         let dest_meta_val = db.get_cf(&cf_meta, &dest_meta_key).context(RocksSnafu)?;
         let (mut dest_meta, dest_version, dest_exists) = if let Some(dest_val) = dest_meta_val {
-            let mut meta = ParsedSetsMetaValue::new(&dest_val[..])?;
-            let version = if self.is_stale(&dest_val)? {
-                // Destination set is expired, create new version
-                meta.initial_meta_value()
+            if self.is_stale(&dest_val)? {
+                let count_bytes = 0u64.to_le_bytes();
+                let mut new_meta = BaseMetaValue::new(Bytes::from(count_bytes.to_vec()));
+                new_meta.inner.data_type = DataType::Set;
+                let encoded = new_meta.encode();
+                let mut meta = ParsedSetsMetaValue::new(encoded)?;
+                let version = meta.initial_meta_value();
+                (meta, version, true)
             } else {
                 self.check_type(&dest_val, DataType::Set)?;
-                meta.version()
-            };
-            (meta, version, true)
+                let meta = ParsedSetsMetaValue::new(&dest_val[..])?;
+                let version = meta.version();
+                (meta, version, true)
+            }
         } else {
             // Destination set doesn't exist, create new one
             let count_bytes = 0u64.to_le_bytes();
@@ -730,6 +739,7 @@ impl Redis {
 
         // Build destination member key
         let dest_member_key = MemberDataKey::new(destination, dest_version, member).encode()?;
+
         // Check if member already exists in destination
         let member_exists_in_dest = db
             .get_cf(&cf_data, &dest_member_key)

--- a/src/storage/src/redis_sets.rs
+++ b/src/storage/src/redis_sets.rs
@@ -79,11 +79,7 @@ impl Redis {
         let meta_get = db.get_cf(&cf, &base_meta_key).context(RocksSnafu)?;
         let (mut set_meta_value, version, is_new_set) = match meta_get {
             Some(val) => {
-                // Type check
-                self.check_type(&val, DataType::Set)?;
-                let set_meta_value = ParsedSetsMetaValue::new(&val[..])?;
-                // Check if expired
-                if set_meta_value.is_stale() {
+                if self.is_stale(&val)? {
                     // Create new set if expired
                     let count_bytes = 0u64.to_le_bytes().to_vec();
                     let mut new_meta = BaseMetaValue::new(Bytes::from(count_bytes));
@@ -93,6 +89,8 @@ impl Redis {
                     let version = new_set_meta.initial_meta_value();
                     (new_set_meta, version, true)
                 } else {
+                    self.check_type(&val, DataType::Set)?;
+                    let set_meta_value = ParsedSetsMetaValue::new(&val[..])?;
                     let version = set_meta_value.version();
                     (set_meta_value, version, false)
                 }
@@ -186,16 +184,14 @@ impl Redis {
 
         match db.get_cf(&cf, &base_meta_key).context(RocksSnafu)? {
             Some(val) => {
-                // Type check
-                self.check_type(&val, DataType::Set)?;
-                let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-                // Validity check (not expired and count > 0)
-                if !set_meta.is_valid() {
+                if self.is_stale(&val)? {
                     return KeyNotFoundSnafu {
                         key: String::from_utf8_lossy(key).to_string(),
                     }
                     .fail();
                 }
+                self.check_type(&val, DataType::Set)?;
+                let set_meta = ParsedSetsMetaValue::new(&val[..])?;
                 Ok(set_meta.count() as i32)
             }
             None => KeyNotFoundSnafu {
@@ -231,15 +227,12 @@ impl Redis {
             return Ok(Vec::new());
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
-
-        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-        // Validity check (not expired and count > 0)
-        if !set_meta.is_valid() {
+        if self.is_stale(&val)? {
             // Redis SMEMBERS returns empty array for expired/invalid keys
             return Ok(Vec::new());
         }
+        self.check_type(&val, DataType::Set)?;
+        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
         let version = set_meta.version();
 
         // Iterate from prefix and collect members until prefix no longer matches
@@ -290,15 +283,12 @@ impl Redis {
             return Ok(false);
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
-
-        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-        // Validity check (not expired and count > 0)
-        if !set_meta.is_valid() {
+        if self.is_stale(&val)? {
             // Redis SISMEMBER returns 0 for expired/invalid keys
             return Ok(false);
         }
+        self.check_type(&val, DataType::Set)?;
+        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
         let version = set_meta.version();
 
         // Check if member exists
@@ -337,15 +327,12 @@ impl Redis {
             return Ok(Vec::new());
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
-
-        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-        // Validity check (not expired and count > 0)
-        if !set_meta.is_valid() {
+        if self.is_stale(&val)? {
             // Redis SRANDMEMBER returns empty array for expired/invalid keys
             return Ok(Vec::new());
         }
+        self.check_type(&val, DataType::Set)?;
+        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
 
         let version = set_meta.version();
         let set_size = set_meta.count() as usize;
@@ -459,15 +446,12 @@ impl Redis {
             return Ok(0);
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
-
-        let mut set_meta = ParsedSetsMetaValue::new(&val[..])?;
-        // Validity check (not expired and count > 0)
-        if !set_meta.is_valid() {
+        if self.is_stale(&val)? {
             // Redis SREM returns 0 for expired/invalid keys
             return Ok(0);
         }
+        self.check_type(&val, DataType::Set)?;
+        let mut set_meta = ParsedSetsMetaValue::new(&val[..])?;
 
         let version = set_meta.version();
         let mut removed_count = 0i32;
@@ -545,15 +529,12 @@ impl Redis {
             return Ok(Vec::new());
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
-
-        let mut set_meta = ParsedSetsMetaValue::new(&val[..])?;
-        // Validity check (not expired and count > 0)
-        if !set_meta.is_valid() {
+        if self.is_stale(&val)? {
             // Redis SPOP returns empty array for expired/invalid keys
             return Ok(Vec::new());
         }
+        self.check_type(&val, DataType::Set)?;
+        let mut set_meta = ParsedSetsMetaValue::new(&val[..])?;
 
         let version = set_meta.version();
         let set_size = set_meta.count() as usize;
@@ -703,14 +684,12 @@ impl Redis {
             return Ok(false);
         };
 
-        // Type check for source
-        self.check_type(&source_val, DataType::Set)?;
-
-        let mut source_meta = ParsedSetsMetaValue::new(&source_val[..])?;
-        if !source_meta.is_valid() {
+        if self.is_stale(&source_val)? {
             // Source set is expired/invalid
             return Ok(false);
         }
+        self.check_type(&source_val, DataType::Set)?;
+        let mut source_meta = ParsedSetsMetaValue::new(&source_val[..])?;
 
         let source_version = source_meta.version();
 
@@ -729,15 +708,13 @@ impl Redis {
         // Handle destination set
         let dest_meta_val = db.get_cf(&cf_meta, &dest_meta_key).context(RocksSnafu)?;
         let (mut dest_meta, dest_version, dest_exists) = if let Some(dest_val) = dest_meta_val {
-            // Type check for destination
-            self.check_type(&dest_val, DataType::Set)?;
-
             let mut meta = ParsedSetsMetaValue::new(&dest_val[..])?;
-            let version = if meta.is_valid() {
-                meta.version()
-            } else {
+            let version = if self.is_stale(&dest_val)? {
                 // Destination set is expired, create new version
                 meta.initial_meta_value()
+            } else {
+                self.check_type(&dest_val, DataType::Set)?;
+                meta.version()
             };
             (meta, version, true)
         } else {
@@ -1952,15 +1929,12 @@ impl Redis {
             return Ok(result);
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
-
-        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-        // Validity check (not expired and count > 0)
-        if !set_meta.is_valid() {
+        if self.is_stale(&val)? {
             // Return empty result for expired/invalid keys
             return Ok(result);
         }
+        self.check_type(&val, DataType::Set)?;
+        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
 
         let version = set_meta.version();
 
@@ -2046,14 +2020,12 @@ impl Redis {
             }
 
             let val = meta_val.expect("meta_val checked non-None above");
-            // Type check
-            self.check_type(&val, DataType::Set)?;
-
-            let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-            if !set_meta.is_valid() {
+            if self.is_stale(&val)? {
                 // If any set is expired/invalid, intersection is empty
                 return Ok(result);
             }
+            self.check_type(&val, DataType::Set)?;
+            let set_meta = ParsedSetsMetaValue::new(&val[..])?;
 
             let count = set_meta.count() as i32;
             if count < smallest_size {
@@ -2121,11 +2093,8 @@ impl Redis {
             let meta_val = db.get_cf(&cf_meta, &base_meta_key).context(RocksSnafu)?;
 
             if let Some(val) = meta_val {
-                // Type check
-                self.check_type(&val, DataType::Set)?;
-
-                let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-                if set_meta.is_valid() {
+                if !self.is_stale(&val)? {
+                    self.check_type(&val, DataType::Set)?;
                     // Get all members of this set and add to union
                     let members = self.smembers(key)?;
                     for member in members {
@@ -2342,15 +2311,12 @@ impl Redis {
             return Ok((0, Vec::new()));
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
-
-        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-        // Validity check (not expired and count > 0)
-        if !set_meta.is_valid() {
+        if self.is_stale(&val)? {
             // Return empty result with cursor 0 for expired/invalid keys
             return Ok((0, Vec::new()));
         }
+        self.check_type(&val, DataType::Set)?;
+        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
 
         let version = set_meta.version();
         let _set_size = set_meta.count() as usize;

--- a/src/storage/src/redis_strings.rs
+++ b/src/storage/src/redis_strings.rs
@@ -503,21 +503,19 @@ impl Redis {
                 .context(RocksSnafu)?
             {
                 Some(val) => {
-                    // Check type - if not string type, return None (like Redis does)
                     if self.check_type(val.as_slice(), DataType::String).is_err() {
                         results.push(None);
                         continue;
                     }
 
                     let string_value = ParsedStringsValue::new(&val[..])?;
-
-                    // Check if key is expired
                     if string_value.is_stale() {
                         results.push(None);
-                    } else {
-                        let user_value = string_value.user_value();
-                        results.push(Some(String::from_utf8_lossy(&user_value).to_string()));
+                        continue;
                     }
+
+                    let user_value = string_value.user_value();
+                    results.push(Some(String::from_utf8_lossy(&user_value).to_string()));
                 }
                 None => {
                     results.push(None);

--- a/src/storage/src/redis_strings.rs
+++ b/src/storage/src/redis_strings.rs
@@ -597,21 +597,19 @@ impl Redis {
                 .context(RocksSnafu)?
             {
                 Some(val) => {
-                    // Check type - if not string type, return None (like Redis does)
                     if self.check_type(val.as_slice(), DataType::String).is_err() {
                         results.push(None);
                         continue;
                     }
 
                     let string_value = ParsedStringsValue::new(&val[..])?;
-
-                    // Check if key is expired
                     if string_value.is_stale() {
                         results.push(None);
-                    } else {
-                        let user_value = string_value.user_value();
-                        results.push(Some(String::from_utf8_lossy(&user_value).to_string()));
+                        continue;
                     }
+
+                    let user_value = string_value.user_value();
+                    results.push(Some(String::from_utf8_lossy(&user_value).to_string()));
                 }
                 None => {
                     results.push(None);

--- a/src/storage/src/redis_zsets.rs
+++ b/src/storage/src/redis_zsets.rs
@@ -79,21 +79,18 @@ impl Redis {
 
         // ZSet exists, update it
         if !base_meta_val.is_empty() {
-            // Check type
-            self.check_type(&base_meta_val, DataType::ZSet)?;
-
-            // Parse existing meta
             let mut parsed_zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
             // Get version and validity
             let version;
             let valid;
-            if parsed_zset_meta.is_valid() {
-                valid = true;
-                version = parsed_zset_meta.version();
-            } else {
+            if self.is_stale(&base_meta_val)? {
                 valid = false;
                 version = parsed_zset_meta.initial_meta_value();
+            } else {
+                self.check_type(&base_meta_val, DataType::ZSet)?;
+                valid = true;
+                version = parsed_zset_meta.version();
             }
 
             // Prepare batch write
@@ -237,12 +234,11 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         *ret = zset_meta.count() as i32;
         Ok(())
@@ -270,12 +266,11 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
         let min_score_key = ZSetsScoreKey::new(key, version, min_score, &[]).encode_seek_key()?;
@@ -342,10 +337,7 @@ impl Redis {
 
         if !base_meta_val.is_empty() {
             // ZSet exists, check if member exists
-            self.check_type(&base_meta_val, DataType::ZSet)?;
-
-            let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-            if !zset_meta.is_valid() {
+            if self.is_stale(&base_meta_val)? {
                 // ZSet is invalid, treat as if it doesn't exist
                 let score_member = ScoreMember::new(new_score, member.to_vec());
                 let mut count = 0;
@@ -354,6 +346,8 @@ impl Redis {
                 *ret = format!("{}", new_score).into_bytes();
                 return Ok(());
             }
+            self.check_type(&base_meta_val, DataType::ZSet)?;
+            let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
             let version = zset_meta.version();
             let member_key = MemberDataKey::new(key, version, member).encode()?;
@@ -461,12 +455,11 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
         let member_key = MemberDataKey::new(key, version, member).encode()?;
@@ -516,12 +509,11 @@ impl Redis {
             return Ok((0, Vec::new()));
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok((0, Vec::new()));
         }
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
         let scan_count = count.unwrap_or(10);
@@ -631,12 +623,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
 
@@ -723,12 +715,11 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
 
@@ -815,12 +806,11 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
         let mut batch = self.create_batch()?;
@@ -907,12 +897,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         // Parse min and max range specifiers
         let (min_member, min_exclusive) = parse_lex_range(min)?;
@@ -995,12 +985,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let count = zset_meta.count() as i64;
         if count == 0 {
@@ -1161,17 +1151,16 @@ impl Redis {
                 continue;
             }
 
-            // Check type
-            self.check_type(&base_meta_val, DataType::ZSet)?;
-
-            let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-            if !zset_meta.is_valid() {
+            if self.is_stale(&base_meta_val)? {
                 if is_inter {
                     // For intersection, if any key is invalid, result is empty
                     return Ok(0);
                 }
                 continue;
             }
+
+            self.check_type(&base_meta_val, DataType::ZSet)?;
+            let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
             let version = zset_meta.version();
             let min_score_key =
@@ -1233,37 +1222,33 @@ impl Redis {
         let mut batch = self.create_batch()?;
 
         // Delete existing destination data if it exists
-        if !dest_meta_val.is_empty() {
+        if !dest_meta_val.is_empty() && !self.is_stale(&dest_meta_val)? {
             self.check_type(&dest_meta_val, DataType::ZSet)?;
             let dest_meta = ParsedZSetsMetaValue::new(&dest_meta_val[..])?;
-            if dest_meta.is_valid() {
-                let dest_version = dest_meta.version();
+            let dest_version = dest_meta.version();
 
-                // Delete all score keys and member keys
-                let min_score_key =
-                    ZSetsScoreKey::new(destination, dest_version, f64::NEG_INFINITY, &[])
-                        .encode_seek_key()?;
-                let iter = db.iterator_cf_opt(
-                    &cf_score,
-                    ReadOptions::default(),
-                    IteratorMode::From(&min_score_key, Direction::Forward),
-                );
+            // Delete all score keys and member keys
+            let min_score_key = ZSetsScoreKey::new(destination, dest_version, f64::NEG_INFINITY, &[])
+                .encode_seek_key()?;
+            let iter = db.iterator_cf_opt(
+                &cf_score,
+                ReadOptions::default(),
+                IteratorMode::From(&min_score_key, Direction::Forward),
+            );
 
-                for item in iter {
-                    let (raw_key, _) = item.context(RocksSnafu)?;
-                    let score_key = ParsedZSetsScoreKey::new(&raw_key)?;
+            for item in iter {
+                let (raw_key, _) = item.context(RocksSnafu)?;
+                let score_key = ParsedZSetsScoreKey::new(&raw_key)?;
 
-                    if destination != score_key.key() || dest_version != score_key.version() {
-                        break;
-                    }
-
-                    // Delete score key and member key
-                    batch.delete(ColumnFamilyIndex::ZsetsScoreCF, &raw_key)?;
-                    let member_key =
-                        MemberDataKey::new(destination, dest_version, score_key.member())
-                            .encode()?;
-                    batch.delete(ColumnFamilyIndex::ZsetsDataCF, &member_key)?;
+                if destination != score_key.key() || dest_version != score_key.version() {
+                    break;
                 }
+
+                // Delete score key and member key
+                batch.delete(ColumnFamilyIndex::ZsetsScoreCF, &raw_key)?;
+                let member_key =
+                    MemberDataKey::new(destination, dest_version, score_key.member()).encode()?;
+                batch.delete(ColumnFamilyIndex::ZsetsDataCF, &member_key)?;
             }
         }
 
@@ -1347,12 +1332,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         // Parse min and max range specifiers
         let (min_member, min_exclusive) = parse_lex_range(min)?;
@@ -1447,12 +1432,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
         let min_score_key = ZSetsScoreKey::new(key, version, min_score, &[]).encode_seek_key()?;
@@ -1530,12 +1515,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let (min_member, min_exclusive) = parse_lex_range(min)?;
         let (max_member, max_exclusive) = parse_lex_range(max)?;
@@ -1639,12 +1624,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let count = zset_meta.count() as i64;
         if count == 0 {
@@ -1769,12 +1754,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
         let min_score_key = ZSetsScoreKey::new(key, version, min_score, &[]).encode_seek_key()?;
@@ -1869,12 +1854,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let count = zset_meta.count() as i64;
         if count == 0 {
@@ -1968,12 +1953,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
         // Start from a position slightly above max_score to ensure we include max_score

--- a/src/storage/src/redis_zsets.rs
+++ b/src/storage/src/redis_zsets.rs
@@ -79,16 +79,17 @@ impl Redis {
 
         // ZSet exists, update it
         if !base_meta_val.is_empty() {
-            let mut parsed_zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-
             // Get version and validity
             let version;
             let valid;
+            let mut parsed_zset_meta;
             if self.is_stale(&base_meta_val)? {
+                parsed_zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
                 valid = false;
                 version = parsed_zset_meta.initial_meta_value();
             } else {
                 self.check_type(&base_meta_val, DataType::ZSet)?;
+                parsed_zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
                 valid = true;
                 version = parsed_zset_meta.version();
             }
@@ -1132,6 +1133,7 @@ impl Redis {
         // Collect all members and their scores from each zset
         use std::collections::HashMap;
         let mut member_scores: HashMap<Vec<u8>, Vec<Option<f64>>> = HashMap::new();
+        let mut result_empty = false;
 
         for (idx, key) in keys.iter().enumerate() {
             let base_meta_key = BaseMetaKey::new(key);
@@ -1141,20 +1143,19 @@ impl Redis {
                 .unwrap_or_else(Vec::new);
 
             if base_meta_val.is_empty() {
-                // Key doesn't exist
                 if is_inter {
                     // For intersection, if any key is missing, result is empty
-                    // Delete destination by setting count to 0 (handled below)
-                    return Ok(0);
+                    result_empty = true;
+                    break;
                 }
-                // For union, mark all members from this key as None
                 continue;
             }
 
             if self.is_stale(&base_meta_val)? {
                 if is_inter {
                     // For intersection, if any key is invalid, result is empty
-                    return Ok(0);
+                    result_empty = true;
+                    break;
                 }
                 continue;
             }
@@ -1190,6 +1191,10 @@ impl Redis {
             }
         }
 
+        if result_empty {
+            member_scores.clear();
+        }
+
         // Filter members based on operation type and compute final scores
         let mut result_members: Vec<ScoreMember> = Vec::new();
 
@@ -1221,9 +1226,11 @@ impl Redis {
 
         let mut batch = self.create_batch()?;
 
-        // Delete existing destination data if it exists
-        if !dest_meta_val.is_empty() && !self.is_stale(&dest_meta_val)? {
-            self.check_type(&dest_meta_val, DataType::ZSet)?;
+        // Delete existing destination data if it is a live ZSet
+        if !dest_meta_val.is_empty()
+            && !self.is_stale(&dest_meta_val)?
+            && dest_meta_val.first().copied() == Some(DataType::ZSet as u8)
+        {
             let dest_meta = ParsedZSetsMetaValue::new(&dest_meta_val[..])?;
             let dest_version = dest_meta.version();
 

--- a/src/storage/src/redis_zsets.rs
+++ b/src/storage/src/redis_zsets.rs
@@ -1228,8 +1228,9 @@ impl Redis {
             let dest_version = dest_meta.version();
 
             // Delete all score keys and member keys
-            let min_score_key = ZSetsScoreKey::new(destination, dest_version, f64::NEG_INFINITY, &[])
-                .encode_seek_key()?;
+            let min_score_key =
+                ZSetsScoreKey::new(destination, dest_version, f64::NEG_INFINITY, &[])
+                    .encode_seek_key()?;
             let iter = db.iterator_cf_opt(
                 &cf_score,
                 ReadOptions::default(),

--- a/src/storage/src/redis_zsets.rs
+++ b/src/storage/src/redis_zsets.rs
@@ -79,16 +79,17 @@ impl Redis {
 
         // ZSet exists, update it
         if !base_meta_val.is_empty() {
-            let mut parsed_zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-
             // Get version and validity
             let version;
             let valid;
+            let mut parsed_zset_meta;
             if self.is_stale(&base_meta_val)? {
+                parsed_zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
                 valid = false;
                 version = parsed_zset_meta.initial_meta_value();
             } else {
                 self.check_type(&base_meta_val, DataType::ZSet)?;
+                parsed_zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
                 valid = true;
                 version = parsed_zset_meta.version();
             }
@@ -1119,6 +1120,7 @@ impl Redis {
         // Collect all members and their scores from each zset
         use std::collections::HashMap;
         let mut member_scores: HashMap<Vec<u8>, Vec<Option<f64>>> = HashMap::new();
+        let mut result_empty = false;
 
         for (idx, key) in keys.iter().enumerate() {
             let base_meta_key = BaseMetaKey::new(key);
@@ -1128,20 +1130,19 @@ impl Redis {
                 .unwrap_or_else(Vec::new);
 
             if base_meta_val.is_empty() {
-                // Key doesn't exist
                 if is_inter {
                     // For intersection, if any key is missing, result is empty
-                    // Delete destination by setting count to 0 (handled below)
-                    return Ok(0);
+                    result_empty = true;
+                    break;
                 }
-                // For union, mark all members from this key as None
                 continue;
             }
 
             if self.is_stale(&base_meta_val)? {
                 if is_inter {
                     // For intersection, if any key is invalid, result is empty
-                    return Ok(0);
+                    result_empty = true;
+                    break;
                 }
                 continue;
             }
@@ -1177,6 +1178,10 @@ impl Redis {
             }
         }
 
+        if result_empty {
+            member_scores.clear();
+        }
+
         // Filter members based on operation type and compute final scores
         let mut result_members: Vec<ScoreMember> = Vec::new();
 
@@ -1208,9 +1213,11 @@ impl Redis {
 
         let mut batch = self.create_batch()?;
 
-        // Delete existing destination data if it exists
-        if !dest_meta_val.is_empty() && !self.is_stale(&dest_meta_val)? {
-            self.check_type(&dest_meta_val, DataType::ZSet)?;
+        // Delete existing destination data if it is a live ZSet
+        if !dest_meta_val.is_empty()
+            && !self.is_stale(&dest_meta_val)?
+            && dest_meta_val.first().copied() == Some(DataType::ZSet as u8)
+        {
             let dest_meta = ParsedZSetsMetaValue::new(&dest_meta_val[..])?;
             let dest_version = dest_meta.version();
 

--- a/src/storage/src/redis_zsets.rs
+++ b/src/storage/src/redis_zsets.rs
@@ -84,7 +84,13 @@ impl Redis {
             let valid;
             let mut parsed_zset_meta;
             if self.is_stale(&base_meta_val)? {
-                parsed_zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
+                // Build a fresh ZSet meta so the persisted type byte is ZSet
+                // regardless of what type the expired value held.
+                let mut fresh =
+                    ZSetsMetaValue::new(bytes::Bytes::copy_from_slice(&0u64.to_le_bytes()));
+                fresh.inner.data_type = DataType::ZSet;
+                let encoded = fresh.encode();
+                parsed_zset_meta = ParsedZSetsMetaValue::new(encoded)?;
                 valid = false;
                 version = parsed_zset_meta.initial_meta_value();
             } else {

--- a/src/storage/src/redis_zsets.rs
+++ b/src/storage/src/redis_zsets.rs
@@ -79,21 +79,18 @@ impl Redis {
 
         // ZSet exists, update it
         if !base_meta_val.is_empty() {
-            // Check type
-            self.check_type(&base_meta_val, DataType::ZSet)?;
-
-            // Parse existing meta
             let mut parsed_zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
             // Get version and validity
             let version;
             let valid;
-            if parsed_zset_meta.is_valid() {
-                valid = true;
-                version = parsed_zset_meta.version();
-            } else {
+            if self.is_stale(&base_meta_val)? {
                 valid = false;
                 version = parsed_zset_meta.initial_meta_value();
+            } else {
+                self.check_type(&base_meta_val, DataType::ZSet)?;
+                valid = true;
+                version = parsed_zset_meta.version();
             }
 
             // Prepare batch write
@@ -237,12 +234,11 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         *ret = zset_meta.count() as i32;
         Ok(())
@@ -270,12 +266,11 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
         let min_score_key = ZSetsScoreKey::new(key, version, min_score, &[]).encode_seek_key()?;
@@ -342,10 +337,7 @@ impl Redis {
 
         if !base_meta_val.is_empty() {
             // ZSet exists, check if member exists
-            self.check_type(&base_meta_val, DataType::ZSet)?;
-
-            let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-            if !zset_meta.is_valid() {
+            if self.is_stale(&base_meta_val)? {
                 // ZSet is invalid, treat as if it doesn't exist
                 let score_member = ScoreMember::new(new_score, member.to_vec());
                 let mut count = 0;
@@ -354,6 +346,8 @@ impl Redis {
                 *ret = format!("{}", new_score).into_bytes();
                 return Ok(());
             }
+            self.check_type(&base_meta_val, DataType::ZSet)?;
+            let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
             let version = zset_meta.version();
             let member_key = MemberDataKey::new(key, version, member).encode()?;
@@ -461,12 +455,11 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
         let member_key = MemberDataKey::new(key, version, member).encode()?;
@@ -516,12 +509,11 @@ impl Redis {
             return Ok((0, Vec::new()));
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok((0, Vec::new()));
         }
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
         let scan_count = count.unwrap_or(10);
@@ -618,12 +610,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
 
@@ -710,12 +702,11 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
 
@@ -802,12 +793,11 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
         let mut batch = self.create_batch()?;
@@ -894,12 +884,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         // Parse min and max range specifiers
         let (min_member, min_exclusive) = parse_lex_range(min)?;
@@ -982,12 +972,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let count = zset_meta.count() as i64;
         if count == 0 {
@@ -1148,17 +1138,16 @@ impl Redis {
                 continue;
             }
 
-            // Check type
-            self.check_type(&base_meta_val, DataType::ZSet)?;
-
-            let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-            if !zset_meta.is_valid() {
+            if self.is_stale(&base_meta_val)? {
                 if is_inter {
                     // For intersection, if any key is invalid, result is empty
                     return Ok(0);
                 }
                 continue;
             }
+
+            self.check_type(&base_meta_val, DataType::ZSet)?;
+            let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
             let version = zset_meta.version();
             let min_score_key =
@@ -1220,37 +1209,33 @@ impl Redis {
         let mut batch = self.create_batch()?;
 
         // Delete existing destination data if it exists
-        if !dest_meta_val.is_empty() {
+        if !dest_meta_val.is_empty() && !self.is_stale(&dest_meta_val)? {
             self.check_type(&dest_meta_val, DataType::ZSet)?;
             let dest_meta = ParsedZSetsMetaValue::new(&dest_meta_val[..])?;
-            if dest_meta.is_valid() {
-                let dest_version = dest_meta.version();
+            let dest_version = dest_meta.version();
 
-                // Delete all score keys and member keys
-                let min_score_key =
-                    ZSetsScoreKey::new(destination, dest_version, f64::NEG_INFINITY, &[])
-                        .encode_seek_key()?;
-                let iter = db.iterator_cf_opt(
-                    &cf_score,
-                    ReadOptions::default(),
-                    IteratorMode::From(&min_score_key, Direction::Forward),
-                );
+            // Delete all score keys and member keys
+            let min_score_key = ZSetsScoreKey::new(destination, dest_version, f64::NEG_INFINITY, &[])
+                .encode_seek_key()?;
+            let iter = db.iterator_cf_opt(
+                &cf_score,
+                ReadOptions::default(),
+                IteratorMode::From(&min_score_key, Direction::Forward),
+            );
 
-                for item in iter {
-                    let (raw_key, _) = item.context(RocksSnafu)?;
-                    let score_key = ParsedZSetsScoreKey::new(&raw_key)?;
+            for item in iter {
+                let (raw_key, _) = item.context(RocksSnafu)?;
+                let score_key = ParsedZSetsScoreKey::new(&raw_key)?;
 
-                    if destination != score_key.key() || dest_version != score_key.version() {
-                        break;
-                    }
-
-                    // Delete score key and member key
-                    batch.delete(ColumnFamilyIndex::ZsetsScoreCF, &raw_key)?;
-                    let member_key =
-                        MemberDataKey::new(destination, dest_version, score_key.member())
-                            .encode()?;
-                    batch.delete(ColumnFamilyIndex::ZsetsDataCF, &member_key)?;
+                if destination != score_key.key() || dest_version != score_key.version() {
+                    break;
                 }
+
+                // Delete score key and member key
+                batch.delete(ColumnFamilyIndex::ZsetsScoreCF, &raw_key)?;
+                let member_key =
+                    MemberDataKey::new(destination, dest_version, score_key.member()).encode()?;
+                batch.delete(ColumnFamilyIndex::ZsetsDataCF, &member_key)?;
             }
         }
 
@@ -1334,12 +1319,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         // Parse min and max range specifiers
         let (min_member, min_exclusive) = parse_lex_range(min)?;
@@ -1434,12 +1419,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
         let min_score_key = ZSetsScoreKey::new(key, version, min_score, &[]).encode_seek_key()?;
@@ -1517,12 +1502,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let (min_member, min_exclusive) = parse_lex_range(min)?;
         let (max_member, max_exclusive) = parse_lex_range(max)?;
@@ -1626,12 +1611,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let count = zset_meta.count() as i64;
         if count == 0 {
@@ -1756,12 +1741,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
         let min_score_key = ZSetsScoreKey::new(key, version, min_score, &[]).encode_seek_key()?;
@@ -1856,12 +1841,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let count = zset_meta.count() as i64;
         if count == 0 {
@@ -1955,12 +1940,12 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
-
-        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-        if !zset_meta.is_valid() {
+        if self.is_stale(&base_meta_val)? {
             return Ok(());
         }
+
+        self.check_type(&base_meta_val, DataType::ZSet)?;
+        let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
         let version = zset_meta.version();
         // Start from a position slightly above max_score to ensure we include max_score

--- a/src/storage/src/redis_zsets.rs
+++ b/src/storage/src/redis_zsets.rs
@@ -1215,8 +1215,9 @@ impl Redis {
             let dest_version = dest_meta.version();
 
             // Delete all score keys and member keys
-            let min_score_key = ZSetsScoreKey::new(destination, dest_version, f64::NEG_INFINITY, &[])
-                .encode_seek_key()?;
+            let min_score_key =
+                ZSetsScoreKey::new(destination, dest_version, f64::NEG_INFINITY, &[])
+                    .encode_seek_key()?;
             let iter = db.iterator_cf_opt(
                 &cf_score,
                 ReadOptions::default(),

--- a/src/storage/tests/redis_set_test.rs
+++ b/src/storage/tests/redis_set_test.rs
@@ -153,6 +153,35 @@ mod redis_set_test {
     }
 
     #[test]
+    fn test_scard_wrong_type_returns_wrongtype_for_live_string() {
+        let test_db_path = unique_test_db_path();
+
+        safe_cleanup_test_db(&test_db_path);
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+
+        let result = redis.open(test_db_path.to_str().unwrap());
+        assert!(result.is_ok(), "open redis db failed: {:?}", result.err());
+
+        let key = b"set_wrongtype_live_short";
+        redis.set(key, b"x").expect("set failed");
+
+        let err = redis.scard(key).unwrap_err().to_string();
+        assert!(
+            err.contains("WRONGTYPE"),
+            "expected WRONGTYPE, got: {err}"
+        );
+
+        redis.set_need_close(true);
+        drop(redis);
+
+        safe_cleanup_test_db(&test_db_path);
+    }
+
+    #[test]
     fn test_sadd_to_existing_set() {
         let test_db_path = unique_test_db_path();
 

--- a/src/storage/tests/redis_set_test.rs
+++ b/src/storage/tests/redis_set_test.rs
@@ -170,10 +170,7 @@ mod redis_set_test {
         redis.set(key, b"x").expect("set failed");
 
         let err = redis.scard(key).unwrap_err().to_string();
-        assert!(
-            err.contains("WRONGTYPE"),
-            "expected WRONGTYPE, got: {err}"
-        );
+        assert!(err.contains("WRONGTYPE"), "expected WRONGTYPE, got: {err}");
 
         redis.set_need_close(true);
         drop(redis);

--- a/src/storage/tests/redis_set_test.rs
+++ b/src/storage/tests/redis_set_test.rs
@@ -179,6 +179,94 @@ mod redis_set_test {
     }
 
     #[test]
+    fn test_smove_basic_moves_member_between_sets() {
+        let test_db_path = unique_test_db_path();
+
+        safe_cleanup_test_db(&test_db_path);
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+
+        let result = redis.open(test_db_path.to_str().unwrap());
+        assert!(result.is_ok(), "open redis db failed: {:?}", result.err());
+
+        let src = b"smove_basic_src";
+        let dst = b"smove_basic_dst";
+
+        let src_members: Vec<&[u8]> = vec![b"a".as_ref(), b"b".as_ref()];
+        redis.sadd(src, &src_members).expect("sadd src failed");
+
+        let dst_members: Vec<&[u8]> = vec![b"x".as_ref()];
+        redis.sadd(dst, &dst_members).expect("sadd dst failed");
+
+        // Move "a" from src -> dst.
+        let moved = redis.smove(src, dst, b"a").expect("smove failed");
+        assert!(moved, "smove should report success when member moves");
+
+        // src should now contain only "b".
+        let mut src_after = redis.smembers(src).expect("smembers src failed");
+        src_after.sort();
+        assert_eq!(src_after, vec!["b".to_string()]);
+
+        // dst should now contain "a" and "x".
+        let mut dst_after = redis.smembers(dst).expect("smembers dst failed");
+        dst_after.sort();
+        assert_eq!(dst_after, vec!["a".to_string(), "x".to_string()]);
+
+        // Counts updated.
+        assert_eq!(redis.scard(src).expect("scard src"), 1);
+        assert_eq!(redis.scard(dst).expect("scard dst"), 2);
+
+        // Moving a non-existent member is a no-op (returns false).
+        let missing = redis.smove(src, dst, b"never").expect("smove missing");
+        assert!(
+            !missing,
+            "smove should report false for missing source member"
+        );
+
+        redis.set_need_close(true);
+        drop(redis);
+
+        safe_cleanup_test_db(&test_db_path);
+    }
+
+    #[test]
+    fn test_smove_dest_wrong_type_returns_wrongtype_for_short_string() {
+        let test_db_path = unique_test_db_path();
+
+        safe_cleanup_test_db(&test_db_path);
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+
+        let result = redis.open(test_db_path.to_str().unwrap());
+        assert!(result.is_ok(), "open redis db failed: {:?}", result.err());
+
+        // Set up a real source set with one member.
+        let src = b"smove_src";
+        let src_members: Vec<&[u8]> = vec![b"m1".as_ref()];
+        redis.sadd(src, &src_members).expect("sadd failed");
+
+        // Destination is a live, short (<16 byte) string. Its encoded length is
+        // smaller than BASE_META_VALUE_LENGTH, so parsing it as Set meta fails
+        // before any type check fires unless SMOVE gates on staleness/type first.
+        let dst = b"smove_dst_short";
+        redis.set(dst, b"x").expect("set failed");
+
+        let err = redis.smove(src, dst, b"m1").unwrap_err().to_string();
+        assert!(err.contains("WRONGTYPE"), "expected WRONGTYPE, got: {err}");
+
+        redis.set_need_close(true);
+        drop(redis);
+
+        safe_cleanup_test_db(&test_db_path);
+    }
+
+    #[test]
     fn test_sadd_to_existing_set() {
         let test_db_path = unique_test_db_path();
 

--- a/src/storage/tests/redis_string_test.rs
+++ b/src/storage/tests/redis_string_test.rs
@@ -350,11 +350,7 @@ mod redis_string_test {
             .hset(hash_key, b"field", b"value")
             .expect("hset failed");
 
-        let keys = vec![
-            string_key.to_vec(),
-            hash_key.to_vec(),
-            missing_key.to_vec(),
-        ];
+        let keys = vec![string_key.to_vec(), hash_key.to_vec(), missing_key.to_vec()];
         let values = redis.mget(&keys).expect("mget failed");
 
         assert_eq!(values.len(), 3);

--- a/src/storage/tests/redis_string_test.rs
+++ b/src/storage/tests/redis_string_test.rs
@@ -328,6 +328,47 @@ mod redis_string_test {
     }
 
     #[test]
+    fn test_redis_mget_wrong_type_returns_nil_entry() {
+        let test_db_path = unique_test_db_path();
+
+        safe_cleanup_test_db(&test_db_path);
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+
+        let result = redis.open(test_db_path.to_str().unwrap());
+        assert!(result.is_ok(), "open redis db failed: {:?}", result.err());
+
+        let string_key = b"mget_string_key";
+        let hash_key = b"mget_hash_key";
+        let missing_key = b"mget_missing_key";
+
+        redis.set(string_key, b"value").expect("set failed");
+        redis
+            .hset(hash_key, b"field", b"value")
+            .expect("hset failed");
+
+        let keys = vec![
+            string_key.to_vec(),
+            hash_key.to_vec(),
+            missing_key.to_vec(),
+        ];
+        let values = redis.mget(&keys).expect("mget failed");
+
+        assert_eq!(values.len(), 3);
+        assert_eq!(values[0], Some("value".to_string()));
+        assert_eq!(values[1], None);
+        assert_eq!(values[2], None);
+
+        redis.set_need_close(true);
+        drop(redis);
+
+        safe_cleanup_test_db(&test_db_path);
+    }
+
+    #[test]
     fn test_redis_setrange_with_binary() {
         let test_db_path = unique_test_db_path();
 

--- a/src/storage/tests/redis_zset_test.rs
+++ b/src/storage/tests/redis_zset_test.rs
@@ -87,6 +87,21 @@ mod redis_zset_test {
     }
 
     #[test]
+    fn test_zcard_wrong_type_returns_wrongtype_for_live_string() {
+        let redis = create_test_redis();
+        let key = b"zset_wrongtype_live_short";
+
+        redis.set(key, b"x").unwrap();
+
+        let mut card = 0;
+        let err = redis.zcard(key, &mut card).unwrap_err().to_string();
+        assert!(
+            err.contains("WRONGTYPE"),
+            "expected WRONGTYPE, got: {err}"
+        );
+    }
+
+    #[test]
     fn test_zscan_basic() {
         let redis = create_test_redis();
         let key = b"test_zset";

--- a/src/storage/tests/redis_zset_test.rs
+++ b/src/storage/tests/redis_zset_test.rs
@@ -95,10 +95,7 @@ mod redis_zset_test {
 
         let mut card = 0;
         let err = redis.zcard(key, &mut card).unwrap_err().to_string();
-        assert!(
-            err.contains("WRONGTYPE"),
-            "expected WRONGTYPE, got: {err}"
-        );
+        assert!(err.contains("WRONGTYPE"), "expected WRONGTYPE, got: {err}");
     }
 
     #[test]

--- a/src/storage/tests/redis_zset_test.rs
+++ b/src/storage/tests/redis_zset_test.rs
@@ -23,8 +23,8 @@ mod redis_zset_test {
     use bytes::Bytes;
     use kstd::lock_mgr::LockMgr;
     use rocksdb::{IteratorMode, ReadOptions};
-    use storage::base_meta_value_format::HashesMetaValue;
-    use storage::base_value_format::DataType;
+    use storage::format_base_meta_value::HashesMetaValue;
+    use storage::format_base_value::DataType;
     use storage::{
         BaseMetaKey, BgTaskHandler, ColumnFamilyIndex, Redis, ScoreMember, StorageOptions,
         safe_cleanup_test_db, unique_test_db_path,

--- a/src/storage/tests/redis_zset_test.rs
+++ b/src/storage/tests/redis_zset_test.rs
@@ -18,10 +18,11 @@
 #![allow(clippy::unwrap_used)]
 
 mod redis_zset_test {
+    use std::sync::Arc;
+
     use bytes::Bytes;
     use kstd::lock_mgr::LockMgr;
     use rocksdb::{IteratorMode, ReadOptions};
-    use std::sync::Arc;
     use storage::base_meta_value_format::HashesMetaValue;
     use storage::base_value_format::DataType;
     use storage::{
@@ -1920,5 +1921,71 @@ mod redis_zset_test {
         let mut card = 0;
         redis.zcard(key, &mut card).unwrap();
         assert_eq!(card, 2);
+    }
+
+    #[test]
+    fn test_zinterstore_dest_live_wrong_type_is_overwritten() {
+        let redis = create_test_redis();
+
+        let key1 = b"zinter_dest_wt_src1";
+        let key2 = b"zinter_dest_wt_src2";
+        let dest = b"zinter_dest_live_string";
+
+        // Destination is a live string key (wrong type).
+        redis.set(dest, b"live_string_value").unwrap();
+
+        let score_members1 = vec![ScoreMember::new(1.0, b"a".to_vec())];
+        let score_members2 = vec![ScoreMember::new(2.0, b"a".to_vec())];
+        let mut ret = 0;
+        redis.zadd(key1, &score_members1, &mut ret).unwrap();
+        redis.zadd(key2, &score_members2, &mut ret).unwrap();
+
+        // ZINTERSTORE must overwrite the live string destination without WRONGTYPE.
+        let keys = vec![key1.to_vec(), key2.to_vec()];
+        let mut count = 0;
+        redis
+            .zinterstore(dest, &keys, &[], "SUM", &mut count)
+            .unwrap();
+        assert_eq!(count, 1);
+
+        let mut score = None;
+        redis.zscore(dest, b"a", &mut score).unwrap();
+        assert_eq!(String::from_utf8(score.unwrap()).unwrap(), "3");
+    }
+
+    #[test]
+    fn test_zunionstore_dest_stale_wrong_type_is_overwritten() {
+        let redis = create_test_redis();
+
+        let key1 = b"zunion_dest_wt_src1";
+        let dest = b"zunion_dest_stale_hash";
+
+        // Inject an expired Hash meta as destination (etime=1 is in the past).
+        let mut hash_meta = HashesMetaValue::new(Bytes::copy_from_slice(&5u64.to_le_bytes()));
+        hash_meta.inner.data_type = DataType::Hash;
+        hash_meta.set_etime(1);
+        let meta_bytes = hash_meta.encode();
+        {
+            let db = redis.db.as_ref().unwrap();
+            let cf = redis.get_cf_handle(ColumnFamilyIndex::MetaCF).unwrap();
+            let encoded_key = BaseMetaKey::new(dest).encode().unwrap();
+            db.put_cf(&cf, &encoded_key, &meta_bytes[..]).unwrap();
+        }
+
+        let score_members1 = vec![ScoreMember::new(1.0, b"a".to_vec())];
+        let mut ret = 0;
+        redis.zadd(key1, &score_members1, &mut ret).unwrap();
+
+        // ZUNIONSTORE must treat stale destination as absent and succeed.
+        let keys = vec![key1.to_vec()];
+        let mut count = 0;
+        redis
+            .zunionstore(dest, &keys, &[], "SUM", &mut count)
+            .unwrap();
+        assert_eq!(count, 1);
+
+        let mut score = None;
+        redis.zscore(dest, b"a", &mut score).unwrap();
+        assert_eq!(String::from_utf8(score.unwrap()).unwrap(), "1");
     }
 }

--- a/src/storage/tests/redis_zset_test.rs
+++ b/src/storage/tests/redis_zset_test.rs
@@ -18,12 +18,15 @@
 #![allow(clippy::unwrap_used)]
 
 mod redis_zset_test {
+    use bytes::Bytes;
     use kstd::lock_mgr::LockMgr;
     use rocksdb::{IteratorMode, ReadOptions};
     use std::sync::Arc;
+    use storage::base_meta_value_format::HashesMetaValue;
+    use storage::base_value_format::DataType;
     use storage::{
-        BgTaskHandler, ColumnFamilyIndex, Redis, ScoreMember, StorageOptions, safe_cleanup_test_db,
-        unique_test_db_path,
+        BaseMetaKey, BgTaskHandler, ColumnFamilyIndex, Redis, ScoreMember, StorageOptions,
+        safe_cleanup_test_db, unique_test_db_path,
     };
 
     fn create_test_redis() -> Redis {
@@ -97,6 +100,37 @@ mod redis_zset_test {
         let mut card = 0;
         let err = redis.zcard(key, &mut card).unwrap_err().to_string();
         assert!(err.contains("WRONGTYPE"), "expected WRONGTYPE, got: {err}");
+    }
+
+    #[test]
+    fn test_zadd_on_stale_wrong_type_treats_key_as_absent() {
+        let redis = create_test_redis();
+        let key = b"zadd_stale_wrong_type";
+
+        // Inject an expired Hash meta directly: type=Hash, count=5, etime=1 (in the past).
+        // is_stale() short-circuits to true on count==0, so we set count>0 to exercise
+        // the etime-based stale path that mirrors a key whose TTL has elapsed.
+        let mut hash_meta = HashesMetaValue::new(Bytes::copy_from_slice(&5u64.to_le_bytes()));
+        hash_meta.inner.data_type = DataType::Hash;
+        hash_meta.set_etime(1);
+        let meta_bytes = hash_meta.encode();
+        {
+            let db = redis.db.as_ref().unwrap();
+            let cf = redis.get_cf_handle(ColumnFamilyIndex::MetaCF).unwrap();
+            let encoded_key = BaseMetaKey::new(key).encode().unwrap();
+            db.put_cf(&cf, &encoded_key, &meta_bytes[..]).unwrap();
+        }
+
+        // ZADD should treat the expired hash key as absent and create a fresh zset.
+        let score_members = vec![ScoreMember::new(1.0, b"m1".to_vec())];
+        let mut ret = 0;
+        redis.zadd(key, &score_members, &mut ret).unwrap();
+        assert_eq!(ret, 1);
+
+        // ZCARD must succeed (not WRONGTYPE) because the meta should now be tagged ZSet.
+        let mut card = 0;
+        redis.zcard(key, &mut card).unwrap();
+        assert_eq!(card, 1);
     }
 
     #[test]

--- a/src/storage/tests/redis_zset_test.rs
+++ b/src/storage/tests/redis_zset_test.rs
@@ -88,6 +88,21 @@ mod redis_zset_test {
     }
 
     #[test]
+    fn test_zcard_wrong_type_returns_wrongtype_for_live_string() {
+        let redis = create_test_redis();
+        let key = b"zset_wrongtype_live_short";
+
+        redis.set(key, b"x").unwrap();
+
+        let mut card = 0;
+        let err = redis.zcard(key, &mut card).unwrap_err().to_string();
+        assert!(
+            err.contains("WRONGTYPE"),
+            "expected WRONGTYPE, got: {err}"
+        );
+    }
+
+    #[test]
     fn test_zscan_basic() {
         let redis = create_test_redis();
         let key = b"test_zset";

--- a/src/storage/tests/redis_zset_test.rs
+++ b/src/storage/tests/redis_zset_test.rs
@@ -96,10 +96,7 @@ mod redis_zset_test {
 
         let mut card = 0;
         let err = redis.zcard(key, &mut card).unwrap_err().to_string();
-        assert!(
-            err.contains("WRONGTYPE"),
-            "expected WRONGTYPE, got: {err}"
-        );
+        assert!(err.contains("WRONGTYPE"), "expected WRONGTYPE, got: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Reorder type checks to occur after stale validation across set, string, and sorted-set operations, ensuring correct `WRONGTYPE` responses for live non-matching keys while treating stale keys as non-existent.

### Key changes

- **Reorder stale/type check flow (set, zset)**: Replace `is_valid()` with centralized `self.is_stale()` gating, and move `check_type()` to after staleness validation. This ensures stale keys are treated as absent before any type check runs.
- **Fix zadd meta parsing order**: Move `ParsedZSetsMetaValue::new()` after `is_stale()`/`check_type()` to prevent wrong error for non-ZSet keys.
- **Fix ZINTERSTORE/ZUNIONSTORE destination cleanup**: Replace early `return Ok(0)` with a flag + break so the destination lock and cleanup logic always executes, preventing stale destination data from surviving.
- **Fix ZINTERSTORE/ZUNIONSTORE destination type check**: Remove `check_type` on destination key — per Redis semantics, store commands overwrite the destination regardless of its current type.
- **Fix mget for expired entries**: Short-circuit on stale values, returning `None` without attempting UTF-8 decode.

### Tests added

- `scard` returns `WRONGTYPE` for a live string key
- `zcard` returns `WRONGTYPE` for a live string key
- `mget` returns `None` for wrong-type and missing keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently treat expired/stale keys as absent across set and sorted-set operations, yielding empty results or not-found errors and avoiding unnecessary parsing.
  * Fix move/merge behaviors to correctly handle stale destinations and preserve member encoding.
  * Short-circuit string multi-get to skip decoding for expired keys.

* **Tests**
  * Added integration tests covering type-mismatch, move semantics, expired-key handling, and multi-key retrieval behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->