### PR TITLE
feat(raft): add versioned proto definitions (kiwi.raft.v1)

### DIFF
--- a/src/raft/build.rs
+++ b/src/raft/build.rs
@@ -1,0 +1,37 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
+    tonic_prost_build::configure()
+        .file_descriptor_set_path(out_dir.join("kiwi.raft.v1_descriptor.bin"))
+        .build_server(true)
+        .build_client(true)
+        .compile_protos(
+            &[
+                "proto/types.proto",
+                "proto/raft.proto",
+                "proto/admin.proto",
+                "proto/client.proto",
+            ],
+            &["proto"],
+        )?;
+    Ok(())
+}

--- a/src/raft/proto/admin.proto
+++ b/src/raft/proto/admin.proto
@@ -1,0 +1,81 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+// 版本化包名
+//
+// 版本历史：
+// - v1: 初始版本，支持基本的 Raft RPC
+// - 未来版本变更将在 ChangeLog 中记录
+package kiwi.raft.v1;
+
+import "types.proto";
+
+// RaftAdminService - 集群管理服务
+service RaftAdminService {
+    // 初始化集群
+    rpc Initialize (InitializeRequest) returns (InitializeResponse);
+
+    // 添加学习者节点
+    rpc AddLearner (AddLearnerRequest) returns (AddLearnerResponse);
+
+    // 修改集群成员
+    rpc ChangeMembership (ChangeMembershipRequest) returns (ChangeMembershipResponse);
+
+    // 移除节点
+    rpc RemoveNode (RemoveNodeRequest) returns (RemoveNodeResponse);
+}
+
+// Initialize - 初始化集群
+message InitializeRequest {
+    repeated NodeConfig nodes = 1;
+}
+
+message InitializeResponse {
+    Response response = 1;
+    uint64 leader_id = 2;
+}
+
+// AddLearner - 添加学习者节点
+message AddLearnerRequest {
+    uint64 node_id = 1;
+    NodeConfig node = 2;
+}
+
+message AddLearnerResponse {
+    Response response = 1;
+}
+
+// ChangeMembership - 修改集群成员
+message ChangeMembershipRequest {
+    repeated NodeConfig members = 1;
+    bool retain = 2;
+}
+
+message ChangeMembershipResponse {
+    Response response = 1;
+}
+
+// RemoveNode - 移除节点
+message RemoveNodeRequest {
+    uint64 node_id = 1;
+}
+
+message RemoveNodeResponse {
+    Response response = 1;
+}

--- a/src/raft/proto/client.proto
+++ b/src/raft/proto/client.proto
@@ -1,0 +1,93 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+// 版本化包名
+//
+// 版本历史：
+// - v1: 初始版本，支持基本的 Raft RPC
+// - 未来版本变更将在 ChangeLog 中记录
+package kiwi.raft.v1;
+
+import "types.proto";
+
+// RaftClientService - 客户端服务
+service RaftClientService {
+    // 写入数据（通过 Raft 共识）
+    rpc Write (WriteRequest) returns (WriteResponse);
+
+    // 读取数据
+    rpc Read (ReadRequest) returns (ReadResponse);
+}
+
+// RaftMetricsService - 集群状态服务
+service RaftMetricsService {
+    // 获取集群指标
+    rpc Metrics (MetricsRequest) returns (MetricsResponse);
+
+    // 获取 Leader 信息
+    rpc Leader (LeaderRequest) returns (LeaderResponse);
+
+    // 获取集群成员列表
+    rpc Members (MembersRequest) returns (MembersResponse);
+}
+
+// Write / Read - 客户端读写
+message WriteRequest {
+    Binlog binlog = 1;
+}
+
+message WriteResponse {
+    Response response = 1;
+    LogId log_id = 2;
+}
+
+message ReadRequest {
+    bytes key = 1;
+}
+
+message ReadResponse {
+    Response response = 1;
+    bytes value = 2;
+}
+
+// Metrics / Leader / Members - 集群状态查询
+message MetricsRequest {}
+
+message MetricsResponse {
+    Response response = 1;
+    bool is_leader = 2;
+    uint64 replication_lag = 3;
+    uint64 current_leader = 4;
+}
+
+message LeaderRequest {}
+
+message LeaderResponse {
+    Response response = 1;
+    uint64 leader_id = 2;
+    NodeConfig leader_node = 3;
+}
+
+message MembersRequest {}
+
+message MembersResponse {
+    Response response = 1;
+    repeated NodeConfig members = 2;
+    repeated uint64 learners = 3;
+}

--- a/src/raft/proto/raft.proto
+++ b/src/raft/proto/raft.proto
@@ -1,0 +1,81 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+// 版本化包名
+//
+// 版本历史：
+// - v1: 初始版本，支持基本的 Raft RPC
+// - 未来版本变更将在 ChangeLog 中记录
+package kiwi.raft.v1;
+
+import "types.proto";
+
+// RaftCoreService - Raft 协议核心服务
+service RaftCoreService {
+    // 请求投票 RPC - 选举阶段使用
+    rpc Vote (VoteRequest) returns (VoteResponse);
+
+    // 追加日志条目 RPC - 日志复制使用
+    rpc AppendEntries (AppendEntriesRequest) returns (AppendEntriesResponse);
+
+    // 流式追加日志 RPC - pipeline 复制（生产阶段使用）
+    rpc StreamAppend (stream AppendEntriesRequest) returns (stream AppendEntriesResponse);
+
+    // 安装快照 RPC - 流式传输（POC 不实现）
+    rpc InstallSnapshot (stream InstallSnapshotRequest) returns (InstallSnapshotResponse);
+}
+
+// Vote RPC - 请求投票
+message VoteRequest {
+    Vote vote = 1;
+    LogId last_log_id = 2;
+}
+
+message VoteResponse {
+    Vote vote = 1;
+    bool vote_granted = 2;
+    LogId last_log_id = 3;
+}
+
+// AppendEntries RPC - 追加日志条目
+message AppendEntriesRequest {
+    Vote vote = 1;
+    LogId prev_log_id = 2;
+    repeated Entry entries = 3;
+    LogId leader_commit = 4;
+}
+
+// TODO: AppendEntriesResponse 可以包含更多信息，例如 conflict_index、conflict_term等
+message AppendEntriesResponse {
+    bool success = 1;
+}
+
+// InstallSnapshot RPC - 安装快照
+message InstallSnapshotRequest {
+    uint64 term = 1;
+    uint64 leader_id = 2;
+    uint64 last_included_index = 3;
+    uint64 last_included_term = 4;
+    bytes data = 5;
+    bool done = 6;
+}
+
+message InstallSnapshotResponse {
+    bool success = 1;
+}

--- a/src/raft/proto/types.proto
+++ b/src/raft/proto/types.proto
@@ -1,0 +1,106 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+// 版本化包名
+//
+// 版本历史：
+// - v1: 初始版本，支持基本的 Raft RPC
+// - 未来版本变更将在 ChangeLog 中记录
+package kiwi.raft.v1;
+
+
+// 节点 ID
+message NodeId {
+    uint64 id = 1;
+}
+
+// Leader ID：包含 term 和 node_id
+message LeaderId {
+    uint64 term = 1;
+    NodeId node_id = 2;
+}
+
+// Log ID：包含 leader_id 和 index
+message LogId {
+    LeaderId leader_id = 1;
+    uint64 index = 2;
+}
+
+// Vote：投票信息
+message Vote {
+    LeaderId leader_id = 1;
+    bool committed = 2;
+}
+
+// 节点配置信息
+message NodeConfig {
+    uint64 node_id = 1;
+    string raft_addr = 2; // gRPC 地址，用于 Raft 内部通信
+    string resp_addr = 3; // RESP 协议地址，用于客户端连接
+}
+
+// 空日志条目（用于心跳等）
+message BlankPayload {}
+
+// 普通日志条目（用户数据）
+message NormalPayload {
+    bytes data = 1;
+}
+
+// 成员变更日志条目
+message Membership {
+    repeated uint64 node_ids = 1;
+    repeated NodeConfig nodes = 2;
+}
+
+// 日志条目 Payload（使用 oneof 实现枚举）
+message EntryPayload {
+    oneof payload {
+        BlankPayload blank = 1;
+        NormalPayload normal = 2;
+        Membership membership = 3;
+    }
+}
+
+// 日志条目
+message Entry {
+    LogId log_id = 1;
+    EntryPayload payload = 2;
+}
+
+// Binlog 条目
+message BinlogEntry {
+    uint32 cf_idx = 1;
+    string op_type = 2; // "Put", "Delete", etc.
+    bytes key = 3;
+    bytes value = 4;
+}
+
+// Binlog 请求
+message Binlog {
+    uint64 db_id = 1;
+    uint64 slot_idx = 2;
+    repeated BinlogEntry entries = 3;
+}
+
+// 通用响应包装
+message Response {
+    bool success = 1;
+    string message = 2;
+}

--- a/src/raft/src/lib.rs
+++ b/src/raft/src/lib.rs
@@ -26,6 +26,13 @@ pub mod network;
 pub mod node;
 pub mod snapshot_archive;
 pub mod state_machine;
+pub mod raft_proto {
+    // 使用版本化的 proto 包名 kiwi.raft.v1
+    tonic::include_proto!("kiwi.raft.v1");
+    pub const FILE_DESCRIPTOR_SET: &[u8] =
+        tonic::include_file_descriptor_set!("kiwi.raft.v1_descriptor");
+}
+
 pub mod table_properties;
 pub mod types;
 


### PR DESCRIPTION
## Summary

- Add proto3 definitions with versioned package `kiwi.raft.v1` for RaftCoreService, RaftAdminService, RaftClientService, RaftMetricsService
- Add `build.rs` with tonic-build configuration using versioned descriptor filename (`kiwi.raft.v1_descriptor.bin`)
- Update `lib.rs` to include `raft_proto` module with versioned proto package

This is **PR 1/5** in a series to migrate the gRPC Raft Network implementation from `feat/raft`:
1. **Proto definitions + build config** (this PR)
2. gRPC error types → base: this branch
3. gRPC network layer with retry → base: PR #2
4. Type conversion + log_id tracking → base: PR #3
5. Cluster management scripts → base: PR #4

## Test plan

- [ ] Verify proto files define correct services and messages
- [ ] Verify `build.rs` compiles proto with `kiwi.raft.v1` package
- [ ] Verify `lib.rs` correctly includes the versioned proto module

🤖 Generated with [Claude Code](https://claude.com/claude-code)