### PR TITLE
feat(conf): Add proper TOML configuration file support

### DIFF
--- a/.ai-team/design-docs/toml-config-design-20260527.md
+++ b/.ai-team/design-docs/toml-config-design-20260527.md
@@ -1,0 +1,83 @@
+# TOML Configuration Support — Design Doc
+
+**Issue:** #247 — Add proper TOML configuration file support
+**Date:** 2026-05-27
+**Status:** Approved
+
+## Problem
+
+Current config system uses a hand-rolled Redis-style parser (`parse_redis_config`) that:
+- Only handles `key = value` and `key value` format
+- Cannot parse TOML sections (`[raft]`), arrays, or nested structures
+- All values are parsed as strings, then manually converted
+- The existing `config.example.toml` uses TOML format that the parser cannot read
+
+## Solution
+
+Replace the manual parser with the `toml` crate + serde `Deserialize`:
+
+### TOML Structure
+
+```toml
+# Basic
+binding = "127.0.0.1"
+port = 7379
+timeout = 300
+memory = "1GB"
+log-dir = "./logs"
+db-dir = "./db"
+db-path = ""
+db-instance-num = 3
+redis-compatible-mode = true
+# requirepass = "secret"
+
+# Compaction
+small-compaction-threshold = 10
+small-compaction-duration-threshold = 180
+
+# RocksDB
+rocksdb-max-subcompactions = 1
+rocksdb-max-background-jobs = 2
+rocksdb-max-write-buffer-number = 2
+rocksdb-min-write-buffer-number-to-merge = 1
+rocksdb-write-buffer-size = 67108864
+rocksdb-level0-file-num-compaction-trigger = 4
+rocksdb-num-levels = 7
+rocksdb-enable-pipelined-write = false
+rocksdb-level0-slowdown-writes-trigger = 20
+rocksdb-level0-stop-writes-trigger = 36
+rocksdb-ttl-second = 0
+rocksdb-periodic-second = 0
+rocksdb-level-compaction-dynamic-level-bytes = false
+rocksdb-max-open-files = 10000
+rocksdb-target-file-size-base = 67108864
+rocksdb-compression-type = "lz4"
+
+# Raft (optional section)
+[raft]
+node-id = 1
+raft-addr = "127.0.0.1:9220"
+resp-addr = "127.0.0.1:7379"
+data-dir = "./raft-data"
+# heartbeat-interval-ms = 500
+# election-timeout-min-ms = 1500
+# election-timeout-max-ms = 3000
+use-memory-log-store = false
+```
+
+### Key Design Decisions
+
+1. **Flat top-level keys** — RocksDB settings stay flat (not nested under `[rocksdb]`) to minimize migration friction
+2. **`[raft]` section** — Uses TOML table syntax, maps to `Option<RaftClusterConfig>`
+3. **`memory` field** — Keep string format ("1GB") with custom serde deserializer (`deserialize_memory`)
+4. **Backward compat** — Drop Redis-style format entirely (it was never a real parser)
+5. **Error messages** — `toml` crate gives line/column numbers in errors
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/conf/Cargo.toml` | Add `toml = "0.8"` |
+| `src/conf/src/config.rs` | Add `Deserialize` derive + serde attrs, rewrite `Config::load()` |
+| `src/conf/src/de_func.rs` | Keep `deserialize_memory`/`deserialize_bool_from_yes_no`, remove `parse_redis_config`/`parse_config_line`/`redis_config_to_ini` |
+| `src/conf/src/lib.rs` | Update tests to use TOML format |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,9 +512,9 @@ dependencies = [
  "openraft",
  "rust-rocksdb",
  "serde",
- "serde_ini",
  "snafu",
  "tempfile",
+ "toml",
  "validator",
 ]
 
@@ -1912,7 +1912,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -2276,12 +2276,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "result"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194d8e591e405d1eecf28819740abed6d719d1a2db87fc0bcdedee9a26d55560"
-
-[[package]]
 name = "rkyv"
 version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2470,17 +2464,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_ini"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb236687e2bb073a7521c021949be944641e671b8505a94069ca37b656c81139"
-dependencies = [
- "result",
- "serde",
- "void",
-]
-
-[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,6 +2474,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2834,6 +2826,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,12 +2857,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -2862,6 +2889,12 @@ checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -3148,12 +3181,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wait-timeout"

--- a/src/conf/Cargo.toml
+++ b/src/conf/Cargo.toml
@@ -8,7 +8,7 @@ workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_ini = "0.2.0"
+toml = "0.8"
 validator = { version = "0.20", features = ["derive"] }
 snafu = "0.8.5"
 rocksdb.workspace = true

--- a/src/conf/kiwi.conf
+++ b/src/conf/kiwi.conf
@@ -1,283 +1,105 @@
 # Copyright (c) 2024-present, arana-db Community.  All rights reserved.
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
+# Kiwi Configuration File (TOML format)
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Kiwi Configuration File
-# 
 # Kiwi is a Redis-compatible NoSQL database built with Rust, RocksDB, and Raft protocol.
-# This configuration file uses Redis-style format with comprehensive comments.
 #
-# Note that in order to read the configuration file, Kiwi must be
-# started with the file path as first argument:
+# Start Kiwi with:
+#   ./kiwi-server /path/to/kiwi.conf
 #
-# ./kiwi-server /path/to/kiwi.conf
-
-# Note on units: when memory size is needed, it is possible to specify
-# it in the usual form of 1k 5GB 4M and so forth:
-#
-# 1k => 1000 bytes
-# 1kb => 1024 bytes
-# 1m => 1000000 bytes
-# 1mb => 1024*1024 bytes
-# 1g => 1000000000 bytes
-# 1gb => 1024*1024*1024 bytes
-#
-# units are case insensitive so 1GB 1Gb 1gB are all the same.
+# Note on memory units: 1k = 1024, 1kb = 1024, 1m = 1048576, 1mb = 1048576,
+# 1g = 1073741824, 1gb = 1073741824. Units are case insensitive.
 
 ################################## NETWORK #####################################
 
 # Accept connections on the specified port, default is 7379.
-# If port 0 is specified Kiwi will not listen on a TCP socket.
-port 7379
-
-# Bind to specific network interfaces. By default, Kiwi listens for connections
-# from all available network interfaces on the host machine.
-# bind 127.0.0.1 -::1
+port = 7379
 
 # Close the connection after a client is idle for N seconds (0 to disable)
-# timeout 0
-
-# TCP keepalive.
-# If non-zero, use SO_KEEPALIVE to send TCP ACKs to clients in absence
-# of communication. This is useful for two reasons:
-# 1) Detect dead peers.
-# 2) Force network equipment in the middle to consider the connection to be alive.
-# tcp-keepalive 300
-
-################################## GENERAL #####################################
-
-# By default Kiwi does not run as a daemon. Use 'yes' if you need it.
-# daemonize no
-
-# Specify the server verbosity level.
-# This can be one of:
-# debug (a lot of information, useful for development/testing)
-# verbose (many rarely useful info, but not a mess like the debug level)
-# notice (moderately verbose, what you want in production probably)
-# warning (only very important / critical messages are logged)
-# nothing (nothing is logged)
-# loglevel notice
-
-# Specify the log file name. Also the empty string can be used to force
-# Kiwi to log on the standard output.
-# logfile ""
-
-# Set the number of databases. The default database is DB 0, you can select
-# a different one on a per-connection basis using SELECT <dbid> where
-# dbid is a number between 0 and 'databases'-1
-# databases 16
+timeout = 50
 
 ############################## MEMORY MANAGEMENT ################################
 
-# Set a memory usage limit to the specified amount of bytes.
-# When the memory limit is reached Kiwi will try to remove keys
-# according to the eviction policy selected.
-memory 10M
-
-# MAXMEMORY POLICY: how Kiwi will select what to remove when maxmemory
-# is reached. You can select one from the following behaviors:
-# volatile-lru -> Evict using approximated LRU, only keys with an expire set.
-# allkeys-lru -> Evict any key using approximated LRU.
-# volatile-lfu -> Evict using approximated LFU, only keys with an expire set.
-# allkeys-lfu -> Evict any key using approximated LFU.
-# volatile-random -> Remove a random key having an expire set.
-# allkeys-random -> Remove a random key, any key.
-# volatile-ttl -> Remove the key with the nearest expire time (minor TTL)
-# noeviction -> Don't evict anything, just return an error on write operations.
-# maxmemory-policy noeviction
-
-################################ SNAPSHOTTING  ################################
-
-# Save the DB to disk.
-# save <seconds> <changes> [<seconds> <changes> ...]
-# Kiwi will save the DB if the given number of seconds elapsed and it
-# surpassed the given number of write operations against the DB.
-# save 3600 1 300 100 60 10000
-
-# The filename where to dump the DB
-# dbfilename dump.rdb
-
-# The working directory.
-# The DB will be written inside this directory, with the filename specified
-# above using the 'dbfilename' configuration directive.
-# dir ./
-
-################################# REPLICATION #################################
-
-# Master-Replica replication. Use replicaof to make a Kiwi instance a copy of
-# another Kiwi server.
-# replicaof <masterip> <masterport>
-
-# If the master is password protected (using the "requirepass" configuration
-# directive below) it is possible to tell the replica to authenticate before
-# starting the replication synchronization process.
-# masterauth <master-password>
-
-################################## SECURITY ###################################
-
-# Warning: since Kiwi is pretty fast, an outside user can try up to
-# 1 million passwords per second against a modern box. This means that you
-# should use very strong passwords, otherwise they will be very easy to break.
-# requirepass foobared
-
-################################### CLIENTS ####################################
-
-# Set the max number of connected clients at the same time. By default
-# this limit is set to 10000 clients.
-# maxclients 10000
-
-############################### ADVANCED CONFIG ###############################
-
-# Hashes are encoded using a memory efficient data structure when they have a
-# small number of entries, and the biggest entry does not exceed a given
-# threshold. These thresholds can be configured using the following directives.
-# hash-max-listpack-entries 512
-# hash-max-listpack-value 64
-
-# Lists are also encoded in a special way to save a lot of space.
-# list-max-listpack-size -2
-# list-compress-depth 0
-
-# Sets have a special encoding when a set is composed
-# of just strings that happen to be integers in radix 10 in the range
-# of 64 bit signed integers.
-# set-max-intset-entries 512
-
-# Similarly to hashes and lists, sorted sets are also specially encoded in
-# order to save a lot of space.
-# zset-max-listpack-entries 128
-# zset-max-listpack-value 64
-
-# HyperLogLog sparse representation bytes limit.
-# hll-sparse-max-bytes 3000
-
-# Streams macro node max size / items.
-# stream-node-max-bytes 4096
-# stream-node-max-entries 100
-
-# Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
-# order to help rehashing the main Kiwi hash table.
-# activerehashing yes
-
-# The client output buffer limits can be used to force disconnection of clients
-# that are not reading data from the server fast enough for some reason.
-# client-output-buffer-limit normal 0 0 0
-# client-output-buffer-limit replica 256mb 64mb 60
-# client-output-buffer-limit pubsub 32mb 8mb 60
-
-# Redis calls an internal function to perform many background tasks, like
-# closing connections of clients in timeout, purging expired keys that are
-# never requested, and so forth.
-# hz 10
+# Set a memory usage limit. Accepts human-readable sizes like "10MB", "1GB".
+memory = "10MB"
 
 ################################## KIWI SPECIFIC ###############################
 
-# Kiwi-specific configuration options
+# Log directory
+log-dir = "/data/kiwi_rs/logs"
 
-# Log directory for Kiwi logs
-# log-dir /data/kiwi_rs/logs
-
-# Directory where RocksDB data files are stored.
-# When db-instance-num > 1, each instance creates a subdirectory (e.g., ./db/0, ./db/1).
-# db-dir ./db
+# Directory where RocksDB data files are stored
+db-dir = "./db"
 
 # Enable Redis compatibility mode
-# redis-compatible-mode yes
+redis-compatible-mode = false
 
 # Number of database instances
-# db-instance-num 3
+db-instance-num = 3
 
 # Small compaction threshold - minimum number of keys to trigger compaction
-small-compaction-threshold 5000
+small-compaction-threshold = 5000
 
 # Small compaction duration threshold - minimum duration in milliseconds
-small-compaction-duration-threshold 10000
+small-compaction-duration-threshold = 10000
+
+################################## ROCKSDB #####################################
+
+# Maximum number of concurrent subcompactions
+rocksdb-max-subcompactions = 2
+
+# Maximum number of concurrent background jobs (compactions and flushes)
+rocksdb-max-background-jobs = 4
+
+# Maximum number of write buffers
+rocksdb-max-write-buffer-number = 2
+
+# Minimum number of write buffers to merge before writing to storage
+rocksdb-min-write-buffer-number-to-merge = 2
+
+# Amount of data to build up in memory before writing to disk (64MB)
+rocksdb-write-buffer-size = 67108864
+
+# Number of files to trigger level-0 compaction
+rocksdb-level0-file-num-compaction-trigger = 4
+
+# Number of levels in the RocksDB LSM tree
+rocksdb-num-levels = 7
+
+# Enable pipelined write for better performance
+rocksdb-enable-pipelined-write = false
+
+# Slow down writes when this many level-0 files exist
+rocksdb-level0-slowdown-writes-trigger = 20
+
+# Stop writes when this many level-0 files exist
+rocksdb-level0-stop-writes-trigger = 36
+
+# TTL for keys in seconds (7 days)
+rocksdb-ttl-second = 604800
+
+# Periodic compaction interval in seconds (3 days)
+rocksdb-periodic-second = 259200
+
+# Enable dynamic level bytes for level compaction
+rocksdb-level-compaction-dynamic-level-bytes = true
+
+# Maximum number of open files
+rocksdb-max-open-files = 10000
+
+# Target file size for level-1 and above (64MB)
+rocksdb-target-file-size-base = 67108864
+
+# Compression algorithm: none, lz4, snappy, zstd, zlib, bz2
+rocksdb-compression-type = "lz4"
 
 ################################## RAFT CONFIG #################################
 
-# Raft cluster configuration (optional, enables cluster mode when set)
-
-# Unique node ID within the cluster
-# raft-node-id 1
-
-# Raft internal communication address
-# raft-addr 127.0.0.1:8081
-
-# Redis-compatible client address for this node
-# raft-resp-addr 127.0.0.1:6379
-
-# Directory to store Raft log data
-# raft-data-dir /tmp/kiwi/raft
-
-# Raft log store backend: yes = in-memory (for testing), no = RocksDB (default, persistent)
-# raft-use-memory-log-store no
-
-# RocksDB configuration options for Kiwi's storage engine
-
-# Maximum number of concurrent subcompactions
-rocksdb-max-subcompactions 2
-
-# Maximum number of concurrent background jobs (compactions and flushes)
-rocksdb-max-background-jobs 4
-
-# Maximum number of write buffers that are built up in memory
-rocksdb-max-write-buffer-number 2
-
-# Minimum number of write buffers that will be merged together before writing to storage
-rocksdb-min-write-buffer-number-to-merge 2
-
-# Amount of data to build up in memory before writing to disk
-rocksdb-write-buffer-size 67108864
-
-# Number of files to trigger level-0 compaction
-rocksdb-level0-file-num-compaction-trigger 4
-
-# Number of levels in the RocksDB LSM tree
-rocksdb-num-levels 7
-
-# Enable pipelined write for better performance
-rocksdb-enable-pipelined-write no
-
-# Slow down writes when this many level-0 files exist
-rocksdb-level0-slowdown-writes-trigger 20
-
-# Stop writes when this many level-0 files exist
-rocksdb-level0-stop-writes-trigger 36
-
-# TTL (Time To Live) for keys in seconds
-rocksdb-ttl-second 604800
-
-# Periodic compaction interval in seconds
-rocksdb-periodic-second 259200
-
-# Enable dynamic level bytes for level compaction
-rocksdb-level-compaction-dynamic-level-bytes yes
-
-# Maximum number of open files that RocksDB can have
-rocksdb-max-open-files 10000
-
-# Target file size for level-1 and above
-rocksdb-target-file-size-base 67108864
-
-# Compression algorithm for RocksDB column families.
-# Applies to all column families (default, hash_data_cf, set_data_cf, list_data_cf, zset_data_cf, zset_score_cf).
-# Supported values: none, lz4, snappy, zstd, zlib, bz2
-# Default: lz4 (good balance of speed and compression ratio)
-# - lz4:    fast compression/decompression, moderate ratio (recommended for most workloads)
-# - snappy: similar to lz4, slightly lower ratio but very fast
-# - zstd:   best compression ratio, moderate speed (recommended for storage-constrained environments)
-# - none:   no compression (highest performance, largest disk usage)
-rocksdb-compression-type lz4
+# Uncomment to enable Raft cluster mode:
+#
+# [raft]
+# node-id = 1
+# raft-addr = "127.0.0.1:8081"
+# resp-addr = "127.0.0.1:6379"
+# data-dir = "/tmp/kiwi/raft"
+# use-memory-log-store = false

--- a/src/conf/kiwi.conf
+++ b/src/conf/kiwi.conf
@@ -1,5 +1,20 @@
 # Copyright (c) 2024-present, arana-db Community.  All rights reserved.
 #
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Kiwi Configuration File (TOML format)
 #
 # Kiwi is a Redis-compatible NoSQL database built with Rust, RocksDB, and Raft protocol.

--- a/src/conf/src/config.rs
+++ b/src/conf/src/config.rs
@@ -15,16 +15,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use rocksdb::DBCompressionType;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 use snafu::ResultExt;
 use std::fmt::Formatter;
 use validator::Validate;
 
-use crate::de_func::{parse_bool_from_string, parse_memory, parse_redis_config};
+use crate::de_func::deserialize_memory;
 use crate::error::Error;
 
 /// Compression algorithm for RocksDB column families.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum CompressionType {
     None,
     Snappy,
@@ -32,6 +32,27 @@ pub enum CompressionType {
     Zstd,
     Zlib,
     Bz2,
+}
+
+impl<'de> Deserialize<'de> for CompressionType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.to_lowercase().as_str() {
+            "none" | "no" => Ok(CompressionType::None),
+            "snappy" => Ok(CompressionType::Snappy),
+            "lz4" => Ok(CompressionType::Lz4),
+            "zstd" => Ok(CompressionType::Zstd),
+            "zlib" => Ok(CompressionType::Zlib),
+            "bz2" => Ok(CompressionType::Bz2),
+            _ => Err(de::Error::custom(format!(
+                "unknown compression type '{}', valid values: none, snappy, lz4, zstd, zlib, bz2",
+                s
+            ))),
+        }
+    }
 }
 
 impl CompressionType {
@@ -82,44 +103,133 @@ impl std::str::FromStr for CompressionType {
 
 const DEFAULT_BINDING: &str = "127.0.0.1";
 const DEFAULT_PORT: u16 = 7379; // Redis-compatible port (7xxx variant of 6379)
-// config struct define - keeping original config items but using Redis-style format
-#[derive(Validate)]
+
+/// Default functions for serde
+mod defaults {
+    pub fn binding() -> String { super::DEFAULT_BINDING.to_string() }
+    pub fn port() -> u16 { super::DEFAULT_PORT }
+    pub fn timeout() -> u32 { 50 }
+    pub fn memory() -> u64 { 1024 * 1024 * 1024 } // 1GB
+    pub fn log_dir() -> String { "/data/kiwi_rs/logs".to_string() }
+    pub fn db_dir() -> String { "./db".to_string() }
+    pub fn db_path() -> String { "./db".to_string() }
+    pub fn redis_compatible_mode() -> bool { false }
+    pub fn db_instance_num() -> usize { 3 }
+    pub fn rocksdb_max_subcompactions() -> u32 { 0 }
+    pub fn rocksdb_max_background_jobs() -> i32 { 4 }
+    pub fn rocksdb_max_write_buffer_number() -> i32 { 2 }
+    pub fn rocksdb_min_write_buffer_number_to_merge() -> i32 { 2 }
+    pub fn rocksdb_write_buffer_size() -> usize { 64 << 20 } // 64MB
+    pub fn rocksdb_level0_file_num_compaction_trigger() -> i32 { 4 }
+    pub fn rocksdb_num_levels() -> i32 { 7 }
+    pub fn rocksdb_enable_pipelined_write() -> bool { false }
+    pub fn rocksdb_level0_slowdown_writes_trigger() -> i32 { 20 }
+    pub fn rocksdb_level0_stop_writes_trigger() -> i32 { 36 }
+    pub fn rocksdb_ttl_second() -> u64 { 30 * 24 * 60 * 60 } // 30 days
+    pub fn rocksdb_periodic_second() -> u64 { 30 * 24 * 60 * 60 } // 30 days
+    pub fn rocksdb_level_compaction_dynamic_level_bytes() -> bool { true }
+    pub fn rocksdb_max_open_files() -> i32 { 10000 }
+    pub fn rocksdb_target_file_size_base() -> u64 { 64 << 20 } // 64MB
+    pub fn rocksdb_compression_type() -> super::CompressionType { super::CompressionType::Lz4 }
+    pub fn small_compaction_threshold() -> usize { 5000 }
+    pub fn small_compaction_duration_threshold() -> usize { 10000 }
+}
+
+// config struct define
+#[derive(Deserialize, Validate)]
+#[serde(rename_all = "kebab-case")]
 pub struct Config {
-    // Original config items from config.ini
+    #[serde(default = "defaults::binding")]
+    pub binding: String,
+
     #[validate(range(min = 1024, max = 65535))]
+    #[serde(default = "defaults::port")]
     pub port: u16,
+
+    #[serde(default = "defaults::timeout")]
+    pub timeout: u32,
+
+    /// Memory limit for the server. Accepts human-readable sizes like "1GB", "256MB"
+    /// or raw byte counts as integers.
+    #[serde(default = "defaults::memory", deserialize_with = "deserialize_memory")]
     pub memory: u64,
+
+    #[serde(default = "defaults::log_dir")]
+    pub log_dir: String,
+
+    #[serde(default = "defaults::db_dir")]
+    pub db_dir: String,
+
+    #[serde(default = "defaults::db_path")]
+    pub db_path: String,
+
+    #[serde(default = "defaults::redis_compatible_mode")]
+    pub redis_compatible_mode: bool,
+
+    #[serde(default = "defaults::db_instance_num")]
+    pub db_instance_num: usize,
+
+    #[serde(default = "defaults::small_compaction_threshold")]
     pub small_compaction_threshold: usize,
+
+    #[serde(default = "defaults::small_compaction_duration_threshold")]
     pub small_compaction_duration_threshold: usize,
+
+    #[serde(default = "defaults::rocksdb_max_subcompactions")]
     pub rocksdb_max_subcompactions: u32,
+
+    #[serde(default = "defaults::rocksdb_max_background_jobs")]
     pub rocksdb_max_background_jobs: i32,
+
+    #[serde(default = "defaults::rocksdb_max_write_buffer_number")]
     pub rocksdb_max_write_buffer_number: i32,
+
+    #[serde(default = "defaults::rocksdb_min_write_buffer_number_to_merge")]
     pub rocksdb_min_write_buffer_number_to_merge: i32,
+
+    #[serde(default = "defaults::rocksdb_write_buffer_size")]
     pub rocksdb_write_buffer_size: usize,
+
+    #[serde(default = "defaults::rocksdb_level0_file_num_compaction_trigger")]
     pub rocksdb_level0_file_num_compaction_trigger: i32,
+
+    #[serde(default = "defaults::rocksdb_num_levels")]
     pub rocksdb_num_levels: i32,
+
+    #[serde(default = "defaults::rocksdb_enable_pipelined_write")]
     pub rocksdb_enable_pipelined_write: bool,
+
+    #[serde(default = "defaults::rocksdb_level0_slowdown_writes_trigger")]
     pub rocksdb_level0_slowdown_writes_trigger: i32,
+
+    #[serde(default = "defaults::rocksdb_level0_stop_writes_trigger")]
     pub rocksdb_level0_stop_writes_trigger: i32,
+
+    #[serde(default = "defaults::rocksdb_ttl_second")]
     pub rocksdb_ttl_second: u64,
+
+    #[serde(default = "defaults::rocksdb_periodic_second")]
     pub rocksdb_periodic_second: u64,
+
+    #[serde(default = "defaults::rocksdb_level_compaction_dynamic_level_bytes")]
     pub rocksdb_level_compaction_dynamic_level_bytes: bool,
+
+    #[serde(default = "defaults::rocksdb_max_open_files")]
     pub rocksdb_max_open_files: i32,
+
+    #[serde(default = "defaults::rocksdb_target_file_size_base")]
     pub rocksdb_target_file_size_base: u64,
+
     /// Compression algorithm applied to all column families.
     /// Supported values: none, lz4, snappy, zstd, zlib, bz2. Default: lz4.
+    #[serde(default = "defaults::rocksdb_compression_type")]
     pub rocksdb_compression_type: CompressionType,
 
-    // Additional fields from original config
-    pub binding: String,
-    pub timeout: u32,
-    pub log_dir: String,
-    pub db_dir: String,
-    pub redis_compatible_mode: bool,
-    pub db_instance_num: usize,
-    pub db_path: String,
     /// Authentication password. When set, clients must authenticate via AUTH command.
+    #[serde(default)]
     pub requirepass: Option<String>,
+
+    #[serde(default)]
     pub raft: Option<RaftClusterConfig>,
 }
 
@@ -201,17 +311,22 @@ impl std::fmt::Debug for Config {
     }
 }
 
-#[derive(Debug, Validate, Clone)]
+#[derive(Debug, Deserialize, Validate, Clone)]
+#[serde(rename_all = "kebab-case")]
 pub struct RaftClusterConfig {
     #[validate(range(min = 1))]
     pub node_id: u64,
     pub raft_addr: String,
     pub resp_addr: String,
     pub data_dir: String,
+    #[serde(default)]
     pub heartbeat_interval_ms: Option<u64>,
+    #[serde(default)]
     pub election_timeout_min_ms: Option<u64>,
+    #[serde(default)]
     pub election_timeout_max_ms: Option<u64>,
     /// 是否使用内存日志存储，默认 false（使用 RocksDB 持久化存储）
+    #[serde(default)]
     pub use_memory_log_store: bool,
 }
 
@@ -219,362 +334,67 @@ pub struct RaftClusterConfig {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            binding: DEFAULT_BINDING.to_string(),
-            port: DEFAULT_PORT,
-            timeout: 50,
-            memory: 1024 * 1024 * 1024, // 1GB
-            log_dir: "/data/kiwi_rs/logs".to_string(),
-            db_dir: "./db".to_string(),
-            redis_compatible_mode: false,
-
-            rocksdb_max_subcompactions: 0,
-            rocksdb_max_background_jobs: 4,
-            rocksdb_max_write_buffer_number: 2,
-            rocksdb_min_write_buffer_number_to_merge: 2,
-            rocksdb_write_buffer_size: 64 << 20, // 64MB
-            rocksdb_level0_file_num_compaction_trigger: 4,
-            rocksdb_num_levels: 7,
-            rocksdb_enable_pipelined_write: false,
-            rocksdb_level0_slowdown_writes_trigger: 20,
-            rocksdb_level0_stop_writes_trigger: 36,
-            rocksdb_ttl_second: 30 * 24 * 60 * 60, // 30 days
-            rocksdb_periodic_second: 30 * 24 * 60 * 60, // 30 days
-            rocksdb_level_compaction_dynamic_level_bytes: true,
-            rocksdb_max_open_files: 10000,
-            rocksdb_target_file_size_base: 64 << 20, // 64MB
-            rocksdb_compression_type: CompressionType::Lz4,
-
-            db_instance_num: 3,
-            db_path: "./db".to_string(),
-            small_compaction_threshold: 5000,
-            small_compaction_duration_threshold: 10000,
+            binding: defaults::binding(),
+            port: defaults::port(),
+            timeout: defaults::timeout(),
+            memory: defaults::memory(),
+            log_dir: defaults::log_dir(),
+            db_dir: defaults::db_dir(),
+            db_path: defaults::db_path(),
+            redis_compatible_mode: defaults::redis_compatible_mode(),
+            rocksdb_max_subcompactions: defaults::rocksdb_max_subcompactions(),
+            rocksdb_max_background_jobs: defaults::rocksdb_max_background_jobs(),
+            rocksdb_max_write_buffer_number: defaults::rocksdb_max_write_buffer_number(),
+            rocksdb_min_write_buffer_number_to_merge:
+                defaults::rocksdb_min_write_buffer_number_to_merge(),
+            rocksdb_write_buffer_size: defaults::rocksdb_write_buffer_size(),
+            rocksdb_level0_file_num_compaction_trigger:
+                defaults::rocksdb_level0_file_num_compaction_trigger(),
+            rocksdb_num_levels: defaults::rocksdb_num_levels(),
+            rocksdb_enable_pipelined_write: defaults::rocksdb_enable_pipelined_write(),
+            rocksdb_level0_slowdown_writes_trigger:
+                defaults::rocksdb_level0_slowdown_writes_trigger(),
+            rocksdb_level0_stop_writes_trigger: defaults::rocksdb_level0_stop_writes_trigger(),
+            rocksdb_ttl_second: defaults::rocksdb_ttl_second(),
+            rocksdb_periodic_second: defaults::rocksdb_periodic_second(),
+            rocksdb_level_compaction_dynamic_level_bytes:
+                defaults::rocksdb_level_compaction_dynamic_level_bytes(),
+            rocksdb_max_open_files: defaults::rocksdb_max_open_files(),
+            rocksdb_target_file_size_base: defaults::rocksdb_target_file_size_base(),
+            rocksdb_compression_type: defaults::rocksdb_compression_type(),
+            db_instance_num: defaults::db_instance_num(),
+            small_compaction_threshold: defaults::small_compaction_threshold(),
+            small_compaction_duration_threshold: defaults::small_compaction_duration_threshold(),
             requirepass: None,
             raft: None,
         }
     }
 }
+
 impl Config {
-    // load config from file - supports Redis-style format with comments
+    /// Load config from a TOML file.
+    ///
+    /// Missing fields use their default values. The `[raft]` section is optional.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::ConfigFile` if the file cannot be read,
+    /// `Error::InvalidConfig` if TOML parsing fails,
+    /// or `Error::ValidConfigFail` if validation constraints are violated.
     pub fn load(path: &str) -> Result<Self, Error> {
         let content =
             std::fs::read_to_string(path).context(crate::error::ConfigFileSnafu { path })?;
 
-        // Parse Redis-style configuration
-        let config_map = parse_redis_config(&content).map_err(|e| Error::InvalidConfig {
-            source: serde_ini::de::Error::Custom(e),
-        })?;
+        let mut config: Config = toml::from_str(&content).context(crate::error::InvalidConfigSnafu)?;
 
-        // Create config from parsed values
-        let mut config = Config::default();
-
-        let mut raft_node_id: Option<u64> = None;
-        let mut raft_addr: Option<String> = None;
-        let mut raft_resp_addr: Option<String> = None;
-        let mut raft_data_dir: Option<String> = None;
-        let mut raft_heartbeat_interval: Option<u64> = None;
-        let mut raft_election_timeout_min: Option<u64> = None;
-        let mut raft_election_timeout_max: Option<u64> = None;
-        let mut raft_use_memory_log_store: bool = false;
-
-        // Parse each configuration value
-        for (key, value) in config_map {
-            match key.as_str() {
-                "port" => {
-                    config.port = value.parse().map_err(|e| Error::InvalidConfig {
-                        source: serde_ini::de::Error::Custom(format!("Invalid port: {}", e)),
-                    })?;
-                }
-                "binding" => {
-                    config.binding = value;
-                }
-                "timeout" => {
-                    config.timeout = value.parse().map_err(|e| Error::InvalidConfig {
-                        source: serde_ini::de::Error::Custom(format!("Invalid timeout: {}", e)),
-                    })?;
-                }
-                "log-dir" => {
-                    config.log_dir = value;
-                }
-                "db-dir" => {
-                    let trimmed = value.trim();
-                    if trimmed.is_empty() {
-                        return Err(Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(
-                                "db-dir must not be empty".to_string(),
-                            ),
-                        });
-                    }
-                    config.db_dir = trimmed.to_string();
-                    config.db_path = trimmed.to_string();
-                }
-                "redis-compatible-mode" => {
-                    config.redis_compatible_mode =
-                        parse_bool_from_string(&value).map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid redis-compatible-mode: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "db-instance-num" => {
-                    config.db_instance_num = value.parse().map_err(|e| Error::InvalidConfig {
-                        source: serde_ini::de::Error::Custom(format!(
-                            "Invalid db-instance-num: {}",
-                            e
-                        )),
-                    })?;
-                }
-                "memory" => {
-                    config.memory =
-                        parse_memory(&value).map_err(|e| Error::MemoryParse { source: e })?;
-                }
-                "small-compaction-threshold" => {
-                    config.small_compaction_threshold =
-                        value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid small-compaction-threshold: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "small-compaction-duration-threshold" => {
-                    config.small_compaction_duration_threshold =
-                        value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid small-compaction-duration-threshold: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "rocksdb-max-subcompactions" => {
-                    config.rocksdb_max_subcompactions =
-                        value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid rocksdb-max-subcompactions: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "rocksdb-max-background-jobs" => {
-                    config.rocksdb_max_background_jobs =
-                        value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid rocksdb-max-background-jobs: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "rocksdb-max-write-buffer-number" => {
-                    config.rocksdb_max_write_buffer_number =
-                        value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid rocksdb-max-write-buffer-number: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "rocksdb-min-write-buffer-number-to-merge" => {
-                    config.rocksdb_min_write_buffer_number_to_merge =
-                        value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid rocksdb-min-write-buffer-number-to-merge: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "rocksdb-write-buffer-size" => {
-                    config.rocksdb_write_buffer_size =
-                        value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid rocksdb-write-buffer-size: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "rocksdb-level0-file-num-compaction-trigger" => {
-                    config.rocksdb_level0_file_num_compaction_trigger =
-                        value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid rocksdb-level0-file-num-compaction-trigger: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "rocksdb-num-levels" => {
-                    config.rocksdb_num_levels =
-                        value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid rocksdb-num-levels: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "rocksdb-enable-pipelined-write" => {
-                    config.rocksdb_enable_pipelined_write = parse_bool_from_string(&value)
-                        .map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid rocksdb-enable-pipelined-write: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "rocksdb-level0-slowdown-writes-trigger" => {
-                    config.rocksdb_level0_slowdown_writes_trigger =
-                        value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid rocksdb-level0-slowdown-writes-trigger: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "rocksdb-level0-stop-writes-trigger" => {
-                    config.rocksdb_level0_stop_writes_trigger =
-                        value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid rocksdb-level0-stop-writes-trigger: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "rocksdb-ttl-second" => {
-                    config.rocksdb_ttl_second =
-                        value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid rocksdb-ttl-second: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "rocksdb-periodic-second" => {
-                    config.rocksdb_periodic_second =
-                        value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid rocksdb-periodic-second: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "rocksdb-level-compaction-dynamic-level-bytes" => {
-                    config.rocksdb_level_compaction_dynamic_level_bytes =
-                        parse_bool_from_string(&value).map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid rocksdb-level-compaction-dynamic-level-bytes: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "rocksdb-max-open-files" => {
-                    config.rocksdb_max_open_files =
-                        value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid rocksdb-max-open-files: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "rocksdb-target-file-size-base" => {
-                    config.rocksdb_target_file_size_base =
-                        value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid rocksdb-target-file-size-base: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "rocksdb-compression-type" => {
-                    config.rocksdb_compression_type =
-                        value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid rocksdb-compression-type: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "raft-node-id" | "cluster-node-id" => {
-                    raft_node_id = Some(value.parse().map_err(|e| Error::InvalidConfig {
-                        source: serde_ini::de::Error::Custom(format!(
-                            "Invalid raft-node-id: {}",
-                            e
-                        )),
-                    })?);
-                }
-                "raft-addr" | "cluster-addr" => {
-                    raft_addr = Some(value);
-                }
-                "raft-resp-addr" | "cluster-resp-addr" => {
-                    raft_resp_addr = Some(value);
-                }
-                "raft-data-dir" | "cluster-data-dir" => {
-                    raft_data_dir = Some(value);
-                }
-                "raft-heartbeat-interval" | "cluster-heartbeat-interval" => {
-                    raft_heartbeat_interval =
-                        Some(value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid raft-heartbeat-interval: {}",
-                                e
-                            )),
-                        })?);
-                }
-                "raft-election-timeout-min" | "cluster-election-timeout-min" => {
-                    raft_election_timeout_min =
-                        Some(value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid raft-election-timeout-min: {}",
-                                e
-                            )),
-                        })?);
-                }
-                "raft-election-timeout-max" | "cluster-election-timeout-max" => {
-                    raft_election_timeout_max =
-                        Some(value.parse().map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid raft-election-timeout-max: {}",
-                                e
-                            )),
-                        })?);
-                }
-                "raft-use-memory-log-store" => {
-                    raft_use_memory_log_store =
-                        parse_bool_from_string(&value).map_err(|e| Error::InvalidConfig {
-                            source: serde_ini::de::Error::Custom(format!(
-                                "Invalid raft-use-memory-log-store: {}",
-                                e
-                            )),
-                        })?;
-                }
-                "db-path" => {
-                    config.db_path = value.clone();
-                    config.db_dir = value;
-                }
-                "requirepass" => {
-                    config.requirepass = Some(value);
-                }
-                _ => {
-                    // Unknown configuration key, skip it
-                    continue;
-                }
-            }
-        }
-
-        if let (Some(node_id), Some(addr), Some(resp_addr), Some(data_dir)) =
-            (raft_node_id, raft_addr, raft_resp_addr, raft_data_dir)
-        {
-            config.raft = Some(RaftClusterConfig {
-                node_id,
-                raft_addr: addr,
-                resp_addr,
-                data_dir,
-                heartbeat_interval_ms: raft_heartbeat_interval,
-                election_timeout_min_ms: raft_election_timeout_min,
-                election_timeout_max_ms: raft_election_timeout_max,
-                use_memory_log_store: raft_use_memory_log_store,
-            });
+        // If db-dir is set but db-path is not explicitly set, sync them
+        if config.db_dir != defaults::db_dir() && config.db_path == defaults::db_path() {
+            config.db_path = config.db_dir.clone();
         }
 
         config
             .validate()
-            .map_err(|_e| Error::ValidConfigFail { source: _e })?;
+            .map_err(|e| Error::ValidConfigFail { source: e })?;
 
         Ok(config)
     }
@@ -605,7 +425,7 @@ impl Config {
         options.set_max_open_files(self.rocksdb_max_open_files);
         options.set_target_file_size_base(self.rocksdb_target_file_size_base);
 
-        // Apply compression to all levels (level 0 and 1 use no compression, levels 2+ use configured type)
+        // Apply compression to all column families (level 0 and 1 use no compression, levels 2+ use configured type)
         let compression = self.rocksdb_compression_type.to_rocksdb();
         let mut compressions = vec![DBCompressionType::None; 3];
         for _ in 3..self.rocksdb_num_levels {

--- a/src/conf/src/config.rs
+++ b/src/conf/src/config.rs
@@ -106,33 +106,87 @@ const DEFAULT_PORT: u16 = 7379; // Redis-compatible port (7xxx variant of 6379)
 
 /// Default functions for serde
 mod defaults {
-    pub fn binding() -> String { super::DEFAULT_BINDING.to_string() }
-    pub fn port() -> u16 { super::DEFAULT_PORT }
-    pub fn timeout() -> u32 { 50 }
-    pub fn memory() -> u64 { 1024 * 1024 * 1024 } // 1GB
-    pub fn log_dir() -> String { "/data/kiwi_rs/logs".to_string() }
-    pub fn db_dir() -> String { "./db".to_string() }
-    pub fn db_path() -> String { "./db".to_string() }
-    pub fn redis_compatible_mode() -> bool { false }
-    pub fn db_instance_num() -> usize { 3 }
-    pub fn rocksdb_max_subcompactions() -> u32 { 0 }
-    pub fn rocksdb_max_background_jobs() -> i32 { 4 }
-    pub fn rocksdb_max_write_buffer_number() -> i32 { 2 }
-    pub fn rocksdb_min_write_buffer_number_to_merge() -> i32 { 2 }
-    pub fn rocksdb_write_buffer_size() -> usize { 64 << 20 } // 64MB
-    pub fn rocksdb_level0_file_num_compaction_trigger() -> i32 { 4 }
-    pub fn rocksdb_num_levels() -> i32 { 7 }
-    pub fn rocksdb_enable_pipelined_write() -> bool { false }
-    pub fn rocksdb_level0_slowdown_writes_trigger() -> i32 { 20 }
-    pub fn rocksdb_level0_stop_writes_trigger() -> i32 { 36 }
-    pub fn rocksdb_ttl_second() -> u64 { 30 * 24 * 60 * 60 } // 30 days
-    pub fn rocksdb_periodic_second() -> u64 { 30 * 24 * 60 * 60 } // 30 days
-    pub fn rocksdb_level_compaction_dynamic_level_bytes() -> bool { true }
-    pub fn rocksdb_max_open_files() -> i32 { 10000 }
-    pub fn rocksdb_target_file_size_base() -> u64 { 64 << 20 } // 64MB
-    pub fn rocksdb_compression_type() -> super::CompressionType { super::CompressionType::Lz4 }
-    pub fn small_compaction_threshold() -> usize { 5000 }
-    pub fn small_compaction_duration_threshold() -> usize { 10000 }
+    pub fn binding() -> String {
+        super::DEFAULT_BINDING.to_string()
+    }
+    pub fn port() -> u16 {
+        super::DEFAULT_PORT
+    }
+    pub fn timeout() -> u32 {
+        50
+    }
+    pub fn memory() -> u64 {
+        1024 * 1024 * 1024
+    } // 1GB
+    pub fn log_dir() -> String {
+        "/data/kiwi_rs/logs".to_string()
+    }
+    pub fn db_dir() -> String {
+        "./db".to_string()
+    }
+    pub fn db_path() -> String {
+        "./db".to_string()
+    }
+    pub fn redis_compatible_mode() -> bool {
+        false
+    }
+    pub fn db_instance_num() -> usize {
+        3
+    }
+    pub fn rocksdb_max_subcompactions() -> u32 {
+        0
+    }
+    pub fn rocksdb_max_background_jobs() -> i32 {
+        4
+    }
+    pub fn rocksdb_max_write_buffer_number() -> i32 {
+        2
+    }
+    pub fn rocksdb_min_write_buffer_number_to_merge() -> i32 {
+        2
+    }
+    pub fn rocksdb_write_buffer_size() -> usize {
+        64 << 20
+    } // 64MB
+    pub fn rocksdb_level0_file_num_compaction_trigger() -> i32 {
+        4
+    }
+    pub fn rocksdb_num_levels() -> i32 {
+        7
+    }
+    pub fn rocksdb_enable_pipelined_write() -> bool {
+        false
+    }
+    pub fn rocksdb_level0_slowdown_writes_trigger() -> i32 {
+        20
+    }
+    pub fn rocksdb_level0_stop_writes_trigger() -> i32 {
+        36
+    }
+    pub fn rocksdb_ttl_second() -> u64 {
+        30 * 24 * 60 * 60
+    } // 30 days
+    pub fn rocksdb_periodic_second() -> u64 {
+        30 * 24 * 60 * 60
+    } // 30 days
+    pub fn rocksdb_level_compaction_dynamic_level_bytes() -> bool {
+        true
+    }
+    pub fn rocksdb_max_open_files() -> i32 {
+        10000
+    }
+    pub fn rocksdb_target_file_size_base() -> u64 {
+        64 << 20
+    } // 64MB
+    pub fn rocksdb_compression_type() -> super::CompressionType {
+        super::CompressionType::Lz4
+    }
+    pub fn small_compaction_threshold() -> usize {
+        5000
+    }
+    pub fn small_compaction_duration_threshold() -> usize {
+        10000
+    }
 }
 
 // config struct define
@@ -385,7 +439,8 @@ impl Config {
         let content =
             std::fs::read_to_string(path).context(crate::error::ConfigFileSnafu { path })?;
 
-        let mut config: Config = toml::from_str(&content).context(crate::error::InvalidConfigSnafu)?;
+        let mut config: Config =
+            toml::from_str(&content).context(crate::error::InvalidConfigSnafu)?;
 
         // If db-dir is set but db-path is not explicitly set, sync them
         if config.db_dir != defaults::db_dir() && config.db_path == defaults::db_path() {

--- a/src/conf/src/de_func.rs
+++ b/src/conf/src/de_func.rs
@@ -14,45 +14,60 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use std::collections::HashMap;
-
 use serde::{Deserialize, Deserializer, de};
 
 use crate::error::MemoryParseError;
+
+/// Serde deserializer for boolean fields that accept yes/no/true/false/1/0/on/off.
+/// TOML natively supports true/false, so this is mainly for backward-compatible values.
 pub fn deserialize_bool_from_yes_no<'de, D>(deserializer: D) -> Result<bool, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let s: String = Deserialize::deserialize(deserializer)?;
-    match s.to_lowercase().as_str() {
-        "yes" | "true" | "1" | "on" => Ok(true),
-        "no" | "false" | "0" | "off" => Ok(false),
-        _ => Err(de::Error::custom(
-            "expected one of: yes, no, true, false, 1, 0, on, off",
-        )),
+    // First try TOML native bool
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum BoolLike {
+        Bool(bool),
+        String(String),
+        Int(i64),
+    }
+
+    match BoolLike::deserialize(deserializer)? {
+        BoolLike::Bool(b) => Ok(b),
+        BoolLike::Int(i) => match i {
+            1 => Ok(true),
+            0 => Ok(false),
+            _ => Err(de::Error::custom(format!(
+                "invalid integer for bool: {}, expected 0 or 1",
+                i
+            ))),
+        },
+        BoolLike::String(s) => match s.to_lowercase().as_str() {
+            "yes" | "true" | "1" | "on" => Ok(true),
+            "no" | "false" | "0" | "off" => Ok(false),
+            _ => Err(de::Error::custom(
+                "expected one of: yes, no, true, false, 1, 0, on, off",
+            )),
+        },
     }
 }
 
+/// Serde deserializer for memory fields that accept human-readable sizes like "256MB", "1GB".
 pub fn deserialize_memory<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let s: String = Deserialize::deserialize(deserializer)?;
-    match parse_memory(s.as_str()) {
-        Ok(num) => Ok(num),
-        Err(e) => Err(de::Error::custom(e)),
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum MemoryLike {
+        Int(u64),
+        String(String),
     }
-}
 
-/// Parse boolean from string (for config parsing, not serde)
-pub fn parse_bool_from_string(s: &str) -> Result<bool, String> {
-    match s.to_lowercase().as_str() {
-        "yes" | "true" | "1" | "on" => Ok(true),
-        "no" | "false" | "0" | "off" => Ok(false),
-        _ => Err(format!(
-            "Invalid boolean value '{}', expected one of: yes, no, true, false, 1, 0, on, off",
-            s
-        )),
+    match MemoryLike::deserialize(deserializer)? {
+        MemoryLike::Int(n) => Ok(n),
+        MemoryLike::String(s) => parse_memory(s.as_str()).map_err(de::Error::custom),
     }
 }
 
@@ -96,70 +111,4 @@ pub fn parse_memory(input: &str) -> Result<u64, MemoryParseError> {
             raw: input.to_string(),
         }),
     }
-}
-
-/// Parse Redis-style configuration file content
-/// Supports comments starting with # and empty lines
-pub fn parse_redis_config(content: &str) -> Result<HashMap<String, String>, String> {
-    let mut config = HashMap::new();
-
-    for (line_num, raw_line) in content.lines().enumerate() {
-        // Remove inline comments (everything after '#'), then trim
-        let line = raw_line
-            .split_once('#')
-            .map_or(raw_line, |(before, _)| before)
-            .trim();
-
-        // Skip empty lines
-        if line.is_empty() {
-            continue;
-        }
-
-        // Parse key-value pairs
-        if let Some((key, value)) = parse_config_line(line) {
-            config.insert(key, value);
-        } else {
-            return Err(format!(
-                "Invalid configuration line {}: {}",
-                line_num + 1,
-                line
-            ));
-        }
-    }
-
-    Ok(config)
-}
-
-/// Parse a single configuration line
-/// Supports both "key value" and "key=value" formats
-fn parse_config_line(line: &str) -> Option<(String, String)> {
-    // Try "key=value" format first
-    if let Some(pos) = line.find('=') {
-        let key = line[..pos].trim().to_string();
-        let value = line[pos + 1..].trim().to_string();
-        return Some((key, value));
-    }
-
-    // Try "key value" format
-    if let Some(pos) = line.find(' ') {
-        let key = line[..pos].trim().to_string();
-        let value = line[pos..].trim().to_string();
-        if !value.is_empty() {
-            return Some((key, value));
-        }
-    }
-
-    None
-}
-
-/// Convert Redis-style configuration to INI format for compatibility
-pub fn redis_config_to_ini(content: &str) -> Result<String, String> {
-    let config = parse_redis_config(content)?;
-    let mut ini_content = String::new();
-
-    for (key, value) in config {
-        ini_content.push_str(&format!("{} = {}\n", key, value));
-    }
-
-    Ok(ini_content)
 }

--- a/src/conf/src/error.rs
+++ b/src/conf/src/error.rs
@@ -18,7 +18,6 @@ use std::io;
 use std::num::ParseIntError;
 use std::path::PathBuf;
 
-use serde_ini::de::Error as serdeErr;
 use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
@@ -28,7 +27,7 @@ pub enum Error {
     ConfigFile { source: io::Error, path: PathBuf },
 
     #[snafu(display("Invalid configuration: {}", source))]
-    InvalidConfig { source: serdeErr },
+    InvalidConfig { source: toml::de::Error },
 
     #[snafu(display("validate fail: {}", source))]
     ValidConfigFail { source: validator::ValidationErrors },

--- a/src/conf/src/lib.rs
+++ b/src/conf/src/lib.rs
@@ -19,7 +19,6 @@ pub mod de_func;
 pub mod error;
 pub mod raft_type;
 
-#[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod tests {
     use validator::Validate;
@@ -75,37 +74,8 @@ mod tests {
 
     #[test]
     fn test_validate_port_range() {
-        let mut invalid_config = Config {
-            binding: "127.0.0.1".to_string(),
-            port: 999,
-            timeout: 100,
-            redis_compatible_mode: false,
-            log_dir: "".to_string(),
-            db_dir: "./db".to_string(),
-            memory: 1024,
-            rocksdb_max_subcompactions: 0,
-            rocksdb_max_background_jobs: 4,
-            rocksdb_max_write_buffer_number: 2,
-            rocksdb_min_write_buffer_number_to_merge: 2,
-            rocksdb_write_buffer_size: 64 << 20,
-            rocksdb_level0_file_num_compaction_trigger: 4,
-            rocksdb_num_levels: 7,
-            rocksdb_enable_pipelined_write: false,
-            rocksdb_level0_slowdown_writes_trigger: 20,
-            rocksdb_level0_stop_writes_trigger: 36,
-            rocksdb_ttl_second: 30 * 24 * 60 * 60,
-            rocksdb_periodic_second: 30 * 24 * 60 * 60,
-            rocksdb_level_compaction_dynamic_level_bytes: true,
-            rocksdb_max_open_files: 10000,
-            rocksdb_target_file_size_base: 64 << 20,
-            rocksdb_compression_type: config::CompressionType::Lz4,
-            db_instance_num: 3,
-            small_compaction_threshold: 5000,
-            small_compaction_duration_threshold: 10000,
-            db_path: "./db".to_string(),
-            requirepass: None,
-            raft: None,
-        };
+        let mut invalid_config = Config::default();
+        invalid_config.port = 999;
         assert!(invalid_config.validate().is_err());
 
         invalid_config.port = 8080;
@@ -122,16 +92,109 @@ mod tests {
     fn test_db_dir_from_config_file() {
         use std::io::Write;
 
-        let filename = format!("kiwi_test_db_dir_{}.conf", std::process::id());
-        let tmp = std::env::temp_dir().join(filename);
+        let tmp = std::env::temp_dir().join(format!(
+            "kiwi_test_db_dir_{}.toml",
+            std::process::id()
+        ));
         let config_path = tmp.to_str().unwrap();
         let mut f = std::fs::File::create(config_path).unwrap();
-        writeln!(f, "port 7379").unwrap();
-        writeln!(f, "db-dir /data/kiwi/db").unwrap();
+        writeln!(f, "port = 7379").unwrap();
+        writeln!(f, "db-dir = \"/data/kiwi/db\"").unwrap();
         drop(f);
 
         let config = Config::load(config_path).unwrap();
         assert_eq!("/data/kiwi/db", config.db_dir);
+
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[test]
+    fn test_toml_raft_section() {
+        use std::io::Write;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "kiwi_test_raft_{}.toml",
+            std::process::id()
+        ));
+        let config_path = tmp.to_str().unwrap();
+        let mut f = std::fs::File::create(config_path).unwrap();
+        writeln!(f, "port = 7379").unwrap();
+        writeln!(f, "[raft]").unwrap();
+        writeln!(f, "node-id = 1").unwrap();
+        writeln!(f, "raft-addr = \"127.0.0.1:8081\"").unwrap();
+        writeln!(f, "resp-addr = \"127.0.0.1:6379\"").unwrap();
+        writeln!(f, "data-dir = \"/tmp/kiwi/raft\"").unwrap();
+        drop(f);
+
+        let config = Config::load(config_path).unwrap();
+        assert!(config.raft.is_some());
+        let raft = config.raft.unwrap();
+        assert_eq!(1, raft.node_id);
+        assert_eq!("127.0.0.1:8081", raft.raft_addr);
+        assert_eq!("127.0.0.1:6379", raft.resp_addr);
+        assert_eq!("/tmp/kiwi/raft", raft.data_dir);
+        assert!(!raft.use_memory_log_store);
+
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[test]
+    fn test_toml_memory_string() {
+        use std::io::Write;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "kiwi_test_memory_{}.toml",
+            std::process::id()
+        ));
+        let config_path = tmp.to_str().unwrap();
+        let mut f = std::fs::File::create(config_path).unwrap();
+        writeln!(f, "port = 7379").unwrap();
+        writeln!(f, "memory = \"2GB\"").unwrap();
+        drop(f);
+
+        let config = Config::load(config_path).unwrap();
+        assert_eq!(2 * 1024 * 1024 * 1024, config.memory);
+
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[test]
+    fn test_toml_memory_integer() {
+        use std::io::Write;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "kiwi_test_memory_int_{}.toml",
+            std::process::id()
+        ));
+        let config_path = tmp.to_str().unwrap();
+        let mut f = std::fs::File::create(config_path).unwrap();
+        writeln!(f, "port = 7379").unwrap();
+        writeln!(f, "memory = 536870912").unwrap(); // 512MB as raw bytes
+        drop(f);
+
+        let config = Config::load(config_path).unwrap();
+        assert_eq!(536870912, config.memory);
+
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[test]
+    fn test_minimal_toml() {
+        use std::io::Write;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "kiwi_test_minimal_{}.toml",
+            std::process::id()
+        ));
+        let config_path = tmp.to_str().unwrap();
+        let mut f = std::fs::File::create(config_path).unwrap();
+        writeln!(f, "# minimal config - everything else uses defaults").unwrap();
+        drop(f);
+
+        let config = Config::load(config_path).unwrap();
+        assert_eq!(7379, config.port);
+        assert_eq!("127.0.0.1", config.binding);
+        assert!(config.raft.is_none());
 
         let _ = std::fs::remove_file(config_path);
     }

--- a/src/conf/src/lib.rs
+++ b/src/conf/src/lib.rs
@@ -92,10 +92,8 @@ mod tests {
     fn test_db_dir_from_config_file() {
         use std::io::Write;
 
-        let tmp = std::env::temp_dir().join(format!(
-            "kiwi_test_db_dir_{}.toml",
-            std::process::id()
-        ));
+        let tmp =
+            std::env::temp_dir().join(format!("kiwi_test_db_dir_{}.toml", std::process::id()));
         let config_path = tmp.to_str().unwrap();
         let mut f = std::fs::File::create(config_path).unwrap();
         writeln!(f, "port = 7379").unwrap();
@@ -112,10 +110,7 @@ mod tests {
     fn test_toml_raft_section() {
         use std::io::Write;
 
-        let tmp = std::env::temp_dir().join(format!(
-            "kiwi_test_raft_{}.toml",
-            std::process::id()
-        ));
+        let tmp = std::env::temp_dir().join(format!("kiwi_test_raft_{}.toml", std::process::id()));
         let config_path = tmp.to_str().unwrap();
         let mut f = std::fs::File::create(config_path).unwrap();
         writeln!(f, "port = 7379").unwrap();
@@ -142,10 +137,8 @@ mod tests {
     fn test_toml_memory_string() {
         use std::io::Write;
 
-        let tmp = std::env::temp_dir().join(format!(
-            "kiwi_test_memory_{}.toml",
-            std::process::id()
-        ));
+        let tmp =
+            std::env::temp_dir().join(format!("kiwi_test_memory_{}.toml", std::process::id()));
         let config_path = tmp.to_str().unwrap();
         let mut f = std::fs::File::create(config_path).unwrap();
         writeln!(f, "port = 7379").unwrap();
@@ -162,10 +155,8 @@ mod tests {
     fn test_toml_memory_integer() {
         use std::io::Write;
 
-        let tmp = std::env::temp_dir().join(format!(
-            "kiwi_test_memory_int_{}.toml",
-            std::process::id()
-        ));
+        let tmp =
+            std::env::temp_dir().join(format!("kiwi_test_memory_int_{}.toml", std::process::id()));
         let config_path = tmp.to_str().unwrap();
         let mut f = std::fs::File::create(config_path).unwrap();
         writeln!(f, "port = 7379").unwrap();
@@ -182,10 +173,8 @@ mod tests {
     fn test_minimal_toml() {
         use std::io::Write;
 
-        let tmp = std::env::temp_dir().join(format!(
-            "kiwi_test_minimal_{}.toml",
-            std::process::id()
-        ));
+        let tmp =
+            std::env::temp_dir().join(format!("kiwi_test_minimal_{}.toml", std::process::id()));
         let config_path = tmp.to_str().unwrap();
         let mut f = std::fs::File::create(config_path).unwrap();
         writeln!(f, "# minimal config - everything else uses defaults").unwrap();


### PR DESCRIPTION
## Summary

Replace the hand-rolled Redis-style config parser with the `toml` crate + serde `Deserialize` for type-safe configuration parsing.

Closes #247

## Changes

### Dependencies
- Replace `serde_ini = "0.2.0"` with `toml = "0.8"` in `src/conf/Cargo.toml`

### `src/conf/src/config.rs`
- Add `Deserialize` derive with `#[serde(rename_all = "kebab-case")]` on `Config` and `RaftClusterConfig`
- Every field gets `#[serde(default = "...")]` pointing to a `defaults` module
- `Config::load()` rewritten: `toml::from_str()` replaces the 300-line `match` block
- `memory` field uses `deserialize_memory` — accepts both `"1GB"` strings and raw integer byte counts
- Custom `Deserialize` impl for `CompressionType` (case-insensitive string matching)

### `src/conf/src/de_func.rs`
- Remove `parse_redis_config`, `parse_config_line`, `redis_config_to_ini`, `parse_bool_from_string`
- Keep `deserialize_memory` + `parse_memory` (enhanced to accept both TOML integers and strings)
- Keep `deserialize_bool_from_yes_no` (enhanced to accept TOML native booleans)

### `src/conf/src/error.rs`
- Replace `serde_ini::de::Error` with `toml::de::Error` in the `InvalidConfig` variant

### `src/conf/kiwi.conf`
- Convert from Redis-style `key value` format to proper TOML format
- Raft section now uses `[raft]` table syntax

### `src/conf/src/lib.rs` (tests)
- Update existing tests for TOML format
- Add 4 new tests:
  - `test_toml_raft_section` — verifies `[raft]` TOML table parsing
  - `test_toml_memory_string` — verifies `memory = "2GB"` parsing
  - `test_toml_memory_integer` — verifies `memory = 536870912` parsing
  - `test_minimal_toml` — verifies empty file uses all defaults

## TOML Config Example

```toml
port = 7379
memory = "1GB"
db-dir = "./db"
rocksdb-compression-type = "lz4"

[raft]
node-id = 1
raft-addr = "127.0.0.1:8081"
resp-addr = "127.0.0.1:6379"
data-dir = "/tmp/kiwi/raft"
```

## Testing

```
running 8 tests
test tests::test_config_parsing ... ok
test tests::test_validate_port_range ... ok
test tests::test_db_dir_default ... ok
test tests::test_db_dir_from_config_file ... ok
test tests::test_toml_raft_section ... ok
test tests::test_toml_memory_string ... ok
test tests::test_toml_memory_integer ... ok
test tests::test_minimal_toml ... ok
```

Full workspace `cargo check` and `cargo test` pass.

## Benefits

- **Type-safe**: TOML deserializes directly to strongly-typed structs, no manual string parsing
- **~320 fewer lines**: removed 300+ lines of error-prone match arms
- **Native TOML sections**: `[raft]` maps to `Option<RaftClusterConfig>` natively
- **Better error messages**: `toml` crate reports exact line/column numbers
- **Industry standard**: TOML is widely used in the Rust ecosystem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Configuration file format migrated from Redis-style syntax to TOML format
  * The `kiwi.conf` configuration file now uses TOML key-value syntax with organized sections
  * Core operational settings and RocksDB tuning parameters are now configured via TOML

* **Documentation**
  * Added design documentation detailing the configuration system migration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arana-db/kiwi/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->