### PR TITLE
fix: clippy warnings

### DIFF
--- a/src/common/runtime/additional_unit_tests.rs
+++ b/src/common/runtime/additional_unit_tests.rs
@@ -24,11 +24,7 @@
 //! - Request/response serialization and correlation
 //! - Configuration validation and defaults
 
-#![allow(clippy::unwrap_used)]
-
 use std::time::Duration;
-
-use serde_json;
 
 // Import the dual runtime components
 use crate::manager::LifecycleState;

--- a/src/common/runtime/stress_tests.rs
+++ b/src/common/runtime/stress_tests.rs
@@ -25,8 +25,6 @@
 //!
 //! Requirements covered: 6.1, 6.2, 6.3, 6.4, 6.5
 
-#![allow(clippy::unwrap_used)]
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;

--- a/src/common/runtime/tests.rs
+++ b/src/common/runtime/tests.rs
@@ -17,8 +17,6 @@
 
 //! Unit tests for dual runtime architecture core components
 
-#![allow(clippy::unwrap_used)]
-
 use std::time::Duration;
 
 // Import the dual runtime components

--- a/src/net/tests/performance_tests.rs
+++ b/src/net/tests/performance_tests.rs
@@ -94,7 +94,7 @@ impl NetworkPerformanceTests {
                     let op_start = Instant::now();
 
                     // Simulate getting and returning a connection
-                    match pool_clone
+                    if let Ok(conn) = pool_clone
                         .get_connection(|| async {
                             // Simulate connection creation
                             tokio::time::sleep(Duration::from_micros(100)).await;
@@ -102,13 +102,10 @@ impl NetworkPerformanceTests {
                         })
                         .await
                     {
-                        Ok(conn) => {
-                            // Simulate some work
-                            tokio::time::sleep(Duration::from_micros(50)).await;
-                            pool_clone.return_connection(conn).await;
-                            client_successful += 1;
-                        }
-                        Err(_) => {}
+                        // Simulate some work
+                        tokio::time::sleep(Duration::from_micros(50)).await;
+                        pool_clone.return_connection(conn).await;
+                        client_successful += 1;
                     }
 
                     client_latencies.push(op_start.elapsed());

--- a/src/raft/src/log_store_rocksdb.rs
+++ b/src/raft/src/log_store_rocksdb.rs
@@ -662,13 +662,10 @@ mod tests {
             let deserialized: Entry<conf::raft_type::KiwiTypeConfig> = deserialize(&serialized).expect("Deserialization should succeed");
             prop_assert_eq!(entry.log_id, deserialized.log_id);
             // Note: We compare log_id and payload structure
-            match (&entry.payload, &deserialized.payload) {
-                (EntryPayload::Normal(b1), EntryPayload::Normal(b2)) => {
-                    prop_assert_eq!(b1.db_id, b2.db_id);
-                    prop_assert_eq!(b1.slot_idx, b2.slot_idx);
-                    prop_assert_eq!(b1.entries.len(), b2.entries.len());
-                }
-                _ => {}
+            if let (EntryPayload::Normal(b1), EntryPayload::Normal(b2)) = (&entry.payload, &deserialized.payload) {
+                prop_assert_eq!(b1.db_id, b2.db_id);
+                prop_assert_eq!(b1.slot_idx, b2.slot_idx);
+                prop_assert_eq!(b1.entries.len(), b2.entries.len());
             }
         }
     }
@@ -976,7 +973,7 @@ mod tests {
                     for entry in &sequential_entries {
                         let key = encode_log_key(entry.log_id.index);
                         let value = serialize(&entry).unwrap();
-                        batch.put_cf(&logs_cf, &key, &value);
+                        batch.put_cf(&logs_cf, key, &value);
                     }
 
                     engine_clone.write(batch).unwrap();
@@ -1112,7 +1109,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -1163,7 +1160,7 @@ mod tests {
 
             let key = encode_log_key(1);
             let corrupted_value = vec![0xFF, 0xFF, 0xFF, 0xFF]; // Invalid JSON
-            batch.put_cf(&logs_cf, &key, &corrupted_value);
+            batch.put_cf(&logs_cf, key, &corrupted_value);
 
             engine_clone.write(batch).unwrap();
         }
@@ -1238,7 +1235,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -1302,7 +1299,7 @@ mod tests {
 
             let key = encode_log_key(entry.log_id.index);
             let value = serialize(&entry).unwrap();
-            batch.put_cf(&logs_cf, &key, &value);
+            batch.put_cf(&logs_cf, key, &value);
 
             engine_clone.write(batch).unwrap();
         }
@@ -1704,7 +1701,7 @@ mod tests {
                     for entry in &sequential_entries {
                         let key = encode_log_key(entry.log_id.index);
                         let value = serialize(&entry).unwrap();
-                        batch.put_cf(&logs_cf, &key, &value);
+                        batch.put_cf(&logs_cf, key, &value);
                     }
 
                     engine_clone.write(batch).unwrap();
@@ -1784,7 +1781,7 @@ mod tests {
                     for entry in &sequential_entries {
                         let key = encode_log_key(entry.log_id.index);
                         let value = serialize(&entry).unwrap();
-                        batch.put_cf(&logs_cf, &key, &value);
+                        batch.put_cf(&logs_cf, key, &value);
                     }
 
                     engine_clone.write(batch).unwrap();
@@ -1878,7 +1875,7 @@ mod tests {
                     for entry in &sequential_entries {
                         let key = encode_log_key(entry.log_id.index);
                         let value = serialize(&entry).unwrap();
-                        batch.put_cf(&logs_cf, &key, &value);
+                        batch.put_cf(&logs_cf, key, &value);
                     }
 
                     engine_clone.write(batch).unwrap();
@@ -2018,7 +2015,7 @@ mod tests {
                     for entry in &sequential_entries {
                         let key = encode_log_key(entry.log_id.index);
                         let value = serialize(&entry).unwrap();
-                        batch.put_cf(&logs_cf, &key, &value);
+                        batch.put_cf(&logs_cf, key, &value);
                     }
 
                     engine_clone.write(batch).unwrap();
@@ -2143,7 +2140,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2220,7 +2217,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2296,7 +2293,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2385,7 +2382,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2501,7 +2498,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2557,7 +2554,7 @@ mod tests {
 
             let key = encode_log_key(entry.log_id.index);
             let value = serialize(&entry).unwrap();
-            batch.put_cf(&logs_cf, &key, &value);
+            batch.put_cf(&logs_cf, key, &value);
 
             engine_clone.write(batch).unwrap();
         }
@@ -2623,7 +2620,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2715,7 +2712,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2783,7 +2780,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2850,7 +2847,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2940,7 +2937,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -3042,7 +3039,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -3118,7 +3115,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -3207,7 +3204,7 @@ mod tests {
 
             let key = encode_log_key(entry.log_id.index);
             let value = serialize(&entry).unwrap();
-            batch.put_cf(&logs_cf, &key, &value);
+            batch.put_cf(&logs_cf, key, &value);
 
             engine_clone.write(batch).unwrap();
         }
@@ -3265,7 +3262,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -3329,7 +3326,7 @@ mod tests {
 
             let key = encode_log_key(entry1.log_id.index);
             let value = serialize(&entry1).unwrap();
-            batch.put_cf(&logs_cf, &key, &value);
+            batch.put_cf(&logs_cf, key, &value);
 
             engine_clone.write(batch).unwrap();
         }
@@ -3365,7 +3362,7 @@ mod tests {
 
             let key = encode_log_key(entry2.log_id.index);
             let value = serialize(&entry2).unwrap();
-            batch.put_cf(&logs_cf, &key, &value);
+            batch.put_cf(&logs_cf, key, &value);
 
             engine_clone.write(batch).unwrap();
         }
@@ -3410,7 +3407,7 @@ mod tests {
 
             let key = encode_log_key(entry.log_id.index);
             let value = serialize(&entry).unwrap();
-            batch.put_cf(&logs_cf, &key, &value);
+            batch.put_cf(&logs_cf, key, &value);
 
             engine_clone.write(batch).unwrap();
         }

--- a/src/raft/tests/log_store_rocksdb_test.rs
+++ b/src/raft/tests/log_store_rocksdb_test.rs
@@ -84,7 +84,7 @@ fn write_entries_directly(engine: &Arc<dyn Engine>, entries: &[Entry<KiwiTypeCon
     for entry in entries {
         let key = (entry.log_id.index).to_be_bytes();
         let value = serde_json::to_vec(&entry).expect("Serialization should succeed");
-        batch.put_cf(&logs_cf, &key, &value);
+        batch.put_cf(&logs_cf, key, &value);
     }
 
     engine.write(batch).expect("Write should succeed");
@@ -642,7 +642,7 @@ async fn test_large_entry_persistence() {
     {
         let _log_store = RocksdbLogStore::new(engine.clone()).expect("Failed to create log store");
 
-        write_entries_directly(&engine, &[large_entry.clone()]);
+        write_entries_directly(&engine, std::slice::from_ref(&large_entry));
     }
 
     // Phase 2: Restart and verify large entry

--- a/src/raft/tests/logindex_integration.rs
+++ b/src/raft/tests/logindex_integration.rs
@@ -73,8 +73,8 @@ fn test_full_flow_multi_cf_properties() {
     let expected_seq = db.latest_sequence_number();
 
     let cf_tracker = LogIndexOfColumnFamilies::new();
-    for i in 0..CF_NAMES.len() {
-        let cf = db.cf_handle(CF_NAMES[i]).expect("cf handle");
+    for cf_name in &CF_NAMES {
+        let cf = db.cf_handle(cf_name).expect("cf handle");
         let collection = db
             .get_properties_of_all_tables_cf(&cf)
             .expect("get properties");

--- a/src/storage/src/data_compaction_filter.rs
+++ b/src/storage/src/data_compaction_filter.rs
@@ -298,7 +298,7 @@ mod tests {
                     ListsMetaValue::new(bytes::Bytes::copy_from_slice(&1u64.to_le_bytes()));
                 meta_value.set_version(version);
                 meta_value.set_etime(etime);
-                db.put(&meta_key, &meta_value.encode()).unwrap();
+                db.put(&meta_key, meta_value.encode()).unwrap();
             }
             DataType::Hash | DataType::Set | DataType::ZSet => {
                 let mut meta_value =
@@ -306,7 +306,7 @@ mod tests {
                 meta_value.inner.data_type = data_type;
                 meta_value.set_version(version);
                 meta_value.set_etime(etime);
-                db.put(&meta_key, &meta_value.encode()).unwrap();
+                db.put(&meta_key, meta_value.encode()).unwrap();
             }
             _ => panic!("unsupported data type for meta: {data_type:?}"),
         }
@@ -430,7 +430,7 @@ mod tests {
         meta_value.inner.data_type = DataType::Hash;
         meta_value.set_version(1);
         meta_value.set_etime(past_time); // expired
-        db.put(&meta_key, &meta_value.encode()).unwrap();
+        db.put(&meta_key, meta_value.encode()).unwrap();
 
         std::thread::sleep(std::time::Duration::from_millis(10));
 
@@ -457,7 +457,7 @@ mod tests {
         meta_value.inner.data_type = DataType::Hash;
         meta_value.set_version(2); // meta version is 2
         meta_value.set_etime(0);
-        db.put(&meta_key, &meta_value.encode()).unwrap();
+        db.put(&meta_key, meta_value.encode()).unwrap();
 
         std::thread::sleep(std::time::Duration::from_millis(10));
 

--- a/src/storage/src/format_zset_score_key.rs
+++ b/src/storage/src/format_zset_score_key.rs
@@ -222,7 +222,7 @@ mod tests {
     fn test_encode_decode_roundtrip_basic() {
         let key = b"test_key";
         let version = 42u64;
-        let score = 3.14f64;
+        let score = 3.25f64;
         let member = b"member1";
 
         let score_key = ZSetsScoreKey::new(key, version, score, member);
@@ -400,7 +400,7 @@ mod tests {
     fn test_encode_seek_key_format() {
         let key = b"test_key";
         let version = 42u64;
-        let score = 3.14f64;
+        let score = 3.25f64;
         let member = b"member1";
 
         let score_key = ZSetsScoreKey::new(key, version, score, member);
@@ -485,7 +485,7 @@ mod tests {
         let mut encoded_keys = Vec::new();
 
         for member in &members {
-            let score_key = ZSetsScoreKey::new(key, version, score, *member);
+            let score_key = ZSetsScoreKey::new(key, version, score, member);
             let encoded = score_key.encode().expect("encode failed");
             encoded_keys.push(encoded);
         }

--- a/src/storage/src/meta_compaction_filter.rs
+++ b/src/storage/src/meta_compaction_filter.rs
@@ -146,7 +146,7 @@ mod tests {
 
     #[test]
     fn test_meta_compaction_filter_factory() {
-        let mut factory = MetaCompactionFilterFactory::default();
+        let mut factory = MetaCompactionFilterFactory;
         let context = CompactionFilterContext {
             is_full_compaction: false,
             is_manual_compaction: false,
@@ -162,7 +162,7 @@ mod tests {
 
     #[test]
     fn test_string_value_not_expired() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_key");
         let encoded_key = key.encode().unwrap();
 
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn test_string_value_expired() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_key");
         let encoded_key = key.encode().unwrap();
 
@@ -194,7 +194,7 @@ mod tests {
 
     #[test]
     fn test_string_value_permanent() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_key");
         let encoded_key = key.encode().unwrap();
 
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn test_list_meta_value_not_expired() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_list_key");
         let encoded_key = key.encode().unwrap();
 
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn test_list_meta_value_expired() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_list_key");
         let encoded_key = key.encode().unwrap();
 
@@ -242,7 +242,7 @@ mod tests {
 
     #[test]
     fn test_list_meta_value_empty_and_expired_version() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_list_key");
         let encoded_key = key.encode().unwrap();
 
@@ -258,7 +258,7 @@ mod tests {
 
     #[test]
     fn test_list_meta_value_empty_but_recent_version() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_list_key");
         let encoded_key = key.encode().unwrap();
 
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn test_hash_meta_value_not_expired() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_hash_key");
         let encoded_key = key.encode().unwrap();
 
@@ -292,7 +292,7 @@ mod tests {
 
     #[test]
     fn test_hash_meta_value_expired() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_hash_key");
         let encoded_key = key.encode().unwrap();
 
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn test_hash_meta_value_empty_and_expired_version() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_hash_key");
         let encoded_key = key.encode().unwrap();
 
@@ -327,7 +327,7 @@ mod tests {
 
     #[test]
     fn test_set_meta_value_expired() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_set_key");
         let encoded_key = key.encode().unwrap();
 
@@ -344,7 +344,7 @@ mod tests {
 
     #[test]
     fn test_zset_meta_value_expired() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_zset_key");
         let encoded_key = key.encode().unwrap();
 
@@ -361,7 +361,7 @@ mod tests {
 
     #[test]
     fn test_invalid_key() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let invalid_key = b"short"; // Key is too short to be valid
 
         let string_value = StringValue::new(b"test_value".as_slice());
@@ -373,7 +373,7 @@ mod tests {
 
     #[test]
     fn test_empty_value() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_key");
         let encoded_key = key.encode().unwrap();
 
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn test_invalid_data_type() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_key");
         let encoded_key = key.encode().unwrap();
 
@@ -398,7 +398,7 @@ mod tests {
 
     #[test]
     fn test_invalid_string_value_format() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_key");
         let encoded_key = key.encode().unwrap();
 
@@ -411,7 +411,7 @@ mod tests {
 
     #[test]
     fn test_unknown_data_type() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_key");
         let encoded_key = key.encode().unwrap();
 
@@ -425,7 +425,7 @@ mod tests {
 
     #[test]
     fn test_list_meta_value_with_etime_zero_but_expired_version() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_list_key");
         let encoded_key = key.encode().unwrap();
 
@@ -442,7 +442,7 @@ mod tests {
 
     #[test]
     fn test_hash_meta_value_with_etime_zero_but_expired_version() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_hash_key");
         let encoded_key = key.encode().unwrap();
 

--- a/src/storage/tests/redis_basic_test.rs
+++ b/src/storage/tests/redis_basic_test.rs
@@ -264,7 +264,7 @@ mod is_stale_tests {
         let redis = create_redis_instance();
         let result = redis.is_stale(&[]);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), false);
+        assert!(!result.unwrap());
     }
 
     #[test]
@@ -346,11 +346,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
-            "Permanent string should not be stale"
-        );
+        assert!(!result.unwrap(), "Permanent string should not be stale");
     }
 
     #[test]
@@ -361,9 +357,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Future-expiring string should not be stale"
         );
     }
@@ -376,7 +371,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "Expired string should be stale");
+        assert!(result.unwrap(), "Expired string should be stale");
     }
 
     #[test]
@@ -386,9 +381,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Empty permanent string should not be stale"
         );
     }
@@ -400,7 +394,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "Hash with count=0 should be stale");
+        assert!(result.unwrap(), "Hash with count=0 should be stale");
     }
 
     #[test]
@@ -410,9 +404,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Permanent hash with count>0 should not be stale"
         );
     }
@@ -425,9 +418,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Future-expiring hash with count>0 should not be stale"
         );
     }
@@ -440,7 +432,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "Expired hash should be stale");
+        assert!(result.unwrap(), "Expired hash should be stale");
     }
 
     #[test]
@@ -451,9 +443,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
+        assert!(
             result.unwrap(),
-            true,
             "Hash with count=0 should be stale even if not expired"
         );
     }
@@ -465,7 +456,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "Set with count=0 should be stale");
+        assert!(result.unwrap(), "Set with count=0 should be stale");
     }
 
     #[test]
@@ -475,9 +466,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Permanent set with count>0 should not be stale"
         );
     }
@@ -490,7 +480,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "Expired set should be stale");
+        assert!(result.unwrap(), "Expired set should be stale");
     }
 
     #[test]
@@ -500,7 +490,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "ZSet with count=0 should be stale");
+        assert!(result.unwrap(), "ZSet with count=0 should be stale");
     }
 
     #[test]
@@ -510,9 +500,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Permanent zset with count>0 should not be stale"
         );
     }
@@ -525,7 +514,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "Expired zset should be stale");
+        assert!(result.unwrap(), "Expired zset should be stale");
     }
 
     #[test]
@@ -535,7 +524,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "List with count=0 should be stale");
+        assert!(result.unwrap(), "List with count=0 should be stale");
     }
 
     #[test]
@@ -545,9 +534,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Permanent list with count>0 should not be stale"
         );
     }
@@ -560,9 +548,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Future-expiring list with count>0 should not be stale"
         );
     }
@@ -575,7 +562,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "Expired list should be stale");
+        assert!(result.unwrap(), "Expired list should be stale");
     }
 
     #[test]
@@ -586,7 +573,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "Value just expired should be stale");
+        assert!(result.unwrap(), "Value just expired should be stale");
     }
 
     #[test]
@@ -597,9 +584,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Value not yet expired should not be stale"
         );
     }
@@ -626,7 +612,7 @@ mod is_stale_tests {
         for (name, value) in test_cases {
             let result = redis.is_stale(&value);
             assert!(result.is_ok(), "{} type should be handled", name);
-            assert_eq!(result.unwrap(), false, "Valid {} should not be stale", name);
+            assert!(!result.unwrap(), "Valid {} should not be stale", name);
         }
     }
 
@@ -639,10 +625,6 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
-            "Hash with max count should not be stale"
-        );
+        assert!(!result.unwrap(), "Hash with max count should not be stale");
     }
 }

--- a/src/storage/tests/redis_list_test.rs
+++ b/src/storage/tests/redis_list_test.rs
@@ -1064,7 +1064,7 @@ mod redis_list_test {
 
                     if thread_id % 2 == 0 {
                         // Use LPUSHX
-                        match redis_clone.lpushx(&key, &[value.clone()]) {
+                        match redis_clone.lpushx(&key, std::slice::from_ref(&value)) {
                             Ok(len) if len > 0 => {
                                 successful_lpushx_clone.fetch_add(1, Ordering::Relaxed)
                             }
@@ -1073,7 +1073,7 @@ mod redis_list_test {
                         };
                     } else {
                         // Use RPUSHX
-                        match redis_clone.rpushx(&key, &[value.clone()]) {
+                        match redis_clone.rpushx(&key, std::slice::from_ref(&value)) {
                             Ok(len) if len > 0 => {
                                 successful_lpushx_clone.fetch_add(1, Ordering::Relaxed)
                             }

--- a/src/storage/tests/redis_zset_test.rs
+++ b/src/storage/tests/redis_zset_test.rs
@@ -114,7 +114,7 @@ mod redis_zset_test {
         println!("Results: {:?}", results);
 
         // For now, just check that we get some results
-        assert!(results.len() > 0, "Should return at least some results");
+        assert!(!results.is_empty(), "Should return at least some results");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Clean up clippy warnings across storage, raft, runtime, and net tests
- Remove redundant test attributes/imports and needless borrows
- Keep changes behavior-preserving while enabling strict clippy checks

## Validation
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --no-fail-fast
- cargo build --release --bin kiwi --locked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated runtime, storage, raft, and network test cases for clearer boolean assertions and improved consistency across scenarios.
  * Refined RocksDB-related test writes and metadata/entry persistence checks to use cleaner argument/borrowing patterns.
  * Adjusted several Redis test assertions and concurrency helpers to better validate expected outcomes.

* **Refactor**
  * Removed test-only lint suppressions and simplified a few test flows (e.g., conditional matching style) without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->