### PR TITLE
fix: raft binlog slot routing

### DIFF
--- a/src/storage/src/batch.rs
+++ b/src/storage/src/batch.rs
@@ -252,7 +252,7 @@ impl BinlogBatch {
         }
     }
 
-    fn infer_user_key(cf_idx: u32, encoded_key: &[u8]) -> Result<Vec<u8>> {
+    pub(crate) fn infer_user_key(cf_idx: u32, encoded_key: &[u8]) -> Result<Vec<u8>> {
         if cf_idx as usize >= ColumnFamilyIndex::COUNT {
             return InvalidFormatSnafu {
                 message: format!("Invalid column family index: {cf_idx}"),

--- a/src/storage/src/batch.rs
+++ b/src/storage/src/batch.rs
@@ -335,6 +335,10 @@ impl Batch for BinlogBatch {
     }
 
     fn commit(self: Box<Self>) -> Result<()> {
+        if self.entries.is_empty() {
+            return Ok(());
+        }
+
         let slot_idx = Self::infer_slot_idx(&self.entries)?;
         let binlog = Binlog {
             db_id: 0, // TODO: thread real db_id from Redis/Storage in a later task
@@ -366,7 +370,6 @@ impl Batch for BinlogBatch {
     }
 }
 
-#[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -380,9 +383,21 @@ mod tests {
 
     fn capture_append_log_fn(captured: Arc<Mutex<Option<conf::raft_type::Binlog>>>) -> AppendLogFn {
         Arc::new(move |binlog| {
-            *captured.lock().unwrap() = Some(binlog);
+            *captured
+                .lock()
+                .expect("capture_append_log_fn should lock captured binlog") = Some(binlog);
             Ok(BinlogResponse::ok())
         })
+    }
+
+    fn take_captured_binlog(
+        captured: &Arc<Mutex<Option<conf::raft_type::Binlog>>>,
+    ) -> conf::raft_type::Binlog {
+        captured
+            .lock()
+            .expect("BinlogBatch test should lock captured binlog")
+            .take()
+            .expect("BinlogBatch test should capture binlog")
     }
 
     #[test]
@@ -390,20 +405,24 @@ mod tests {
         let captured: Arc<Mutex<Option<conf::raft_type::Binlog>>> = Arc::new(Mutex::new(None));
         let append_log_fn = capture_append_log_fn(captured.clone());
         let user_key = b"k1";
-        let encoded_key = BaseKey::new(user_key).encode().unwrap();
+        let encoded_key = BaseKey::new(user_key)
+            .encode()
+            .expect("BinlogBatch test should encode base key");
 
         let mut batch = BinlogBatch::new(append_log_fn);
         batch
             .put(ColumnFamilyIndex::MetaCF, &encoded_key, b"v1")
-            .unwrap();
+            .expect("BinlogBatch test should put entry");
         batch
             .delete(ColumnFamilyIndex::MetaCF, &encoded_key)
-            .unwrap();
+            .expect("BinlogBatch test should delete entry");
         assert_eq!(batch.count(), 2);
 
-        Box::new(batch).commit().unwrap();
+        Box::new(batch)
+            .commit()
+            .expect("BinlogBatch test should commit entries");
 
-        let binlog = captured.lock().unwrap().take().expect("binlog captured");
+        let binlog = take_captured_binlog(&captured);
         assert_eq!(binlog.slot_idx, key_to_slot_id(user_key) as u32);
         assert_eq!(binlog.entries.len(), 2);
         assert_eq!(binlog.entries[0].cf_idx, ColumnFamilyIndex::MetaCF as u32);
@@ -417,12 +436,33 @@ mod tests {
     fn test_binlog_batch_commit_propagates_error() {
         let append_log_fn: AppendLogFn = Arc::new(|_binlog| Err("raft unavailable".to_string()));
         let mut batch = BinlogBatch::new(append_log_fn);
-        let encoded_key = BaseKey::new(b"k").encode().unwrap();
+        let encoded_key = BaseKey::new(b"k")
+            .encode()
+            .expect("BinlogBatch error test should encode base key");
         batch
             .put(ColumnFamilyIndex::MetaCF, &encoded_key, b"v")
-            .unwrap();
+            .expect("BinlogBatch error test should put entry");
         let result = Box::new(batch).commit();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_binlog_batch_commit_empty_is_noop() {
+        let captured: Arc<Mutex<Option<conf::raft_type::Binlog>>> = Arc::new(Mutex::new(None));
+        let append_log_fn = capture_append_log_fn(captured.clone());
+        let batch = BinlogBatch::new(append_log_fn);
+
+        Box::new(batch)
+            .commit()
+            .expect("empty BinlogBatch commit should be a no-op");
+
+        assert!(
+            captured
+                .lock()
+                .expect("empty BinlogBatch test should lock captured binlog")
+                .is_none(),
+            "empty BinlogBatch commit should not append a binlog"
+        );
     }
 
     #[test]
@@ -430,15 +470,19 @@ mod tests {
         let captured: Arc<Mutex<Option<conf::raft_type::Binlog>>> = Arc::new(Mutex::new(None));
         let append_log_fn = capture_append_log_fn(captured.clone());
         let user_key = b"hash_key";
-        let encoded_key = MemberDataKey::new(user_key, 1, b"field").encode().unwrap();
+        let encoded_key = MemberDataKey::new(user_key, 1, b"field")
+            .encode()
+            .expect("BinlogBatch member test should encode member key");
 
         let mut batch = BinlogBatch::new(append_log_fn);
         batch
             .put(ColumnFamilyIndex::HashesDataCF, &encoded_key, b"value")
-            .unwrap();
-        Box::new(batch).commit().unwrap();
+            .expect("BinlogBatch member test should put entry");
+        Box::new(batch)
+            .commit()
+            .expect("BinlogBatch member test should commit entries");
 
-        let binlog = captured.lock().unwrap().take().expect("binlog captured");
+        let binlog = take_captured_binlog(&captured);
         assert_eq!(binlog.slot_idx, key_to_slot_id(user_key) as u32);
     }
 
@@ -447,15 +491,19 @@ mod tests {
         let captured: Arc<Mutex<Option<conf::raft_type::Binlog>>> = Arc::new(Mutex::new(None));
         let append_log_fn = capture_append_log_fn(captured.clone());
         let user_key = b"list_key";
-        let encoded_key = ListsDataKey::new(user_key, 1, 42).encode().unwrap();
+        let encoded_key = ListsDataKey::new(user_key, 1, 42)
+            .encode()
+            .expect("BinlogBatch list test should encode list key");
 
         let mut batch = BinlogBatch::new(append_log_fn);
         batch
             .put(ColumnFamilyIndex::ListsDataCF, &encoded_key, b"value")
-            .unwrap();
-        Box::new(batch).commit().unwrap();
+            .expect("BinlogBatch list test should put entry");
+        Box::new(batch)
+            .commit()
+            .expect("BinlogBatch list test should commit entries");
 
-        let binlog = captured.lock().unwrap().take().expect("binlog captured");
+        let binlog = take_captured_binlog(&captured);
         assert_eq!(binlog.slot_idx, key_to_slot_id(user_key) as u32);
     }
 
@@ -466,15 +514,17 @@ mod tests {
         let user_key = b"zset_key";
         let encoded_key = ZSetsScoreKey::new(user_key, 1, 2.5, b"member")
             .encode()
-            .unwrap();
+            .expect("BinlogBatch zset score test should encode score key");
 
         let mut batch = BinlogBatch::new(append_log_fn);
         batch
             .put(ColumnFamilyIndex::ZsetsScoreCF, &encoded_key, b"")
-            .unwrap();
-        Box::new(batch).commit().unwrap();
+            .expect("BinlogBatch zset score test should put entry");
+        Box::new(batch)
+            .commit()
+            .expect("BinlogBatch zset score test should commit entries");
 
-        let binlog = captured.lock().unwrap().take().expect("binlog captured");
+        let binlog = take_captured_binlog(&captured);
         assert_eq!(binlog.slot_idx, key_to_slot_id(user_key) as u32);
     }
 
@@ -488,19 +538,29 @@ mod tests {
             .find(|key| key_to_slot_id(key.as_bytes()) != first_slot)
             .expect("test keys should include a different slot");
 
-        let first_key = BaseKey::new(first_user_key).encode().unwrap();
-        let second_key = BaseKey::new(second_user_key.as_bytes()).encode().unwrap();
+        let first_key = BaseKey::new(first_user_key)
+            .encode()
+            .expect("BinlogBatch cross-slot test should encode first key");
+        let second_key = BaseKey::new(second_user_key.as_bytes())
+            .encode()
+            .expect("BinlogBatch cross-slot test should encode second key");
 
         let mut batch = BinlogBatch::new(append_log_fn);
         batch
             .put(ColumnFamilyIndex::MetaCF, &first_key, b"v1")
-            .unwrap();
+            .expect("BinlogBatch cross-slot test should put first entry");
         batch
             .put(ColumnFamilyIndex::MetaCF, &second_key, b"v2")
-            .unwrap();
+            .expect("BinlogBatch cross-slot test should put second entry");
 
         let result = Box::new(batch).commit();
         assert!(result.is_err());
-        assert!(format!("{:?}", result.unwrap_err()).contains("CROSSSLOT"));
+        assert!(
+            format!(
+                "{:?}",
+                result.expect_err("BinlogBatch cross-slot test should reject commit")
+            )
+            .contains("CROSSSLOT")
+        );
     }
 }

--- a/src/storage/src/batch.rs
+++ b/src/storage/src/batch.rs
@@ -44,7 +44,10 @@ use rocksdb::{BoundColumnFamily, WriteBatch, WriteOptions};
 use snafu::ResultExt;
 
 use crate::ColumnFamilyIndex;
-use crate::error::{BatchSnafu, Result, RocksSnafu};
+use crate::error::{BatchSnafu, InvalidFormatSnafu, Result, RocksSnafu};
+use crate::slot_indexer::key_to_slot_id;
+use crate::storage_define::{PREFIX_RESERVE_LENGTH, decode_user_key, seek_userkey_delim};
+use bytes::BytesMut;
 use engine::Engine;
 
 /// Trait for batch write operations.
@@ -234,7 +237,6 @@ pub type AppendLogFn =
 /// hands the assembled `Binlog` to `append_log_fn` (which proposes via Raft).
 pub struct BinlogBatch {
     append_log_fn: AppendLogFn,
-    slot_idx: u32,
     entries: Vec<BinlogEntry>,
 }
 
@@ -243,13 +245,71 @@ impl BinlogBatch {
     ///
     /// # Arguments
     /// * `append_log_fn` - Closure that proposes the binlog through Raft.
-    /// * `slot_idx` - Slot index this batch writes to (single-slot per binlog).
-    pub fn new(append_log_fn: AppendLogFn, slot_idx: u32) -> Self {
+    pub fn new(append_log_fn: AppendLogFn) -> Self {
         Self {
             append_log_fn,
-            slot_idx,
             entries: Vec::new(),
         }
+    }
+
+    fn infer_user_key(cf_idx: u32, encoded_key: &[u8]) -> Result<Vec<u8>> {
+        if cf_idx as usize >= ColumnFamilyIndex::COUNT {
+            return InvalidFormatSnafu {
+                message: format!("Invalid column family index: {cf_idx}"),
+            }
+            .fail();
+        }
+
+        if encoded_key.len() <= PREFIX_RESERVE_LENGTH {
+            return InvalidFormatSnafu {
+                message: format!(
+                    "Encoded key too short to infer binlog slot: len={}",
+                    encoded_key.len()
+                ),
+            }
+            .fail();
+        }
+
+        let key_part_start = PREFIX_RESERVE_LENGTH;
+        let key_part = &encoded_key[key_part_start..];
+        let key_part_end = seek_userkey_delim(key_part);
+        if key_part_end > key_part.len() {
+            return InvalidFormatSnafu {
+                message: "Encoded key delimiter not found while inferring binlog slot".to_string(),
+            }
+            .fail();
+        }
+
+        let mut user_key = BytesMut::new();
+        decode_user_key(&key_part[..key_part_end], &mut user_key)?;
+        Ok(user_key.to_vec())
+    }
+
+    fn infer_slot_idx(entries: &[BinlogEntry]) -> Result<u32> {
+        let mut inferred_slot = None;
+
+        for entry in entries {
+            let user_key = Self::infer_user_key(entry.cf_idx, &entry.key)?;
+            let slot = key_to_slot_id(&user_key) as u32;
+
+            match inferred_slot {
+                Some(existing) if existing != slot => {
+                    return BatchSnafu {
+                        message: format!(
+                            "CROSSSLOT binlog batch contains multiple slots: {existing} and {slot}"
+                        ),
+                    }
+                    .fail();
+                }
+                Some(_) => {}
+                None => inferred_slot = Some(slot),
+            }
+        }
+
+        inferred_slot.ok_or_else(|| crate::error::Error::Batch {
+            message: "Cannot infer slot for empty binlog batch".to_string(),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })
     }
 }
 
@@ -275,9 +335,10 @@ impl Batch for BinlogBatch {
     }
 
     fn commit(self: Box<Self>) -> Result<()> {
+        let slot_idx = Self::infer_slot_idx(&self.entries)?;
         let binlog = Binlog {
             db_id: 0, // TODO: thread real db_id from Redis/Storage in a later task
-            slot_idx: self.slot_idx,
+            slot_idx,
             entries: self.entries,
         };
         let resp = (self.append_log_fn)(binlog).map_err(|message| crate::error::Error::Batch {
@@ -309,29 +370,41 @@ impl Batch for BinlogBatch {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::format_base_key::BaseKey;
+    use crate::format_lists_data_key::ListsDataKey;
+    use crate::format_member_data_key::MemberDataKey;
+    use crate::format_zset_score_key::ZSetsScoreKey;
+    use crate::slot_indexer::key_to_slot_id;
     use conf::raft_type::{BinlogResponse, OperateType};
     use std::sync::{Arc, Mutex};
+
+    fn capture_append_log_fn(captured: Arc<Mutex<Option<conf::raft_type::Binlog>>>) -> AppendLogFn {
+        Arc::new(move |binlog| {
+            *captured.lock().unwrap() = Some(binlog);
+            Ok(BinlogResponse::ok())
+        })
+    }
 
     #[test]
     fn test_binlog_batch_accumulates_entries() {
         let captured: Arc<Mutex<Option<conf::raft_type::Binlog>>> = Arc::new(Mutex::new(None));
-        let captured_cl = captured.clone();
-        let append_log_fn: AppendLogFn = Arc::new(move |binlog| {
-            *captured_cl.lock().unwrap() = Some(binlog);
-            Ok(BinlogResponse::ok())
-        });
+        let append_log_fn = capture_append_log_fn(captured.clone());
+        let user_key = b"k1";
+        let encoded_key = BaseKey::new(user_key).encode().unwrap();
 
-        let mut batch = BinlogBatch::new(append_log_fn, 7);
-        batch.put(ColumnFamilyIndex::MetaCF, b"k1", b"v1").unwrap();
+        let mut batch = BinlogBatch::new(append_log_fn);
         batch
-            .delete(ColumnFamilyIndex::HashesDataCF, b"k2")
+            .put(ColumnFamilyIndex::MetaCF, &encoded_key, b"v1")
+            .unwrap();
+        batch
+            .delete(ColumnFamilyIndex::MetaCF, &encoded_key)
             .unwrap();
         assert_eq!(batch.count(), 2);
 
         Box::new(batch).commit().unwrap();
 
         let binlog = captured.lock().unwrap().take().expect("binlog captured");
-        assert_eq!(binlog.slot_idx, 7);
+        assert_eq!(binlog.slot_idx, key_to_slot_id(user_key) as u32);
         assert_eq!(binlog.entries.len(), 2);
         assert_eq!(binlog.entries[0].cf_idx, ColumnFamilyIndex::MetaCF as u32);
         assert_eq!(binlog.entries[0].op_type, OperateType::Put);
@@ -343,9 +416,91 @@ mod tests {
     #[test]
     fn test_binlog_batch_commit_propagates_error() {
         let append_log_fn: AppendLogFn = Arc::new(|_binlog| Err("raft unavailable".to_string()));
-        let mut batch = BinlogBatch::new(append_log_fn, 0);
-        batch.put(ColumnFamilyIndex::MetaCF, b"k", b"v").unwrap();
+        let mut batch = BinlogBatch::new(append_log_fn);
+        let encoded_key = BaseKey::new(b"k").encode().unwrap();
+        batch
+            .put(ColumnFamilyIndex::MetaCF, &encoded_key, b"v")
+            .unwrap();
         let result = Box::new(batch).commit();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_binlog_batch_infers_slot_from_member_data_key() {
+        let captured: Arc<Mutex<Option<conf::raft_type::Binlog>>> = Arc::new(Mutex::new(None));
+        let append_log_fn = capture_append_log_fn(captured.clone());
+        let user_key = b"hash_key";
+        let encoded_key = MemberDataKey::new(user_key, 1, b"field").encode().unwrap();
+
+        let mut batch = BinlogBatch::new(append_log_fn);
+        batch
+            .put(ColumnFamilyIndex::HashesDataCF, &encoded_key, b"value")
+            .unwrap();
+        Box::new(batch).commit().unwrap();
+
+        let binlog = captured.lock().unwrap().take().expect("binlog captured");
+        assert_eq!(binlog.slot_idx, key_to_slot_id(user_key) as u32);
+    }
+
+    #[test]
+    fn test_binlog_batch_infers_slot_from_list_data_key() {
+        let captured: Arc<Mutex<Option<conf::raft_type::Binlog>>> = Arc::new(Mutex::new(None));
+        let append_log_fn = capture_append_log_fn(captured.clone());
+        let user_key = b"list_key";
+        let encoded_key = ListsDataKey::new(user_key, 1, 42).encode().unwrap();
+
+        let mut batch = BinlogBatch::new(append_log_fn);
+        batch
+            .put(ColumnFamilyIndex::ListsDataCF, &encoded_key, b"value")
+            .unwrap();
+        Box::new(batch).commit().unwrap();
+
+        let binlog = captured.lock().unwrap().take().expect("binlog captured");
+        assert_eq!(binlog.slot_idx, key_to_slot_id(user_key) as u32);
+    }
+
+    #[test]
+    fn test_binlog_batch_infers_slot_from_zset_score_key() {
+        let captured: Arc<Mutex<Option<conf::raft_type::Binlog>>> = Arc::new(Mutex::new(None));
+        let append_log_fn = capture_append_log_fn(captured.clone());
+        let user_key = b"zset_key";
+        let encoded_key = ZSetsScoreKey::new(user_key, 1, 2.5, b"member")
+            .encode()
+            .unwrap();
+
+        let mut batch = BinlogBatch::new(append_log_fn);
+        batch
+            .put(ColumnFamilyIndex::ZsetsScoreCF, &encoded_key, b"")
+            .unwrap();
+        Box::new(batch).commit().unwrap();
+
+        let binlog = captured.lock().unwrap().take().expect("binlog captured");
+        assert_eq!(binlog.slot_idx, key_to_slot_id(user_key) as u32);
+    }
+
+    #[test]
+    fn test_binlog_batch_rejects_cross_slot_entries() {
+        let append_log_fn: AppendLogFn = Arc::new(|_binlog| Ok(BinlogResponse::ok()));
+        let first_user_key = b"key_one";
+        let first_slot = key_to_slot_id(first_user_key);
+        let second_user_key = (0..1000)
+            .map(|index| format!("key_two_{index}"))
+            .find(|key| key_to_slot_id(key.as_bytes()) != first_slot)
+            .expect("test keys should include a different slot");
+
+        let first_key = BaseKey::new(first_user_key).encode().unwrap();
+        let second_key = BaseKey::new(second_user_key.as_bytes()).encode().unwrap();
+
+        let mut batch = BinlogBatch::new(append_log_fn);
+        batch
+            .put(ColumnFamilyIndex::MetaCF, &first_key, b"v1")
+            .unwrap();
+        batch
+            .put(ColumnFamilyIndex::MetaCF, &second_key, b"v2")
+            .unwrap();
+
+        let result = Box::new(batch).commit();
+        assert!(result.is_err());
+        assert!(format!("{:?}", result.unwrap_err()).contains("CROSSSLOT"));
     }
 }

--- a/src/storage/src/redis.rs
+++ b/src/storage/src/redis.rs
@@ -452,14 +452,7 @@ impl Redis {
     /// ```
     pub fn create_batch(&self) -> Result<Box<dyn crate::batch::Batch + '_>> {
         if let Some(f) = self.append_log_fn.get() {
-            // TODO(Task 4): self.index is the RocksDB instance ID, not a Redis hash
-            // slot. on_binlog_write routes by slot_idx % instance_num, so this only
-            // round-trips by coincidence. Thread the real slot through here.
-            let slot_idx = self.index as u32;
-            return Ok(Box::new(crate::batch::BinlogBatch::new(
-                f.clone(),
-                slot_idx,
-            )));
+            return Ok(Box::new(crate::batch::BinlogBatch::new(f.clone())));
         }
 
         self.create_rocks_batch()

--- a/src/storage/src/redis_strings.rs
+++ b/src/storage/src/redis_strings.rs
@@ -22,10 +22,12 @@ use chrono::Utc;
 use kstd::lock_mgr::ScopeRecordLock;
 use rocksdb::ReadOptions;
 use snafu::{OptionExt, ResultExt};
+use std::collections::HashMap;
 
 use crate::error::Error::*;
+use crate::slot_indexer::key_to_slot_id;
 use crate::{
-    BaseMetaKey, ColumnFamilyIndex, DataType, Redis, Result, TypeCheckState,
+    BaseMetaKey, BinlogBatch, ColumnFamilyIndex, DataType, Redis, Result, TypeCheckState,
     error::{InvalidFormatSnafu, KeyNotFoundSnafu, OptionNoneSnafu, RocksSnafu},
     format_base_key::BaseKey,
     format_strings_value::{ParsedStringsValue, StringValue},
@@ -2158,24 +2160,47 @@ impl Redis {
 
                     // When chunk is full, delete and clear
                     if keys_chunk.len() >= CHUNK_SIZE {
-                        let mut batch = self.create_batch()?;
-                        for key in &keys_chunk {
-                            batch.delete(cf_index, key)?;
-                        }
-                        batch.commit()?;
+                        self.flush_keys_chunk(cf_index, &keys_chunk)?;
                         keys_chunk.clear();
                     }
                 }
 
                 // Delete remaining keys in the last chunk
                 if !keys_chunk.is_empty() {
-                    let mut batch = self.create_batch()?;
-                    for key in &keys_chunk {
-                        batch.delete(cf_index, key)?;
-                    }
-                    batch.commit()?;
+                    self.flush_keys_chunk(cf_index, &keys_chunk)?;
                 }
             }
+        }
+
+        Ok(())
+    }
+
+    fn flush_keys_chunk(&self, cf_index: ColumnFamilyIndex, keys_chunk: &[Vec<u8>]) -> Result<()> {
+        if keys_chunk.is_empty() {
+            return Ok(());
+        }
+
+        if self.append_log_fn.get().is_none() {
+            let mut batch = self.create_batch()?;
+            for key in keys_chunk {
+                batch.delete(cf_index, key)?;
+            }
+            return batch.commit();
+        }
+
+        let mut keys_by_slot: HashMap<u32, Vec<&Vec<u8>>> = HashMap::new();
+        for key in keys_chunk {
+            let user_key = BinlogBatch::infer_user_key(cf_index as u32, key)?;
+            let slot_idx = key_to_slot_id(&user_key) as u32;
+            keys_by_slot.entry(slot_idx).or_default().push(key);
+        }
+
+        for keys in keys_by_slot.into_values() {
+            let mut batch = self.create_batch()?;
+            for key in keys {
+                batch.delete(cf_index, key)?;
+            }
+            batch.commit()?;
         }
 
         Ok(())

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -712,9 +712,11 @@ mod append_log_fn_tests {
         inst.set_append_log_fn(f);
 
         let mut b = inst.create_batch().unwrap();
-        let encoded_key = crate::format_base_key::BaseKey::new(b"k").encode().unwrap();
+        let encoded_key = crate::format_base_key::BaseKey::new(b"k")
+            .encode()
+            .expect("cluster batch test should encode base key");
         b.put(crate::ColumnFamilyIndex::MetaCF, &encoded_key, b"v")
-            .unwrap();
+            .expect("cluster batch test should put encoded base key");
         Box::new(b).commit().unwrap();
         assert!(
             called.load(Ordering::SeqCst),

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -642,6 +642,7 @@ mod append_log_fn_tests {
     use crate::batch::AppendLogFn;
     use conf::raft_type::BinlogResponse;
     use std::sync::Arc;
+    use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, Ordering};
 
     // These tests open a full RocksDB via `Storage::open`. RocksDB keeps
@@ -765,6 +766,58 @@ mod append_log_fn_tests {
             0,
             "on_binlog_write must not propose to raft"
         );
+
+        crate::safe_cleanup_test_db(&path);
+    }
+
+    #[tokio::test]
+    async fn test_flushdb_groups_cluster_binlogs_by_slot() {
+        if running_under_sanitizer() {
+            return;
+        }
+
+        let path = crate::unique_test_db_path();
+        let mut storage = Storage::new(1, 0);
+        storage
+            .open(Arc::new(crate::StorageOptions::default()), &path)
+            .unwrap();
+
+        let first_key = b"flush_slot_one";
+        let first_slot = crate::slot_indexer::key_to_slot_id(first_key);
+        let second_key = (0..1000)
+            .map(|index| format!("flush_slot_two_{index}"))
+            .find(|key| crate::slot_indexer::key_to_slot_id(key.as_bytes()) != first_slot)
+            .expect("test keys should include a different slot");
+
+        storage.set(first_key, b"v1").unwrap();
+        storage.set(second_key.as_bytes(), b"v2").unwrap();
+
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let captured_cl = captured.clone();
+        let f: AppendLogFn = Arc::new(move |binlog| {
+            captured_cl.lock().unwrap().push(binlog);
+            Ok(BinlogResponse::ok())
+        });
+        storage.set_append_log_fn(f);
+
+        storage.flushdb().unwrap();
+
+        let binlogs = captured.lock().unwrap();
+        assert!(
+            binlogs.len() >= 2,
+            "flushdb should split multi-slot keys into separate binlogs"
+        );
+        for binlog in binlogs.iter() {
+            assert!(!binlog.entries.is_empty());
+            for entry in &binlog.entries {
+                let user_key = crate::BinlogBatch::infer_user_key(entry.cf_idx, &entry.key)
+                    .expect("flushdb should emit decodable keys");
+                assert_eq!(
+                    binlog.slot_idx,
+                    crate::slot_indexer::key_to_slot_id(&user_key) as u32
+                );
+            }
+        }
 
         crate::safe_cleanup_test_db(&path);
     }

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -711,7 +711,9 @@ mod append_log_fn_tests {
         inst.set_append_log_fn(f);
 
         let mut b = inst.create_batch().unwrap();
-        b.put(crate::ColumnFamilyIndex::MetaCF, b"k", b"v").unwrap();
+        let encoded_key = crate::format_base_key::BaseKey::new(b"k").encode().unwrap();
+        b.put(crate::ColumnFamilyIndex::MetaCF, &encoded_key, b"v")
+            .unwrap();
         Box::new(b).commit().unwrap();
         assert!(
             called.load(Ordering::SeqCst),


### PR DESCRIPTION
## Summary
- Infer Raft binlog slot IDs from encoded batch entry keys at commit time
- Remove the incorrect use of Redis instance index as `Binlog.slot_idx`
- Reject cross-slot binlog batches instead of proposing incorrectly routed Raft logs
- Add coverage for meta/member/list/zset-score key slot inference

## Validation
- `cargo fmt --all --check`
- `cargo test -p storage batch::tests -- --nocapture`
- `cargo test -p storage`
- `cargo check --workspace`

Note: `cargo clippy --workspace --all-targets -- -D warnings` is still blocked by pre-existing warnings on main unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Binlog batch commits now automatically infer the target cluster slot from the keys collected in the batch.
  * Cluster-mode flush/deletion now groups work by slot to emit slot-specific binlogs.

* **Bug Fixes**
  * Improved slot inference across additional encoded key formats.
  * Empty batches no longer emit binlogs, and cross-slot batches are rejected with a clear error.

* **Tests**
  * Updated and added coverage for slot inference, empty-batch behavior, and multi-slot flush expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->