### PR TITLE
fix: re-arm raft append hook after snapshot install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,7 @@ jobs:
                 --workspace --exclude storage \
                 -- --skip cursor_snapshot_roundtrip \
                 --skip install_snapshot_with_existing_data \
+                --skip install_snapshot_rearms_append_log_hook \
                 --skip test_snapshot_with_logindex_state \
                 --skip test_on_binlog_write_updates_collector \
                 --skip test_collector_state_export_restore

--- a/src/common/runtime/additional_unit_tests.rs
+++ b/src/common/runtime/additional_unit_tests.rs
@@ -24,11 +24,7 @@
 //! - Request/response serialization and correlation
 //! - Configuration validation and defaults
 
-#![allow(clippy::unwrap_used)]
-
 use std::time::Duration;
-
-use serde_json;
 
 // Import the dual runtime components
 use crate::manager::LifecycleState;

--- a/src/common/runtime/stress_tests.rs
+++ b/src/common/runtime/stress_tests.rs
@@ -25,8 +25,6 @@
 //!
 //! Requirements covered: 6.1, 6.2, 6.3, 6.4, 6.5
 
-#![allow(clippy::unwrap_used)]
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;

--- a/src/common/runtime/tests.rs
+++ b/src/common/runtime/tests.rs
@@ -17,8 +17,6 @@
 
 //! Unit tests for dual runtime architecture core components
 
-#![allow(clippy::unwrap_used)]
-
 use std::time::Duration;
 
 // Import the dual runtime components

--- a/src/kstd/src/lock_mgr.rs
+++ b/src/kstd/src/lock_mgr.rs
@@ -90,10 +90,7 @@ impl LockMgr {
         let indexes = self.sorted_indexes(keys);
         let mut guards = Vec::with_capacity(indexes.len());
         for index in indexes {
-            match self.mutex_pool[index].try_lock() {
-                Some(guard) => guards.push(guard),
-                None => return None,
-            }
+            guards.push(self.mutex_pool[index].try_lock()?);
         }
         Some(ScopedMultiLock { guards })
     }

--- a/src/net/tests/performance_tests.rs
+++ b/src/net/tests/performance_tests.rs
@@ -94,7 +94,7 @@ impl NetworkPerformanceTests {
                     let op_start = Instant::now();
 
                     // Simulate getting and returning a connection
-                    match pool_clone
+                    if let Ok(conn) = pool_clone
                         .get_connection(|| async {
                             // Simulate connection creation
                             tokio::time::sleep(Duration::from_micros(100)).await;
@@ -102,13 +102,10 @@ impl NetworkPerformanceTests {
                         })
                         .await
                     {
-                        Ok(conn) => {
-                            // Simulate some work
-                            tokio::time::sleep(Duration::from_micros(50)).await;
-                            pool_clone.return_connection(conn).await;
-                            client_successful += 1;
-                        }
-                        Err(_) => {}
+                        // Simulate some work
+                        tokio::time::sleep(Duration::from_micros(50)).await;
+                        pool_clone.return_connection(conn).await;
+                        client_successful += 1;
                     }
 
                     client_latencies.push(op_start.elapsed());

--- a/src/raft/src/log_store_rocksdb.rs
+++ b/src/raft/src/log_store_rocksdb.rs
@@ -662,13 +662,12 @@ mod tests {
             let deserialized: Entry<conf::raft_type::KiwiTypeConfig> = deserialize(&serialized).expect("Deserialization should succeed");
             prop_assert_eq!(entry.log_id, deserialized.log_id);
             // Note: We compare log_id and payload structure
-            match (&entry.payload, &deserialized.payload) {
-                (EntryPayload::Normal(b1), EntryPayload::Normal(b2)) => {
-                    prop_assert_eq!(b1.db_id, b2.db_id);
-                    prop_assert_eq!(b1.slot_idx, b2.slot_idx);
-                    prop_assert_eq!(b1.entries.len(), b2.entries.len());
-                }
-                _ => {}
+            if let (EntryPayload::Normal(b1), EntryPayload::Normal(b2)) =
+                (&entry.payload, &deserialized.payload)
+            {
+                prop_assert_eq!(b1.db_id, b2.db_id);
+                prop_assert_eq!(b1.slot_idx, b2.slot_idx);
+                prop_assert_eq!(b1.entries.len(), b2.entries.len());
             }
         }
     }
@@ -976,7 +975,7 @@ mod tests {
                     for entry in &sequential_entries {
                         let key = encode_log_key(entry.log_id.index);
                         let value = serialize(&entry).unwrap();
-                        batch.put_cf(&logs_cf, &key, &value);
+                        batch.put_cf(&logs_cf, key, &value);
                     }
 
                     engine_clone.write(batch).unwrap();
@@ -1112,7 +1111,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -1163,7 +1162,7 @@ mod tests {
 
             let key = encode_log_key(1);
             let corrupted_value = vec![0xFF, 0xFF, 0xFF, 0xFF]; // Invalid JSON
-            batch.put_cf(&logs_cf, &key, &corrupted_value);
+            batch.put_cf(&logs_cf, key, &corrupted_value);
 
             engine_clone.write(batch).unwrap();
         }
@@ -1238,7 +1237,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -1302,7 +1301,7 @@ mod tests {
 
             let key = encode_log_key(entry.log_id.index);
             let value = serialize(&entry).unwrap();
-            batch.put_cf(&logs_cf, &key, &value);
+            batch.put_cf(&logs_cf, key, &value);
 
             engine_clone.write(batch).unwrap();
         }
@@ -1704,7 +1703,7 @@ mod tests {
                     for entry in &sequential_entries {
                         let key = encode_log_key(entry.log_id.index);
                         let value = serialize(&entry).unwrap();
-                        batch.put_cf(&logs_cf, &key, &value);
+                        batch.put_cf(&logs_cf, key, &value);
                     }
 
                     engine_clone.write(batch).unwrap();
@@ -1784,7 +1783,7 @@ mod tests {
                     for entry in &sequential_entries {
                         let key = encode_log_key(entry.log_id.index);
                         let value = serialize(&entry).unwrap();
-                        batch.put_cf(&logs_cf, &key, &value);
+                        batch.put_cf(&logs_cf, key, &value);
                     }
 
                     engine_clone.write(batch).unwrap();
@@ -1878,7 +1877,7 @@ mod tests {
                     for entry in &sequential_entries {
                         let key = encode_log_key(entry.log_id.index);
                         let value = serialize(&entry).unwrap();
-                        batch.put_cf(&logs_cf, &key, &value);
+                        batch.put_cf(&logs_cf, key, &value);
                     }
 
                     engine_clone.write(batch).unwrap();
@@ -2018,7 +2017,7 @@ mod tests {
                     for entry in &sequential_entries {
                         let key = encode_log_key(entry.log_id.index);
                         let value = serialize(&entry).unwrap();
-                        batch.put_cf(&logs_cf, &key, &value);
+                        batch.put_cf(&logs_cf, key, &value);
                     }
 
                     engine_clone.write(batch).unwrap();
@@ -2143,7 +2142,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2220,7 +2219,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2296,7 +2295,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2385,7 +2384,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2501,7 +2500,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2557,7 +2556,7 @@ mod tests {
 
             let key = encode_log_key(entry.log_id.index);
             let value = serialize(&entry).unwrap();
-            batch.put_cf(&logs_cf, &key, &value);
+            batch.put_cf(&logs_cf, key, &value);
 
             engine_clone.write(batch).unwrap();
         }
@@ -2623,7 +2622,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2715,7 +2714,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2783,7 +2782,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2850,7 +2849,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -2940,7 +2939,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -3042,7 +3041,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -3118,7 +3117,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -3207,7 +3206,7 @@ mod tests {
 
             let key = encode_log_key(entry.log_id.index);
             let value = serialize(&entry).unwrap();
-            batch.put_cf(&logs_cf, &key, &value);
+            batch.put_cf(&logs_cf, key, &value);
 
             engine_clone.write(batch).unwrap();
         }
@@ -3265,7 +3264,7 @@ mod tests {
             for entry in &entries {
                 let key = encode_log_key(entry.log_id.index);
                 let value = serialize(&entry).unwrap();
-                batch.put_cf(&logs_cf, &key, &value);
+                batch.put_cf(&logs_cf, key, &value);
             }
 
             engine_clone.write(batch).unwrap();
@@ -3329,7 +3328,7 @@ mod tests {
 
             let key = encode_log_key(entry1.log_id.index);
             let value = serialize(&entry1).unwrap();
-            batch.put_cf(&logs_cf, &key, &value);
+            batch.put_cf(&logs_cf, key, &value);
 
             engine_clone.write(batch).unwrap();
         }
@@ -3365,7 +3364,7 @@ mod tests {
 
             let key = encode_log_key(entry2.log_id.index);
             let value = serialize(&entry2).unwrap();
-            batch.put_cf(&logs_cf, &key, &value);
+            batch.put_cf(&logs_cf, key, &value);
 
             engine_clone.write(batch).unwrap();
         }
@@ -3410,7 +3409,7 @@ mod tests {
 
             let key = encode_log_key(entry.log_id.index);
             let value = serialize(&entry).unwrap();
-            batch.put_cf(&logs_cf, &key, &value);
+            batch.put_cf(&logs_cf, key, &value);
 
             engine_clone.write(batch).unwrap();
         }

--- a/src/raft/src/node.rs
+++ b/src/raft/src/node.rs
@@ -20,6 +20,7 @@ use openraft::{Config, Raft, SnapshotPolicy};
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use arc_swap::ArcSwap;
 
@@ -178,6 +179,7 @@ pub async fn create_raft_node(
     config: RaftConfig,
     storage_swap: Arc<ArcSwap<Storage>>,
     pause_controller: Option<Arc<dyn PauseController>>,
+    append_log_fn: Option<Arc<OnceLock<storage::AppendLogFn>>>,
 ) -> Result<Arc<RaftApp>, anyhow::Error> {
     let raft_config = build_raft_config(&config)?;
     let snapshot_work_dir = config.data_dir.join("snapshots");
@@ -191,6 +193,7 @@ pub async fn create_raft_node(
         storage_swap.clone(),
         config.db_path.clone(),
         snapshot_work_dir,
+        append_log_fn,
     );
 
     if let Some(ctrl) = pause_controller {

--- a/src/raft/src/state_machine.rs
+++ b/src/raft/src/state_machine.rs
@@ -31,6 +31,7 @@
 use std::io::{self, Cursor};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use arc_swap::ArcSwap;
 use openraft::{
@@ -185,6 +186,8 @@ pub struct KiwiStateMachine {
     snapshot_idx: u64,
     /// Pause controller for coordinating with StorageServer.
     pause_controller: Option<Arc<dyn PauseController>>,
+    /// Shared Raft append-log callback used to re-arm restored Storage after snapshot install.
+    append_log_fn: Option<Arc<OnceLock<storage::AppendLogFn>>>,
 }
 
 impl KiwiStateMachine {
@@ -198,6 +201,7 @@ impl KiwiStateMachine {
         storage_swap: Arc<ArcSwap<Storage>>,
         db_path: PathBuf,
         snapshot_work_dir: PathBuf,
+        append_log_fn: Option<Arc<OnceLock<storage::AppendLogFn>>>,
     ) -> Self {
         Self {
             _node_id: node_id,
@@ -208,6 +212,7 @@ impl KiwiStateMachine {
             last_membership: StoredMembership::default(),
             snapshot_idx: 0,
             pause_controller: None,
+            append_log_fn,
         }
     }
 
@@ -221,6 +226,12 @@ impl KiwiStateMachine {
     /// Set pause controller for coordinating with StorageServer.
     pub fn set_pause_controller(&mut self, controller: Arc<dyn PauseController>) {
         self.pause_controller = Some(controller);
+    }
+
+    fn rearm_append_log_fn(&self, storage: &Storage) {
+        if let Some(append_log_fn) = self.append_log_fn.as_ref().and_then(|holder| holder.get()) {
+            storage.set_append_log_fn(append_log_fn.clone());
+        }
     }
 
     /// Apply binlog to storage.
@@ -385,6 +396,7 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
             cleanup_on_error();
             storage_err_to_raft(e)
         })?;
+        self.rearm_append_log_fn(&new_storage);
 
         // ========== Phase 6: Swap ArcSwap (atomic switch) ==========
         self.storage_swap.swap(Arc::new(new_storage));

--- a/src/raft/tests/log_store_rocksdb_test.rs
+++ b/src/raft/tests/log_store_rocksdb_test.rs
@@ -84,7 +84,7 @@ fn write_entries_directly(engine: &Arc<dyn Engine>, entries: &[Entry<KiwiTypeCon
     for entry in entries {
         let key = (entry.log_id.index).to_be_bytes();
         let value = serde_json::to_vec(&entry).expect("Serialization should succeed");
-        batch.put_cf(&logs_cf, &key, &value);
+        batch.put_cf(&logs_cf, key, &value);
     }
 
     engine.write(batch).expect("Write should succeed");
@@ -642,7 +642,7 @@ async fn test_large_entry_persistence() {
     {
         let _log_store = RocksdbLogStore::new(engine.clone()).expect("Failed to create log store");
 
-        write_entries_directly(&engine, &[large_entry.clone()]);
+        write_entries_directly(&engine, std::slice::from_ref(&large_entry));
     }
 
     // Phase 2: Restart and verify large entry

--- a/src/raft/tests/logindex_integration.rs
+++ b/src/raft/tests/logindex_integration.rs
@@ -73,8 +73,8 @@ fn test_full_flow_multi_cf_properties() {
     let expected_seq = db.latest_sequence_number();
 
     let cf_tracker = LogIndexOfColumnFamilies::new();
-    for i in 0..CF_NAMES.len() {
-        let cf = db.cf_handle(CF_NAMES[i]).expect("cf handle");
+    for cf_name in CF_NAMES {
+        let cf = db.cf_handle(cf_name).expect("cf handle");
         let collection = db
             .get_properties_of_all_tables_cf(&cf)
             .expect("get properties");

--- a/src/raft/tests/snapshot_logindex_test.rs
+++ b/src/raft/tests/snapshot_logindex_test.rs
@@ -96,7 +96,13 @@ async fn test_snapshot_with_logindex_state() -> anyhow::Result<()> {
 
         // Create state machine and build snapshot
         let storage_swap = Arc::new(ArcSwap::from(Arc::clone(&storage)));
-        let mut sm = KiwiStateMachine::new(1, storage_swap, src_db_path.clone(), snap_root.clone());
+        let mut sm = KiwiStateMachine::new(
+            1,
+            storage_swap,
+            src_db_path.clone(),
+            snap_root.clone(),
+            None,
+        );
 
         let mut builder = sm.get_snapshot_builder().await;
         let snap = builder.build_snapshot().await?;
@@ -129,7 +135,13 @@ async fn test_snapshot_with_logindex_state() -> anyhow::Result<()> {
     let target_storage = Arc::new(Storage::new(1, 0));
     let target_swap = Arc::new(ArcSwap::from(target_storage));
 
-    let mut sm2 = KiwiStateMachine::new(2, target_swap.clone(), restore_db_path.clone(), snap_root);
+    let mut sm2 = KiwiStateMachine::new(
+        2,
+        target_swap.clone(),
+        restore_db_path.clone(),
+        snap_root,
+        None,
+    );
 
     sm2.install_snapshot(&meta, Box::new(std::io::Cursor::new(bytes)))
         .await?;

--- a/src/raft/tests/snapshot_roundtrip_test.rs
+++ b/src/raft/tests/snapshot_roundtrip_test.rs
@@ -17,7 +17,8 @@
 
 #![allow(clippy::unwrap_used)]
 
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
 
 use arc_swap::ArcSwap;
 use openraft::RaftSnapshotBuilder;
@@ -58,6 +59,7 @@ async fn cursor_snapshot_roundtrip() -> anyhow::Result<()> {
         storage_swap.clone(),
         src_db_path.clone(),
         snap_root.clone(),
+        None,
     );
 
     let mut builder = sm.get_snapshot_builder().await;
@@ -90,6 +92,7 @@ async fn cursor_snapshot_roundtrip() -> anyhow::Result<()> {
         target_swap.clone(),
         restore_db_path.clone(),
         snap_root.clone(),
+        None,
     );
     sm2.install_snapshot(&meta, Box::new(std::io::Cursor::new(bytes)))
         .await?;
@@ -143,6 +146,7 @@ async fn install_snapshot_with_existing_data() -> anyhow::Result<()> {
         source_swap.clone(),
         src_db_path.clone(),
         snap_root.clone(),
+        None,
     );
 
     let mut builder = sm_source.get_snapshot_builder().await;
@@ -172,6 +176,7 @@ async fn install_snapshot_with_existing_data() -> anyhow::Result<()> {
         target_swap.clone(),
         restore_db_path.clone(),
         snap_root.clone(),
+        None,
     );
 
     sm_target
@@ -188,6 +193,87 @@ async fn install_snapshot_with_existing_data() -> anyhow::Result<()> {
     assert_eq!(restored.get(b"key2")?, "value2");
 
     drop(sm_target);
+    drop(target_swap);
+    close_storage(restored, "restored storage").await?;
+    close_storage(target_storage, "target placeholder storage").await?;
+
+    safe_cleanup_test_db(&src_db_path);
+    safe_cleanup_test_db(&restore_db_path);
+    safe_cleanup_test_db(&snap_root);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn install_snapshot_rearms_append_log_hook() -> anyhow::Result<()> {
+    let src_db_path = unique_test_db_path();
+    let restore_db_path = unique_test_db_path();
+    let snap_root = unique_test_db_path();
+
+    std::fs::create_dir_all(&snap_root)?;
+
+    let source_storage = {
+        let mut storage = Storage::new(1, 0);
+        let options = Arc::new(StorageOptions::default());
+        let _rx = storage.open(options, &src_db_path)?;
+        Arc::new(storage)
+    };
+    source_storage.set(b"snap_key", b"snap_value")?;
+
+    let source_swap = Arc::new(ArcSwap::from(source_storage.clone()));
+    let mut source_sm = KiwiStateMachine::new(
+        1,
+        source_swap.clone(),
+        src_db_path.clone(),
+        snap_root.clone(),
+        None,
+    );
+
+    let mut builder = source_sm.get_snapshot_builder().await;
+    let snapshot = builder.build_snapshot().await?;
+    let snapshot_meta = snapshot.meta.clone();
+    let snapshot_bytes = snapshot.snapshot.into_inner();
+
+    drop(builder);
+    drop(source_sm);
+    drop(source_swap);
+    close_storage(source_storage, "source storage").await?;
+
+    let hook_called = Arc::new(AtomicBool::new(false));
+    let hook_called_clone = hook_called.clone();
+    let append_log_fn: storage::AppendLogFn = Arc::new(move |_binlog| {
+        hook_called_clone.store(true, Ordering::SeqCst);
+        Ok(conf::raft_type::BinlogResponse::ok())
+    });
+    let append_log_fn_holder = Arc::new(OnceLock::new());
+    let _ = append_log_fn_holder.set(append_log_fn);
+
+    let target_storage = Arc::new(Storage::new(1, 0));
+    let target_swap = Arc::new(ArcSwap::from(target_storage.clone()));
+    let mut target_sm = KiwiStateMachine::new(
+        2,
+        target_swap.clone(),
+        restore_db_path.clone(),
+        snap_root.clone(),
+        Some(append_log_fn_holder),
+    );
+
+    target_sm
+        .install_snapshot(
+            &snapshot_meta,
+            Box::new(std::io::Cursor::new(snapshot_bytes)),
+        )
+        .await?;
+
+    let restored = target_swap.load_full();
+    assert_eq!(restored.get(b"snap_key")?, "snap_value");
+    restored.set(b"after_snapshot", b"goes_through_hook")?;
+    assert!(
+        hook_called.load(Ordering::SeqCst),
+        "restored storage should be re-armed with append_log_fn"
+    );
+
+    drop(target_sm);
     drop(target_swap);
     close_storage(restored, "restored storage").await?;
     close_storage(target_storage, "target placeholder storage").await?;

--- a/src/server/src/main.rs
+++ b/src/server/src/main.rs
@@ -24,6 +24,7 @@ use runtime::{
 };
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use storage::StorageOptions;
 use storage::storage::Storage;
 
@@ -250,10 +251,16 @@ async fn start_server(
 
         let storage_swap = global_storage.arc_swap();
         let pause_controller_wrapper = Arc::new(PauseControllerWrapper(pause_controller));
+        let append_log_fn_holder = Arc::new(OnceLock::new());
 
-        let raft_app = create_raft_node(raft_config, storage_swap, Some(pause_controller_wrapper))
-            .await
-            .map_err(|e| std::io::Error::other(format!("Failed to create Raft node: {}", e)))?;
+        let raft_app = create_raft_node(
+            raft_config,
+            storage_swap,
+            Some(pause_controller_wrapper),
+            Some(append_log_fn_holder.clone()),
+        )
+        .await
+        .map_err(|e| std::io::Error::other(format!("Failed to create Raft node: {}", e)))?;
 
         // Bridge: storage runtime -> (channel) -> network runtime drain task -> client_write.
         let (log_tx, mut log_rx) =
@@ -287,6 +294,7 @@ async fn start_server(
             tokio::task::block_in_place(|| rx.blocking_recv())
                 .map_err(|_| "raft response channel closed".to_string())?
         });
+        let _ = append_log_fn_holder.set(append_log_fn.clone());
         global_storage.load().set_append_log_fn(append_log_fn);
 
         let raft_addr = raft_app.raft_addr.clone();

--- a/src/storage/src/data_compaction_filter.rs
+++ b/src/storage/src/data_compaction_filter.rs
@@ -298,7 +298,7 @@ mod tests {
                     ListsMetaValue::new(bytes::Bytes::copy_from_slice(&1u64.to_le_bytes()));
                 meta_value.set_version(version);
                 meta_value.set_etime(etime);
-                db.put(&meta_key, &meta_value.encode()).unwrap();
+                db.put(&meta_key, meta_value.encode()).unwrap();
             }
             DataType::Hash | DataType::Set | DataType::ZSet => {
                 let mut meta_value =
@@ -306,7 +306,7 @@ mod tests {
                 meta_value.inner.data_type = data_type;
                 meta_value.set_version(version);
                 meta_value.set_etime(etime);
-                db.put(&meta_key, &meta_value.encode()).unwrap();
+                db.put(&meta_key, meta_value.encode()).unwrap();
             }
             _ => panic!("unsupported data type for meta: {data_type:?}"),
         }
@@ -430,7 +430,7 @@ mod tests {
         meta_value.inner.data_type = DataType::Hash;
         meta_value.set_version(1);
         meta_value.set_etime(past_time); // expired
-        db.put(&meta_key, &meta_value.encode()).unwrap();
+        db.put(&meta_key, meta_value.encode()).unwrap();
 
         std::thread::sleep(std::time::Duration::from_millis(10));
 
@@ -457,7 +457,7 @@ mod tests {
         meta_value.inner.data_type = DataType::Hash;
         meta_value.set_version(2); // meta version is 2
         meta_value.set_etime(0);
-        db.put(&meta_key, &meta_value.encode()).unwrap();
+        db.put(&meta_key, meta_value.encode()).unwrap();
 
         std::thread::sleep(std::time::Duration::from_millis(10));
 

--- a/src/storage/src/format_zset_score_key.rs
+++ b/src/storage/src/format_zset_score_key.rs
@@ -222,7 +222,7 @@ mod tests {
     fn test_encode_decode_roundtrip_basic() {
         let key = b"test_key";
         let version = 42u64;
-        let score = 3.14f64;
+        let score = 3.15f64;
         let member = b"member1";
 
         let score_key = ZSetsScoreKey::new(key, version, score, member);
@@ -400,7 +400,7 @@ mod tests {
     fn test_encode_seek_key_format() {
         let key = b"test_key";
         let version = 42u64;
-        let score = 3.14f64;
+        let score = 3.15f64;
         let member = b"member1";
 
         let score_key = ZSetsScoreKey::new(key, version, score, member);
@@ -485,7 +485,7 @@ mod tests {
         let mut encoded_keys = Vec::new();
 
         for member in &members {
-            let score_key = ZSetsScoreKey::new(key, version, score, *member);
+            let score_key = ZSetsScoreKey::new(key, version, score, member);
             let encoded = score_key.encode().expect("encode failed");
             encoded_keys.push(encoded);
         }

--- a/src/storage/src/meta_compaction_filter.rs
+++ b/src/storage/src/meta_compaction_filter.rs
@@ -146,7 +146,7 @@ mod tests {
 
     #[test]
     fn test_meta_compaction_filter_factory() {
-        let mut factory = MetaCompactionFilterFactory::default();
+        let mut factory = MetaCompactionFilterFactory;
         let context = CompactionFilterContext {
             is_full_compaction: false,
             is_manual_compaction: false,
@@ -162,7 +162,7 @@ mod tests {
 
     #[test]
     fn test_string_value_not_expired() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_key");
         let encoded_key = key.encode().unwrap();
 
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn test_string_value_expired() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_key");
         let encoded_key = key.encode().unwrap();
 
@@ -194,7 +194,7 @@ mod tests {
 
     #[test]
     fn test_string_value_permanent() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_key");
         let encoded_key = key.encode().unwrap();
 
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn test_list_meta_value_not_expired() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_list_key");
         let encoded_key = key.encode().unwrap();
 
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn test_list_meta_value_expired() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_list_key");
         let encoded_key = key.encode().unwrap();
 
@@ -242,7 +242,7 @@ mod tests {
 
     #[test]
     fn test_list_meta_value_empty_and_expired_version() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_list_key");
         let encoded_key = key.encode().unwrap();
 
@@ -258,7 +258,7 @@ mod tests {
 
     #[test]
     fn test_list_meta_value_empty_but_recent_version() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_list_key");
         let encoded_key = key.encode().unwrap();
 
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn test_hash_meta_value_not_expired() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_hash_key");
         let encoded_key = key.encode().unwrap();
 
@@ -292,7 +292,7 @@ mod tests {
 
     #[test]
     fn test_hash_meta_value_expired() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_hash_key");
         let encoded_key = key.encode().unwrap();
 
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn test_hash_meta_value_empty_and_expired_version() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_hash_key");
         let encoded_key = key.encode().unwrap();
 
@@ -327,7 +327,7 @@ mod tests {
 
     #[test]
     fn test_set_meta_value_expired() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_set_key");
         let encoded_key = key.encode().unwrap();
 
@@ -344,7 +344,7 @@ mod tests {
 
     #[test]
     fn test_zset_meta_value_expired() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_zset_key");
         let encoded_key = key.encode().unwrap();
 
@@ -361,7 +361,7 @@ mod tests {
 
     #[test]
     fn test_invalid_key() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let invalid_key = b"short"; // Key is too short to be valid
 
         let string_value = StringValue::new(b"test_value".as_slice());
@@ -373,7 +373,7 @@ mod tests {
 
     #[test]
     fn test_empty_value() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_key");
         let encoded_key = key.encode().unwrap();
 
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn test_invalid_data_type() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_key");
         let encoded_key = key.encode().unwrap();
 
@@ -398,7 +398,7 @@ mod tests {
 
     #[test]
     fn test_invalid_string_value_format() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_key");
         let encoded_key = key.encode().unwrap();
 
@@ -411,7 +411,7 @@ mod tests {
 
     #[test]
     fn test_unknown_data_type() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_key");
         let encoded_key = key.encode().unwrap();
 
@@ -425,7 +425,7 @@ mod tests {
 
     #[test]
     fn test_list_meta_value_with_etime_zero_but_expired_version() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_list_key");
         let encoded_key = key.encode().unwrap();
 
@@ -442,7 +442,7 @@ mod tests {
 
     #[test]
     fn test_hash_meta_value_with_etime_zero_but_expired_version() {
-        let mut filter = MetaCompactionFilter::default();
+        let mut filter = MetaCompactionFilter;
         let key = BaseKey::new(b"test_hash_key");
         let encoded_key = key.encode().unwrap();
 

--- a/src/storage/tests/redis_basic_test.rs
+++ b/src/storage/tests/redis_basic_test.rs
@@ -194,7 +194,7 @@ mod is_stale_tests {
         let redis = create_redis_instance();
         let result = redis.is_stale(&[]);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), false);
+        assert!(!result.unwrap());
     }
 
     #[test]
@@ -276,11 +276,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
-            "Permanent string should not be stale"
-        );
+        assert!(!result.unwrap(), "Permanent string should not be stale");
     }
 
     #[test]
@@ -291,9 +287,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Future-expiring string should not be stale"
         );
     }
@@ -306,7 +301,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "Expired string should be stale");
+        assert!(result.unwrap(), "Expired string should be stale");
     }
 
     #[test]
@@ -316,9 +311,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Empty permanent string should not be stale"
         );
     }
@@ -330,7 +324,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "Hash with count=0 should be stale");
+        assert!(result.unwrap(), "Hash with count=0 should be stale");
     }
 
     #[test]
@@ -340,9 +334,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Permanent hash with count>0 should not be stale"
         );
     }
@@ -355,9 +348,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Future-expiring hash with count>0 should not be stale"
         );
     }
@@ -370,7 +362,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "Expired hash should be stale");
+        assert!(result.unwrap(), "Expired hash should be stale");
     }
 
     #[test]
@@ -381,9 +373,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
+        assert!(
             result.unwrap(),
-            true,
             "Hash with count=0 should be stale even if not expired"
         );
     }
@@ -395,7 +386,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "Set with count=0 should be stale");
+        assert!(result.unwrap(), "Set with count=0 should be stale");
     }
 
     #[test]
@@ -405,9 +396,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Permanent set with count>0 should not be stale"
         );
     }
@@ -420,7 +410,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "Expired set should be stale");
+        assert!(result.unwrap(), "Expired set should be stale");
     }
 
     #[test]
@@ -430,7 +420,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "ZSet with count=0 should be stale");
+        assert!(result.unwrap(), "ZSet with count=0 should be stale");
     }
 
     #[test]
@@ -440,9 +430,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Permanent zset with count>0 should not be stale"
         );
     }
@@ -455,7 +444,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "Expired zset should be stale");
+        assert!(result.unwrap(), "Expired zset should be stale");
     }
 
     #[test]
@@ -465,7 +454,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "List with count=0 should be stale");
+        assert!(result.unwrap(), "List with count=0 should be stale");
     }
 
     #[test]
@@ -475,9 +464,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Permanent list with count>0 should not be stale"
         );
     }
@@ -490,9 +478,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Future-expiring list with count>0 should not be stale"
         );
     }
@@ -505,7 +492,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "Expired list should be stale");
+        assert!(result.unwrap(), "Expired list should be stale");
     }
 
     #[test]
@@ -516,7 +503,7 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true, "Value just expired should be stale");
+        assert!(result.unwrap(), "Value just expired should be stale");
     }
 
     #[test]
@@ -527,9 +514,8 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "Value not yet expired should not be stale"
         );
     }
@@ -556,7 +542,7 @@ mod is_stale_tests {
         for (name, value) in test_cases {
             let result = redis.is_stale(&value);
             assert!(result.is_ok(), "{} type should be handled", name);
-            assert_eq!(result.unwrap(), false, "Valid {} should not be stale", name);
+            assert!(!result.unwrap(), "Valid {} should not be stale", name);
         }
     }
 
@@ -569,10 +555,6 @@ mod is_stale_tests {
 
         let result = redis.is_stale(&value);
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            false,
-            "Hash with max count should not be stale"
-        );
+        assert!(!result.unwrap(), "Hash with max count should not be stale");
     }
 }

--- a/src/storage/tests/redis_list_test.rs
+++ b/src/storage/tests/redis_list_test.rs
@@ -993,7 +993,7 @@ mod redis_list_test {
 
                     if thread_id % 2 == 0 {
                         // Use LPUSHX
-                        match redis_clone.lpushx(&key, &[value.clone()]) {
+                        match redis_clone.lpushx(&key, std::slice::from_ref(&value)) {
                             Ok(len) if len > 0 => {
                                 successful_lpushx_clone.fetch_add(1, Ordering::Relaxed)
                             }
@@ -1002,7 +1002,7 @@ mod redis_list_test {
                         };
                     } else {
                         // Use RPUSHX
-                        match redis_clone.rpushx(&key, &[value.clone()]) {
+                        match redis_clone.rpushx(&key, std::slice::from_ref(&value)) {
                             Ok(len) if len > 0 => {
                                 successful_lpushx_clone.fetch_add(1, Ordering::Relaxed)
                             }

--- a/src/storage/tests/redis_zset_test.rs
+++ b/src/storage/tests/redis_zset_test.rs
@@ -113,7 +113,7 @@ mod redis_zset_test {
         println!("Results: {:?}", results);
 
         // For now, just check that we get some results
-        assert!(results.len() > 0, "Should return at least some results");
+        assert!(!results.is_empty(), "Should return at least some results");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Preserve the Raft append-log hook in a shared holder
- Re-arm restored Storage after snapshot install before swapping it into ArcSwap
- Add regression coverage to ensure writes after snapshot install still go through the append hook

## Validation
- cargo test -p raft --test snapshot_roundtrip_test -- --nocapture
- cargo fmt --all --check
- cargo check --workspace


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured append-log processing continues working after Raft snapshots are installed.
  * Preserved append-log callbacks when storage is replaced during snapshot recovery.
  * Updated nightly sanitizer checks to skip a known incompatible test.

* **Tests**
  * Added coverage verifying append-log callbacks are restored and triggered after snapshot installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->