### PR TITLE
refactor(storage): unify redis type checking across storage commands

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -219,6 +219,10 @@ case $COMMAND in
 
     test)
         info "Running tests..."
+        # Stabilize tests under low fd limits: increase open-file limit if possible,
+        # and default to a single test thread to avoid exhausting file descriptors.
+        ulimit -n 4096 2>/dev/null || true
+        export RUST_TEST_THREADS="${RUST_TEST_THREADS:-1}"
         cargo test $PROFILE $CARGO_CONFIG_FLAG $VERBOSE
         ;;
 

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -70,7 +70,7 @@ pub use format_base_key::BaseMetaKey;
 pub use format_base_value::*;
 pub use format_zset_score_key::{ScoreMember, ZsetScoreMember};
 pub use options::StorageOptions;
-pub use redis::{ColumnFamilyIndex, Redis};
+pub use redis::{ColumnFamilyIndex, Redis, TypeCheckState};
 pub use statistics::KeyStatistics;
 pub use storage::{BgTask, BgTaskHandler};
 pub use storage_impl::BeforeOrAfter;

--- a/src/storage/src/redis.rs
+++ b/src/storage/src/redis.rs
@@ -94,6 +94,13 @@ impl ColumnFamilyIndex {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeCheckState {
+    Missing,
+    Stale,
+    Match,
+}
+
 #[repr(C, align(64))]
 pub struct Redis {
     pub index: i32,
@@ -644,20 +651,32 @@ impl Redis {
         Ok(())
     }
 
-    pub fn check_type(&self, key: &[u8], key_type: DataType) -> Result<()> {
-        if key.is_empty() {
-            return Ok(());
-        }
-
-        if key.first().copied() == Some(key_type as u8) {
-            return Ok(());
-        }
-
-        Err(RedisErr {
+    fn wrong_type_error() -> crate::error::Error {
+        RedisErr {
             message: "WRONGTYPE Operation against a key holding the wrong kind of value"
                 .to_string(),
             location: Default::default(),
-        })
+        }
+    }
+
+    pub fn check_type_state(&self, value_raw: &[u8], expected: DataType) -> Result<TypeCheckState> {
+        if value_raw.is_empty() {
+            return Ok(TypeCheckState::Missing);
+        }
+
+        if self.is_stale(value_raw)? {
+            return Ok(TypeCheckState::Stale);
+        }
+
+        if value_raw.first().copied() == Some(expected as u8) {
+            return Ok(TypeCheckState::Match);
+        }
+
+        Err(Self::wrong_type_error())
+    }
+
+    pub fn check_type(&self, value_raw: &[u8], key_type: DataType) -> Result<()> {
+        self.check_type_state(value_raw, key_type).map(|_| ())
     }
 
     pub fn get_scan_start_point(
@@ -722,7 +741,7 @@ impl Redis {
     /// * `Ok(true)` - the value is expired or the count is 0
     /// * `Ok(false)` - the value is not expired and is valid
     /// * `Err(_)` - parsing error
-    pub fn is_stale(&self, val_raw: &[u8]) -> Result<bool> {
+    pub fn is_stale_static(val_raw: &[u8]) -> Result<bool> {
         if val_raw.is_empty() {
             return Ok(false);
         }
@@ -808,6 +827,10 @@ impl Redis {
             }
             .fail(),
         }
+    }
+
+    pub fn is_stale(&self, val_raw: &[u8]) -> Result<bool> {
+        Self::is_stale_static(val_raw)
     }
 }
 

--- a/src/storage/src/redis_hashes.rs
+++ b/src/storage/src/redis_hashes.rs
@@ -30,7 +30,7 @@ use crate::format_member_data_key::MemberDataKey;
 use crate::get_db_and_cfs;
 use crate::redis_sets::glob_match;
 use crate::util::is_tail_wildcard;
-use crate::{BaseMetaKey, ColumnFamilyIndex, DataType, Redis, Result};
+use crate::{BaseMetaKey, ColumnFamilyIndex, DataType, Redis, Result, TypeCheckState};
 
 impl Redis {
     /// Delete one or more hash fields
@@ -65,20 +65,13 @@ impl Redis {
             .context(RocksSnafu)?
         {
             Some(meta_val_bytes) => {
-                let mut meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
-                if meta_val.is_stale() {
-                    return Ok(0);
-                }
-                if meta_val.inner.data_type != DataType::Hash {
-                    return RedisErrSnafu {
-                        message: format!(
-                            "Wrong type of value, expected: {:?}, got: {:?}",
-                            DataType::Hash,
-                            meta_val.inner.data_type
-                        ),
+                match self.check_type_state(meta_val_bytes.as_ref(), DataType::Hash)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
+                        return Ok(0);
                     }
-                    .fail();
+                    TypeCheckState::Match => {}
                 }
+                let mut meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
 
                 let version = meta_val.version();
                 let mut del_cnt = 0i32;
@@ -153,20 +146,13 @@ impl Redis {
             .get_cf_opt(meta_cf, &base_meta_key, &read_options)
             .context(RocksSnafu)?
         {
-            let meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
-            if meta_val.is_stale() {
-                return Ok(None);
-            }
-            if meta_val.inner.data_type != DataType::Hash {
-                return RedisErrSnafu {
-                    message: format!(
-                        "Wrong type of value, expected: {:?}, got: {:?}",
-                        DataType::Hash,
-                        meta_val.inner.data_type
-                    ),
+            match self.check_type_state(meta_val_bytes.as_ref(), DataType::Hash)? {
+                TypeCheckState::Missing | TypeCheckState::Stale => {
+                    return Ok(None);
                 }
-                .fail();
+                TypeCheckState::Match => {}
             }
+            let meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
             let version = meta_val.version();
             let data_key = MemberDataKey::new(_key, version, _field);
             if let Some(data_val_bytes) = db
@@ -205,20 +191,13 @@ impl Redis {
             .context(RocksSnafu)?
         {
             Some(meta_val_bytes) => {
-                let meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
-                if meta_val.is_stale() {
-                    return Ok(Vec::new());
-                }
-                if meta_val.inner.data_type != DataType::Hash {
-                    return RedisErrSnafu {
-                        message: format!(
-                            "Wrong type of value, expected: {:?}, got: {:?}",
-                            DataType::Hash,
-                            meta_val.inner.data_type
-                        ),
+                match self.check_type_state(meta_val_bytes.as_ref(), DataType::Hash)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
+                        return Ok(Vec::new());
                     }
-                    .fail();
+                    TypeCheckState::Match => {}
                 }
+                let meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
 
                 let version = meta_val.version();
                 let data_key = MemberDataKey::new(key, version, &[]);
@@ -256,20 +235,13 @@ impl Redis {
             .context(RocksSnafu)?
         {
             Some(meta_val_bytes) => {
-                let meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
-                if meta_val.is_stale() {
-                    return Ok(0);
-                }
-                if meta_val.inner.data_type != DataType::Hash {
-                    return RedisErrSnafu {
-                        message: format!(
-                            "Wrong type of value, expected: {:?}, got: {:?}",
-                            DataType::Hash,
-                            meta_val.inner.data_type
-                        ),
+                match self.check_type_state(meta_val_bytes.as_ref(), DataType::Hash)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
+                        return Ok(0);
                     }
-                    .fail();
+                    TypeCheckState::Match => {}
                 }
+                let meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
                 Ok(meta_val.count() as i32)
             }
             None => Ok(0),
@@ -318,25 +290,15 @@ impl Redis {
             .context(RocksSnafu)?
         {
             Some(meta_val_bytes) => {
-                let mut parsed_meta = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
-
-                if parsed_meta.data_type() != DataType::Hash {
-                    if parsed_meta.is_stale() {
+                match self.check_type_state(meta_val_bytes.as_ref(), DataType::Hash)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
                         create_new_hash(self, key, field, value)?;
                         return Ok(1);
-                    } else {
-                        return RedisErrSnafu {
-                            message: format!(
-                                "Wrong type of value, expected: {:?}, got: {:?}",
-                                DataType::Hash,
-                                parsed_meta.inner.data_type
-                            ),
-                        }
-                        .fail();
                     }
+                    TypeCheckState::Match => {}
                 }
-
-                if parsed_meta.is_stale() || parsed_meta.count() == 0 {
+                let mut parsed_meta = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
+                if !parsed_meta.is_valid() {
                     let version = parsed_meta.initial_meta_value();
                     parsed_meta.set_count(1);
 
@@ -438,20 +400,13 @@ impl Redis {
             .context(RocksSnafu)?
         {
             Some(meta_val_bytes) => {
-                let meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
-                if meta_val.is_stale() {
-                    return Ok(Vec::new());
-                }
-                if meta_val.inner.data_type != DataType::Hash {
-                    return RedisErrSnafu {
-                        message: format!(
-                            "Wrong type of value, expected: {:?}, got: {:?}",
-                            DataType::Hash,
-                            meta_val.inner.data_type
-                        ),
+                match self.check_type_state(meta_val_bytes.as_ref(), DataType::Hash)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
+                        return Ok(Vec::new());
                     }
-                    .fail();
+                    TypeCheckState::Match => {}
                 }
+                let meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
 
                 let version = meta_val.version();
                 let data_key = MemberDataKey::new(key, version, &[]);
@@ -503,20 +458,13 @@ impl Redis {
             .context(RocksSnafu)?
         {
             Some(meta_val_bytes) => {
-                let meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
-                if meta_val.is_stale() {
-                    return Ok(Vec::new());
-                }
-                if meta_val.inner.data_type != DataType::Hash {
-                    return RedisErrSnafu {
-                        message: format!(
-                            "Wrong type of value, expected: {:?}, got: {:?}",
-                            DataType::Hash,
-                            meta_val.inner.data_type
-                        ),
+                match self.check_type_state(meta_val_bytes.as_ref(), DataType::Hash)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
+                        return Ok(Vec::new());
                     }
-                    .fail();
+                    TypeCheckState::Match => {}
                 }
+                let meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
 
                 let version = meta_val.version();
                 let data_key = MemberDataKey::new(key, version, &[]);
@@ -566,23 +514,16 @@ impl Redis {
             .context(RocksSnafu)?
         {
             Some(meta_val_bytes) => {
+                match self.check_type_state(meta_val_bytes.as_ref(), DataType::Hash)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
+                        for _ in fields {
+                            results.push(None);
+                        }
+                        return Ok(results);
+                    }
+                    TypeCheckState::Match => {}
+                }
                 let meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
-                if meta_val.is_stale() {
-                    for _ in fields {
-                        results.push(None);
-                    }
-                    return Ok(results);
-                }
-                if meta_val.inner.data_type != DataType::Hash {
-                    return RedisErrSnafu {
-                        message: format!(
-                            "Wrong type of value, expected: {:?}, got: {:?}",
-                            DataType::Hash,
-                            meta_val.inner.data_type
-                        ),
-                    }
-                    .fail();
-                }
 
                 let version = meta_val.version();
                 for field in fields {
@@ -669,25 +610,15 @@ impl Redis {
             .context(RocksSnafu)?
         {
             Some(meta_val_bytes) => {
-                let mut parsed_meta = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
-
-                if parsed_meta.data_type() != DataType::Hash {
-                    if parsed_meta.is_stale() {
+                match self.check_type_state(meta_val_bytes.as_ref(), DataType::Hash)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
                         create_new_hash(self, key, &field_map)?;
                         return Ok(());
-                    } else {
-                        return RedisErrSnafu {
-                            message: format!(
-                                "Wrong type of value, expected: {:?}, got: {:?}",
-                                DataType::Hash,
-                                parsed_meta.inner.data_type
-                            ),
-                        }
-                        .fail();
                     }
+                    TypeCheckState::Match => {}
                 }
-
-                if parsed_meta.is_stale() || parsed_meta.count() == 0 {
+                let mut parsed_meta = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
+                if !parsed_meta.is_valid() {
                     let version = parsed_meta.initial_meta_value();
                     parsed_meta.set_count(field_map.len() as u64);
 
@@ -804,25 +735,15 @@ impl Redis {
             .context(RocksSnafu)?
         {
             Some(meta_val_bytes) => {
-                let mut parsed_meta = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
-
-                if parsed_meta.data_type() != DataType::Hash {
-                    if parsed_meta.is_stale() {
+                match self.check_type_state(meta_val_bytes.as_ref(), DataType::Hash)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
                         create_new_hash(self, key, field, value)?;
                         return Ok(1);
-                    } else {
-                        return RedisErrSnafu {
-                            message: format!(
-                                "Wrong type of value, expected: {:?}, got: {:?}",
-                                DataType::Hash,
-                                parsed_meta.inner.data_type
-                            ),
-                        }
-                        .fail();
                     }
+                    TypeCheckState::Match => {}
                 }
-
-                if parsed_meta.is_stale() || parsed_meta.count() == 0 {
+                let mut parsed_meta = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
+                if !parsed_meta.is_valid() {
                     let version = parsed_meta.initial_meta_value();
                     parsed_meta.set_count(1);
 
@@ -930,25 +851,15 @@ impl Redis {
             .context(RocksSnafu)?
         {
             Some(meta_val_bytes) => {
-                let mut parsed_meta = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
-
-                if parsed_meta.data_type() != DataType::Hash {
-                    if parsed_meta.is_stale() {
+                match self.check_type_state(meta_val_bytes.as_ref(), DataType::Hash)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
                         create_new_hash(self, key, field, increment)?;
                         return Ok(increment);
-                    } else {
-                        return RedisErrSnafu {
-                            message: format!(
-                                "Wrong type of value, expected: {:?}, got: {:?}",
-                                DataType::Hash,
-                                parsed_meta.inner.data_type
-                            ),
-                        }
-                        .fail();
                     }
+                    TypeCheckState::Match => {}
                 }
-
-                if parsed_meta.is_stale() || parsed_meta.count() == 0 {
+                let mut parsed_meta = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
+                if !parsed_meta.is_valid() {
                     let version = parsed_meta.initial_meta_value();
                     parsed_meta.set_count(1);
 
@@ -1086,25 +997,15 @@ impl Redis {
             .context(RocksSnafu)?
         {
             Some(meta_val_bytes) => {
-                let mut parsed_meta = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
-
-                if parsed_meta.data_type() != DataType::Hash {
-                    if parsed_meta.is_stale() {
+                match self.check_type_state(meta_val_bytes.as_ref(), DataType::Hash)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
                         create_new_hash(self, key, field, increment)?;
                         return Ok(increment);
-                    } else {
-                        return RedisErrSnafu {
-                            message: format!(
-                                "Wrong type of value, expected: {:?}, got: {:?}",
-                                DataType::Hash,
-                                parsed_meta.inner.data_type
-                            ),
-                        }
-                        .fail();
                     }
+                    TypeCheckState::Match => {}
                 }
-
-                if parsed_meta.is_stale() || parsed_meta.count() == 0 {
+                let mut parsed_meta = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
+                if !parsed_meta.is_valid() {
                     let version = parsed_meta.initial_meta_value();
                     parsed_meta.set_count(1);
 
@@ -1242,21 +1143,13 @@ impl Redis {
             .context(RocksSnafu)?
         {
             Some(meta_val_bytes) => {
-                let meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
-
-                if meta_val.is_stale() {
-                    return Ok((0, Vec::new()));
-                }
-                if meta_val.data_type() != DataType::Hash {
-                    return RedisErrSnafu {
-                        message: format!(
-                            "Wrong type of value, expected: {:?}, got: {:?}",
-                            DataType::Hash,
-                            meta_val.data_type()
-                        ),
+                match self.check_type_state(meta_val_bytes.as_ref(), DataType::Hash)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
+                        return Ok((0, Vec::new()));
                     }
-                    .fail();
+                    TypeCheckState::Match => {}
                 }
+                let meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
 
                 let mut start_point = String::new();
                 let version = meta_val.version();

--- a/src/storage/src/redis_lists.rs
+++ b/src/storage/src/redis_lists.rs
@@ -22,7 +22,7 @@ use bytes::BytesMut;
 use snafu::{OptionExt, ResultExt};
 
 use crate::{
-    Result,
+    Result, TypeCheckState,
     error::{InvalidFormatSnafu, KeyNotFoundSnafu, OptionNoneSnafu, RocksSnafu},
     format_base_data_value::{BaseDataValue, ParsedBaseDataValue},
     format_base_key::BaseMetaKey,
@@ -36,6 +36,15 @@ use crate::{
 use kstd::lock_mgr::ScopeRecordLock;
 
 impl Redis {
+    /// Create a fresh, initialized list metadata value.
+    fn new_list_meta() -> Result<ParsedListsMetaValue> {
+        let meta_value = ListsMetaValue::new(0u64.to_le_bytes().to_vec());
+        let encoded = meta_value.encode();
+        let mut parsed = ParsedListsMetaValue::new(encoded)?;
+        parsed.initial_meta_value();
+        Ok(parsed)
+    }
+
     /// Core implementation for pushing values to a list
     /// position: true for left (head), false for right (tail)
     /// allow_create: if true, creates new list when key doesn't exist
@@ -67,12 +76,13 @@ impl Redis {
             // If key exists, return current count; if not, return 0
             return match db.get(&meta_key).context(RocksSnafu)? {
                 Some(meta_value) => {
-                    let parsed_meta =
-                        ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?;
-                    if parsed_meta.is_valid() {
-                        Ok(Some(parsed_meta.count() as i64))
-                    } else {
-                        Ok(Some(0))
+                    match self.check_type_state(meta_value.as_ref(), DataType::List)? {
+                        TypeCheckState::Missing | TypeCheckState::Stale => Ok(Some(0)),
+                        TypeCheckState::Match => {
+                            let parsed_meta =
+                                ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?;
+                            Ok(Some(parsed_meta.count() as i64))
+                        }
                     }
                 }
                 None => Ok(Some(0)),
@@ -82,23 +92,24 @@ impl Redis {
         // Get existing metadata
         let mut parsed_meta = match db.get(&meta_key).context(RocksSnafu)? {
             Some(meta_value) => {
-                let mut parsed = ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?;
-                if !parsed.is_valid() {
-                    // Initialize if invalid/expired
-                    parsed.initial_meta_value();
+                match self.check_type_state(meta_value.as_ref(), DataType::List)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
+                        if !allow_create {
+                            return Ok(None);
+                        }
+                        Self::new_list_meta()?
+                    }
+                    TypeCheckState::Match => {
+                        ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?
+                    }
                 }
-                parsed
             }
             None => {
                 if !allow_create {
                     return Ok(None); // Key doesn't exist and creation not allowed
                 }
                 // Create new metadata
-                let meta_value = ListsMetaValue::new(0u64.to_le_bytes().to_vec());
-                let encoded = meta_value.encode();
-                let mut parsed = ParsedListsMetaValue::new(encoded)?;
-                parsed.initial_meta_value();
-                parsed
+                Self::new_list_meta()?
             }
         };
 
@@ -301,18 +312,14 @@ impl Redis {
         // Get existing metadata
         let mut parsed_meta = match db.get(&meta_key).context(RocksSnafu)? {
             Some(meta_value) => {
-                let parsed = ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?;
-                if !parsed.is_valid() {
-                    return Ok(None);
+                match self.check_type_state(meta_value.as_ref(), DataType::List)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => return Ok(None),
+                    TypeCheckState::Match => {}
                 }
-                parsed
+                ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?
             }
             None => return Ok(None),
         };
-
-        if parsed_meta.count() == 0 {
-            return Ok(None);
-        }
 
         let pop_count = count.unwrap_or(1).min(parsed_meta.count() as usize);
         let mut result = Vec::with_capacity(pop_count);
@@ -377,18 +384,14 @@ impl Redis {
         // Get existing metadata
         let mut parsed_meta = match db.get(&meta_key).context(RocksSnafu)? {
             Some(meta_value) => {
-                let parsed = ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?;
-                if !parsed.is_valid() {
-                    return Ok(None);
+                match self.check_type_state(meta_value.as_ref(), DataType::List)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => return Ok(None),
+                    TypeCheckState::Match => {}
                 }
-                parsed
+                ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?
             }
             None => return Ok(None),
         };
-
-        if parsed_meta.count() == 0 {
-            return Ok(None);
-        }
 
         let pop_count = count.unwrap_or(1).min(parsed_meta.count() as usize);
         let mut result = Vec::with_capacity(pop_count);
@@ -453,18 +456,14 @@ impl Redis {
         // Get existing metadata
         let mut parsed_meta = match db.get(&meta_key).context(RocksSnafu)? {
             Some(meta_value) => {
-                let parsed = ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?;
-                if !parsed.is_valid() {
-                    return Ok(None);
+                match self.check_type_state(meta_value.as_ref(), DataType::List)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => return Ok(None),
+                    TypeCheckState::Match => {}
                 }
-                parsed
+                ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?
             }
             None => return Ok(None),
         };
-
-        if parsed_meta.count() == 0 {
-            return Ok(None);
-        }
 
         let pop_count = count.unwrap_or(1).min(parsed_meta.count() as usize);
         let mut result = Vec::with_capacity(pop_count);
@@ -527,12 +526,14 @@ impl Redis {
 
         match db.get(&meta_key).context(RocksSnafu)? {
             Some(meta_value) => {
-                let parsed_meta = ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?;
-                if parsed_meta.is_valid() {
-                    Ok(parsed_meta.count() as i64)
-                } else {
-                    Ok(0)
+                match self.check_type_state(meta_value.as_ref(), DataType::List)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => return Ok(0),
+                    TypeCheckState::Match => {}
                 }
+                Ok(
+                    ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?.count()
+                        as i64,
+                )
             }
             None => Ok(0),
         }
@@ -549,18 +550,14 @@ impl Redis {
         // Get existing metadata
         let parsed_meta = match db.get(&meta_key).context(RocksSnafu)? {
             Some(meta_value) => {
-                let parsed = ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?;
-                if !parsed.is_valid() {
-                    return Ok(None);
+                match self.check_type_state(meta_value.as_ref(), DataType::List)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => return Ok(None),
+                    TypeCheckState::Match => {}
                 }
-                parsed
+                ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?
             }
             None => return Ok(None),
         };
-
-        if parsed_meta.count() == 0 {
-            return Ok(None);
-        }
 
         // Convert negative index to positive
         let real_index = if index < 0 {
@@ -602,18 +599,14 @@ impl Redis {
         // Get existing metadata
         let parsed_meta = match db.get(&meta_key).context(RocksSnafu)? {
             Some(meta_value) => {
-                let parsed = ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?;
-                if !parsed.is_valid() {
-                    return Ok(Vec::new());
+                match self.check_type_state(meta_value.as_ref(), DataType::List)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => return Ok(Vec::new()),
+                    TypeCheckState::Match => {}
                 }
-                parsed
+                ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?
             }
             None => return Ok(Vec::new()),
         };
-
-        if parsed_meta.count() == 0 {
-            return Ok(Vec::new());
-        }
 
         let list_len = parsed_meta.count() as i64;
 
@@ -668,14 +661,16 @@ impl Redis {
         // Get existing metadata
         let parsed_meta = match db.get(&meta_key).context(RocksSnafu)? {
             Some(meta_value) => {
-                let parsed = ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?;
-                if !parsed.is_valid() {
-                    return KeyNotFoundSnafu {
-                        key: String::from_utf8_lossy(key).to_string(),
+                match self.check_type_state(meta_value.as_ref(), DataType::List)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
+                        return KeyNotFoundSnafu {
+                            key: String::from_utf8_lossy(key).to_string(),
+                        }
+                        .fail();
                     }
-                    .fail();
+                    TypeCheckState::Match => {}
                 }
-                parsed
+                ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?
             }
             None => {
                 return KeyNotFoundSnafu {
@@ -684,13 +679,6 @@ impl Redis {
                 .fail();
             }
         };
-
-        if parsed_meta.count() == 0 {
-            return KeyNotFoundSnafu {
-                key: String::from_utf8_lossy(key).to_string(),
-            }
-            .fail();
-        }
 
         // Convert negative index to positive
         let real_index = if index < 0 {
@@ -742,18 +730,14 @@ impl Redis {
         // Get existing metadata
         let mut parsed_meta = match db.get(&meta_key).context(RocksSnafu)? {
             Some(meta_value) => {
-                let parsed = ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?;
-                if !parsed.is_valid() {
-                    return Ok(());
+                match self.check_type_state(meta_value.as_ref(), DataType::List)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => return Ok(()),
+                    TypeCheckState::Match => {}
                 }
-                parsed
+                ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?
             }
             None => return Ok(()),
         };
-
-        if parsed_meta.count() == 0 {
-            return Ok(());
-        }
 
         let list_len = parsed_meta.count() as i64;
 
@@ -841,18 +825,14 @@ impl Redis {
         // Get existing metadata
         let mut parsed_meta = match db.get(&meta_key).context(RocksSnafu)? {
             Some(meta_value) => {
-                let parsed = ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?;
-                if !parsed.is_valid() {
-                    return Ok(0);
+                match self.check_type_state(meta_value.as_ref(), DataType::List)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => return Ok(0),
+                    TypeCheckState::Match => {}
                 }
-                parsed
+                ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?
             }
             None => return Ok(0),
         };
-
-        if parsed_meta.count() == 0 {
-            return Ok(0);
-        }
 
         let mut removed_count = 0i64;
 
@@ -986,14 +966,16 @@ impl Redis {
         // Get existing metadata
         let mut parsed_meta = match db.get(&meta_key).context(RocksSnafu)? {
             Some(meta_value) => {
-                let parsed = ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?;
-                if !parsed.is_valid() {
-                    return KeyNotFoundSnafu {
-                        key: String::from_utf8_lossy(key).to_string(),
+                match self.check_type_state(meta_value.as_ref(), DataType::List)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
+                        return KeyNotFoundSnafu {
+                            key: String::from_utf8_lossy(key).to_string(),
+                        }
+                        .fail();
                     }
-                    .fail();
+                    TypeCheckState::Match => {}
                 }
-                parsed
+                ParsedListsMetaValue::new(BytesMut::from(meta_value.as_slice()))?
             }
             None => {
                 return KeyNotFoundSnafu {
@@ -1002,13 +984,6 @@ impl Redis {
                 .fail();
             }
         };
-
-        if parsed_meta.count() == 0 {
-            return KeyNotFoundSnafu {
-                key: String::from_utf8_lossy(key).to_string(),
-            }
-            .fail();
-        }
 
         // Read all elements to find the pivot
         let mut all_elements = Vec::new();

--- a/src/storage/src/redis_sets.rs
+++ b/src/storage/src/redis_sets.rs
@@ -26,7 +26,7 @@ use rocksdb::{Direction, IteratorMode, ReadOptions};
 use snafu::{OptionExt, ResultExt};
 
 use crate::{
-    ColumnFamilyIndex, Redis, Result,
+    ColumnFamilyIndex, Redis, Result, TypeCheckState,
     error::{InvalidArgumentSnafu, KeyNotFoundSnafu, OptionNoneSnafu, RocksSnafu},
     format_base_data_value::BaseDataValue,
     format_base_key::BaseMetaKey,
@@ -78,13 +78,8 @@ impl Redis {
         let base_meta_key = BaseMetaKey::new(key).encode()?;
         let meta_get = db.get_cf(&cf, &base_meta_key).context(RocksSnafu)?;
         let (mut set_meta_value, version, is_new_set) = match meta_get {
-            Some(val) => {
-                // Type check
-                self.check_type(&val, DataType::Set)?;
-                let set_meta_value = ParsedSetsMetaValue::new(&val[..])?;
-                // Check if expired
-                if set_meta_value.is_stale() {
-                    // Create new set if expired
+            Some(val) => match self.check_type_state(val.as_ref(), DataType::Set)? {
+                TypeCheckState::Missing | TypeCheckState::Stale => {
                     let count_bytes = 0u64.to_le_bytes().to_vec();
                     let mut new_meta = BaseMetaValue::new(Bytes::from(count_bytes));
                     new_meta.inner.data_type = DataType::Set;
@@ -92,11 +87,13 @@ impl Redis {
                     let mut new_set_meta = ParsedSetsMetaValue::new(encoded)?;
                     let version = new_set_meta.initial_meta_value();
                     (new_set_meta, version, true)
-                } else {
+                }
+                TypeCheckState::Match => {
+                    let set_meta_value = ParsedSetsMetaValue::new(&val[..])?;
                     let version = set_meta_value.version();
                     (set_meta_value, version, false)
                 }
-            }
+            },
             None => {
                 // Create new set
                 let count_bytes = 0u64.to_le_bytes().to_vec();
@@ -186,8 +183,15 @@ impl Redis {
 
         match db.get_cf(&cf, &base_meta_key).context(RocksSnafu)? {
             Some(val) => {
-                // Type check
-                self.check_type(&val, DataType::Set)?;
+                match self.check_type_state(val.as_ref(), DataType::Set)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
+                        return KeyNotFoundSnafu {
+                            key: String::from_utf8_lossy(key).to_string(),
+                        }
+                        .fail();
+                    }
+                    TypeCheckState::Match => {}
+                }
                 let set_meta = ParsedSetsMetaValue::new(&val[..])?;
                 // Validity check (not expired and count > 0)
                 if !set_meta.is_valid() {
@@ -231,8 +235,12 @@ impl Redis {
             return Ok(Vec::new());
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
+        match self.check_type_state(val.as_ref(), DataType::Set)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => {
+                return Ok(Vec::new());
+            }
+            TypeCheckState::Match => {}
+        }
 
         let set_meta = ParsedSetsMetaValue::new(&val[..])?;
         // Validity check (not expired and count > 0)
@@ -290,8 +298,12 @@ impl Redis {
             return Ok(false);
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
+        match self.check_type_state(val.as_ref(), DataType::Set)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => {
+                return Ok(false);
+            }
+            TypeCheckState::Match => {}
+        }
 
         let set_meta = ParsedSetsMetaValue::new(&val[..])?;
         // Validity check (not expired and count > 0)
@@ -337,8 +349,12 @@ impl Redis {
             return Ok(Vec::new());
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
+        match self.check_type_state(val.as_ref(), DataType::Set)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => {
+                return Ok(Vec::new());
+            }
+            TypeCheckState::Match => {}
+        }
 
         let set_meta = ParsedSetsMetaValue::new(&val[..])?;
         // Validity check (not expired and count > 0)
@@ -459,8 +475,12 @@ impl Redis {
             return Ok(0);
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
+        match self.check_type_state(val.as_ref(), DataType::Set)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => {
+                return Ok(0);
+            }
+            TypeCheckState::Match => {}
+        }
 
         let mut set_meta = ParsedSetsMetaValue::new(&val[..])?;
         // Validity check (not expired and count > 0)
@@ -545,8 +565,12 @@ impl Redis {
             return Ok(Vec::new());
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
+        match self.check_type_state(val.as_ref(), DataType::Set)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => {
+                return Ok(Vec::new());
+            }
+            TypeCheckState::Match => {}
+        }
 
         let mut set_meta = ParsedSetsMetaValue::new(&val[..])?;
         // Validity check (not expired and count > 0)
@@ -703,8 +727,12 @@ impl Redis {
             return Ok(false);
         };
 
-        // Type check for source
-        self.check_type(&source_val, DataType::Set)?;
+        match self.check_type_state(source_val.as_ref(), DataType::Set)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => {
+                return Ok(false);
+            }
+            TypeCheckState::Match => {}
+        }
 
         let mut source_meta = ParsedSetsMetaValue::new(&source_val[..])?;
         if !source_meta.is_valid() {
@@ -729,17 +757,26 @@ impl Redis {
         // Handle destination set
         let dest_meta_val = db.get_cf(&cf_meta, &dest_meta_key).context(RocksSnafu)?;
         let (mut dest_meta, dest_version, dest_exists) = if let Some(dest_val) = dest_meta_val {
-            // Type check for destination
-            self.check_type(&dest_val, DataType::Set)?;
-
-            let mut meta = ParsedSetsMetaValue::new(&dest_val[..])?;
-            let version = if meta.is_valid() {
-                meta.version()
-            } else {
-                // Destination set is expired, create new version
-                meta.initial_meta_value()
-            };
-            (meta, version, true)
+            match self.check_type_state(dest_val.as_ref(), DataType::Set)? {
+                TypeCheckState::Missing | TypeCheckState::Stale => {
+                    let count_bytes = 0u64.to_le_bytes();
+                    let mut new_meta = BaseMetaValue::new(Bytes::from(count_bytes.to_vec()));
+                    new_meta.inner.data_type = DataType::Set;
+                    let encoded = new_meta.encode();
+                    let mut meta = ParsedSetsMetaValue::new(encoded)?;
+                    let version = meta.initial_meta_value();
+                    (meta, version, false)
+                }
+                TypeCheckState::Match => {
+                    let mut meta = ParsedSetsMetaValue::new(&dest_val[..])?;
+                    let version = if meta.is_valid() {
+                        meta.version()
+                    } else {
+                        meta.initial_meta_value()
+                    };
+                    (meta, version, true)
+                }
+            }
         } else {
             // Destination set doesn't exist, create new one
             let count_bytes = 0u64.to_le_bytes();
@@ -1952,8 +1989,12 @@ impl Redis {
             return Ok(result);
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
+        match self.check_type_state(val.as_ref(), DataType::Set)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => {
+                return Ok(result);
+            }
+            TypeCheckState::Match => {}
+        }
 
         let set_meta = ParsedSetsMetaValue::new(&val[..])?;
         // Validity check (not expired and count > 0)
@@ -2046,8 +2087,12 @@ impl Redis {
             }
 
             let val = meta_val.expect("meta_val checked non-None above");
-            // Type check
-            self.check_type(&val, DataType::Set)?;
+            match self.check_type_state(val.as_ref(), DataType::Set)? {
+                TypeCheckState::Missing | TypeCheckState::Stale => {
+                    return Ok(result);
+                }
+                TypeCheckState::Match => {}
+            }
 
             let set_meta = ParsedSetsMetaValue::new(&val[..])?;
             if !set_meta.is_valid() {
@@ -2121,8 +2166,12 @@ impl Redis {
             let meta_val = db.get_cf(&cf_meta, &base_meta_key).context(RocksSnafu)?;
 
             if let Some(val) = meta_val {
-                // Type check
-                self.check_type(&val, DataType::Set)?;
+                match self.check_type_state(val.as_ref(), DataType::Set)? {
+                    TypeCheckState::Missing | TypeCheckState::Stale => {
+                        continue;
+                    }
+                    TypeCheckState::Match => {}
+                }
 
                 let set_meta = ParsedSetsMetaValue::new(&val[..])?;
                 if set_meta.is_valid() {
@@ -2342,8 +2391,12 @@ impl Redis {
             return Ok((0, Vec::new()));
         };
 
-        // Type check
-        self.check_type(&val, DataType::Set)?;
+        match self.check_type_state(val.as_ref(), DataType::Set)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => {
+                return Ok((0, Vec::new()));
+            }
+            TypeCheckState::Match => {}
+        }
 
         let set_meta = ParsedSetsMetaValue::new(&val[..])?;
         // Validity check (not expired and count > 0)

--- a/src/storage/src/redis_strings.rs
+++ b/src/storage/src/redis_strings.rs
@@ -25,7 +25,7 @@ use snafu::{OptionExt, ResultExt};
 
 use crate::error::Error::*;
 use crate::{
-    BaseMetaKey, ColumnFamilyIndex, DataType, Redis, Result,
+    BaseMetaKey, ColumnFamilyIndex, DataType, Redis, Result, TypeCheckState,
     error::{InvalidFormatSnafu, KeyNotFoundSnafu, OptionNoneSnafu, RocksSnafu},
     format_base_key::BaseKey,
     format_strings_value::{ParsedStringsValue, StringValue},
@@ -181,22 +181,12 @@ impl Redis {
             .context(RocksSnafu)?
             .unwrap_or_else(Vec::new);
 
-        // If key doesn't exist, return 0
-        if encode_value.is_empty() {
-            return Ok(0);
+        match self.check_type_state(encode_value.as_slice(), DataType::String)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(0),
+            TypeCheckState::Match => {}
         }
 
         let decode_value = ParsedStringsValue::new(&encode_value[..])?;
-
-        // Check if key is expired first - expired keys are treated as non-existent
-        if decode_value.is_stale() {
-            return Ok(0);
-        }
-
-        // Now check type on live key to match Redis compatibility
-        // Redis returns WRONGTYPE only for live non-string keys
-        self.check_type(encode_value.as_slice(), DataType::String)?;
-
         // Return the length of the string value
         let user_value = decode_value.user_value();
         Ok(user_value.len() as i32)
@@ -236,22 +226,12 @@ impl Redis {
             .context(RocksSnafu)?
             .unwrap_or_else(Vec::new);
 
-        // If key doesn't exist, return empty string
-        if encode_value.is_empty() {
-            return Ok(Vec::new());
+        match self.check_type_state(encode_value.as_slice(), DataType::String)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(Vec::new()),
+            TypeCheckState::Match => {}
         }
 
         let decode_value = ParsedStringsValue::new(&encode_value[..])?;
-
-        // Check if key is expired first - expired keys are treated as non-existent
-        if decode_value.is_stale() {
-            return Ok(Vec::new());
-        }
-
-        // Now check type on live key to match Redis compatibility
-        // Redis returns WRONGTYPE only for live non-string keys
-        self.check_type(encode_value.as_slice(), DataType::String)?;
-
         let user_value = decode_value.user_value();
         let len = user_value.len() as i64;
 
@@ -348,19 +328,17 @@ impl Redis {
         let mut etime: u64 = 0;
 
         if !encode_value.is_empty() {
-            let decode_value = ParsedStringsValue::new(&encode_value[..])?;
-
-            // Check if key is expired first - expired keys are treated as non-existent
-            if !decode_value.is_stale() {
-                // Now check type on live key to match Redis compatibility
-                // Redis returns WRONGTYPE only for live non-string keys
-                self.check_type(encode_value.as_slice(), DataType::String)?;
-
-                existing_value = decode_value.user_value().to_vec();
-                ctime = decode_value.ctime();
-                etime = decode_value.etime();
+            match self.check_type_state(encode_value.as_slice(), DataType::String)? {
+                TypeCheckState::Missing | TypeCheckState::Stale => {
+                    // Keep the create-as-missing path.
+                }
+                TypeCheckState::Match => {
+                    let decode_value = ParsedStringsValue::new(&encode_value[..])?;
+                    existing_value = decode_value.user_value().to_vec();
+                    ctime = decode_value.ctime();
+                    etime = decode_value.etime();
+                }
             }
-            // If expired, treat as empty string (existing_value remains empty)
         }
 
         // Early return optimization: if value is empty and offset is within bounds
@@ -442,24 +420,17 @@ impl Redis {
         let mut etime: u64 = 0;
 
         if !encode_value.is_empty() {
-            let decode_value = ParsedStringsValue::new(&encode_value[..])?;
-
-            // Check if key is expired first - expired keys are treated as non-existent
-            if decode_value.is_stale() {
-                new_value = value.to_vec();
-                // ctime and etime remain at their initialized values (current time and 0)
-                // This is correct: expired keys don't preserve old metadata
-            } else {
-                // Now check type on live key to match Redis compatibility
-                // Redis returns WRONGTYPE only for live non-string keys
-                self.check_type(encode_value.as_slice(), DataType::String)?;
-
-                // Append to existing value
-                let user_value = decode_value.user_value();
-                // Efficiently concatenate the old value and new value
-                new_value = [&user_value[..], value].concat();
-                ctime = decode_value.ctime();
-                etime = decode_value.etime();
+            match self.check_type_state(encode_value.as_slice(), DataType::String)? {
+                TypeCheckState::Missing | TypeCheckState::Stale => {
+                    new_value = value.to_vec();
+                }
+                TypeCheckState::Match => {
+                    let decode_value = ParsedStringsValue::new(&encode_value[..])?;
+                    let user_value = decode_value.user_value();
+                    new_value = [&user_value[..], value].concat();
+                    ctime = decode_value.ctime();
+                    etime = decode_value.etime();
+                }
             }
         } else {
             // Key doesn't exist, create new
@@ -497,30 +468,24 @@ impl Redis {
             message: "db is not initialized".to_string(),
         })?;
         let string_key = BaseKey::new(key);
-
-        match db
+        let encode_value = db
             .get_opt(&string_key.encode()?, &self.read_options)
             .context(RocksSnafu)?
-        {
-            Some(val) => {
-                let string_value = ParsedStringsValue::new(&val[..])?;
+            .unwrap_or_else(Vec::new);
 
-                // Check if key is expired
-                if string_value.is_stale() {
-                    return KeyNotFoundSnafu {
-                        key: String::from_utf8_lossy(key).to_string(),
-                    }
-                    .fail();
+        match self.check_type_state(encode_value.as_slice(), DataType::String)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => {
+                return KeyNotFoundSnafu {
+                    key: String::from_utf8_lossy(key).to_string(),
                 }
-
-                let user_value = string_value.user_value();
-                Ok(String::from_utf8_lossy(&user_value).to_string())
+                .fail();
             }
-            None => KeyNotFoundSnafu {
-                key: String::from_utf8_lossy(key).to_string(),
-            }
-            .fail(),
+            TypeCheckState::Match => {}
         }
+
+        let string_value = ParsedStringsValue::new(&encode_value[..])?;
+        let user_value = string_value.user_value();
+        Ok(String::from_utf8_lossy(&user_value).to_string())
     }
 
     /// Get the value of a key as bytes, preserving binary data
@@ -529,30 +494,24 @@ impl Redis {
             message: "db is not initialized".to_string(),
         })?;
         let string_key = BaseKey::new(key);
-
-        match db
+        let encode_value = db
             .get_opt(&string_key.encode()?, &self.read_options)
             .context(RocksSnafu)?
-        {
-            Some(val) => {
-                let string_value = ParsedStringsValue::new(&val[..])?;
+            .unwrap_or_else(Vec::new);
 
-                // Check if key is expired
-                if string_value.is_stale() {
-                    return KeyNotFoundSnafu {
-                        key: String::from_utf8_lossy(key).to_string(),
-                    }
-                    .fail();
+        match self.check_type_state(encode_value.as_slice(), DataType::String)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => {
+                return KeyNotFoundSnafu {
+                    key: String::from_utf8_lossy(key).to_string(),
                 }
-
-                let user_value = string_value.user_value();
-                Ok(user_value.to_vec())
+                .fail();
             }
-            None => KeyNotFoundSnafu {
-                key: String::from_utf8_lossy(key).to_string(),
-            }
-            .fail(),
+            TypeCheckState::Match => {}
         }
+
+        let string_value = ParsedStringsValue::new(&encode_value[..])?;
+        let user_value = string_value.user_value();
+        Ok(user_value.to_vec())
     }
 
     /// MGET key [key ...]
@@ -597,20 +556,24 @@ impl Redis {
                 .context(RocksSnafu)?
             {
                 Some(val) => {
-                    // Check type - if not string type, return None (like Redis does)
-                    if self.check_type(val.as_slice(), DataType::String).is_err() {
-                        results.push(None);
-                        continue;
-                    }
+                    let type_state = match self.check_type_state(val.as_slice(), DataType::String) {
+                        Ok(state) => state,
+                        Err(err) => {
+                            if err.to_string().contains("WRONGTYPE") {
+                                results.push(None);
+                                continue;
+                            }
+                            return Err(err);
+                        }
+                    };
 
-                    let string_value = ParsedStringsValue::new(&val[..])?;
-
-                    // Check if key is expired
-                    if string_value.is_stale() {
-                        results.push(None);
-                    } else {
-                        let user_value = string_value.user_value();
-                        results.push(Some(String::from_utf8_lossy(&user_value).to_string()));
+                    match type_state {
+                        TypeCheckState::Missing | TypeCheckState::Stale => results.push(None),
+                        TypeCheckState::Match => {
+                            let string_value = ParsedStringsValue::new(&val[..])?;
+                            let user_value = string_value.user_value();
+                            results.push(Some(String::from_utf8_lossy(&user_value).to_string()));
+                        }
                     }
                 }
                 None => {
@@ -815,39 +778,17 @@ impl Redis {
     /// - 0 if the key was not set
     ///
     /// # Errors
-    /// Returns WRONGTYPE error if key exists but holds a non-string value
+    /// Returns 0 if the key already exists, regardless of type
     pub fn setnx(&self, key: &[u8], value: &[u8]) -> Result<i32> {
-        let db = self.db.as_ref().context(OptionNoneSnafu {
-            message: "db is not initialized".to_string(),
-        })?;
-
-        let string_key = BaseKey::new(key);
-
         // Get lock for the key to ensure atomicity
         let key_str = String::from_utf8_lossy(key).to_string();
         let _lock = ScopeRecordLock::new(self.lock_mgr.as_ref(), &key_str);
 
-        // Check if key exists and is not expired
-        let encode_value = db
-            .get_opt(&string_key.encode()?, &self.read_options)
-            .context(RocksSnafu)?;
-
-        if let Some(val) = encode_value {
-            let string_value = ParsedStringsValue::new(&val[..])?;
-
-            // Check if key is expired first - expired keys are treated as non-existent
-            if !string_value.is_stale() {
-                // Now check type on live key to match Redis compatibility
-                // Redis returns WRONGTYPE only for live non-string keys
-                self.check_type(val.as_slice(), DataType::String)?;
-
-                // Key exists and is not expired, do not set
-                return Ok(0);
-            }
-            // Key is expired, treat as non-existent and continue to set
+        if self.key_exists_live(key)? {
+            return Ok(0);
         }
 
-        // Key doesn't exist or is expired, set the value
+        let string_key = BaseKey::new(key);
         let string_value = StringValue::new(value.to_owned());
 
         let mut batch = self.create_batch()?;
@@ -899,20 +840,13 @@ impl Redis {
             .context(RocksSnafu)?;
 
         let old_value = if let Some(val) = encode_value {
-            let string_value = ParsedStringsValue::new(&val[..])?;
-
-            // Check if key is expired first - expired keys are treated as non-existent
-            if !string_value.is_stale() {
-                // Now check type on live key to match Redis compatibility
-                // Redis returns WRONGTYPE only for live non-string keys
-                self.check_type(val.as_slice(), DataType::String)?;
-
-                // Key exists and is not expired, return old value
-                let user_value = string_value.user_value();
-                Some(String::from_utf8_lossy(&user_value).to_string())
-            } else {
-                // Key is expired, treat as non-existent
-                None
+            match self.check_type_state(val.as_slice(), DataType::String)? {
+                TypeCheckState::Missing | TypeCheckState::Stale => None,
+                TypeCheckState::Match => {
+                    let string_value = ParsedStringsValue::new(&val[..])?;
+                    let user_value = string_value.user_value();
+                    Some(String::from_utf8_lossy(&user_value).to_string())
+                }
             }
         } else {
             // Key doesn't exist
@@ -1193,38 +1127,10 @@ impl Redis {
     /// MSETNX key1 "Hello" key2 "World"  // Sets both keys if neither exists
     /// ```
     pub fn msetnx(&self, kvs: &[(Vec<u8>, Vec<u8>)]) -> Result<bool> {
-        let db = self.db.as_ref().context(OptionNoneSnafu {
-            message: "db is not initialized".to_string(),
-        })?;
-
-        let _cf = self
-            .get_cf_handle(ColumnFamilyIndex::MetaCF)
-            .context(OptionNoneSnafu {
-                message: "cf is not initialized".to_string(),
-            })?;
-
         // Check if any key exists and is not expired
         for (key, _) in kvs {
-            let string_key = BaseKey::new(key);
-
-            match db
-                .get_opt(&string_key.encode()?, &self.read_options)
-                .context(RocksSnafu)?
-            {
-                Some(val) => {
-                    let string_value = ParsedStringsValue::new(&val[..])?;
-
-                    // MSETNX returns false if any live key exists (regardless of type)
-                    // Redis never returns WRONGTYPE for MSETNX - it only checks existence
-                    if !string_value.is_stale() {
-                        // Any live key (any type) blocks the batch
-                        return Ok(false);
-                    }
-                    // Key is expired, treat as non-existent and continue checking
-                }
-                None => {
-                    // Key doesn't exist, continue checking
-                }
+            if self.key_exists_live(key)? {
+                return Ok(false);
             }
         }
 
@@ -1270,25 +1176,23 @@ impl Redis {
 
         // convert user_value to i64
         if !encode_value.is_empty() {
-            let decode_value = ParsedStringsValue::new(&encode_value[..])?;
-            // Check if key is expired first - expired keys are treated as non-existent
-            if !decode_value.is_stale() {
-                // Now check type on live key to match Redis compatibility
-                // Redis returns WRONGTYPE only for live non-string keys
-                self.check_type(encode_value.as_slice(), DataType::String)?;
-
-                let user_value = decode_value.user_value();
-                value = match String::from_utf8_lossy(&user_value).to_string().parse() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        return Err(RedisErr {
-                            message: "value is not an integer or out of range".to_string(),
-                            location: Default::default(),
-                        });
-                    }
-                };
-                ctime = decode_value.ctime();
-                etime = decode_value.etime();
+            match self.check_type_state(encode_value.as_slice(), DataType::String)? {
+                TypeCheckState::Missing | TypeCheckState::Stale => {}
+                TypeCheckState::Match => {
+                    let decode_value = ParsedStringsValue::new(&encode_value[..])?;
+                    let user_value = decode_value.user_value();
+                    value = match String::from_utf8_lossy(&user_value).to_string().parse() {
+                        Ok(v) => v,
+                        Err(_) => {
+                            return Err(RedisErr {
+                                message: "value is not an integer or out of range".to_string(),
+                                location: Default::default(),
+                            });
+                        }
+                    };
+                    ctime = decode_value.ctime();
+                    etime = decode_value.etime();
+                }
             }
         }
 
@@ -1337,25 +1241,23 @@ impl Redis {
 
         // convert user_value to f64
         if !encode_value.is_empty() {
-            let decode_value = ParsedStringsValue::new(&encode_value[..])?;
-            // Check if key is expired first - expired keys are treated as non-existent
-            if !decode_value.is_stale() {
-                // Now check type on live key to match Redis compatibility
-                // Redis returns WRONGTYPE only for live non-string keys
-                self.check_type(encode_value.as_slice(), DataType::String)?;
-
-                let user_value = decode_value.user_value();
-                value = match String::from_utf8_lossy(&user_value).to_string().parse() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        return Err(RedisErr {
-                            message: "value is not a valid float".to_string(),
-                            location: Default::default(),
-                        });
-                    }
-                };
-                ctime = decode_value.ctime();
-                etime = decode_value.etime();
+            match self.check_type_state(encode_value.as_slice(), DataType::String)? {
+                TypeCheckState::Missing | TypeCheckState::Stale => {}
+                TypeCheckState::Match => {
+                    let decode_value = ParsedStringsValue::new(&encode_value[..])?;
+                    let user_value = decode_value.user_value();
+                    value = match String::from_utf8_lossy(&user_value).to_string().parse() {
+                        Ok(v) => v,
+                        Err(_) => {
+                            return Err(RedisErr {
+                                message: "value is not a valid float".to_string(),
+                                location: Default::default(),
+                            });
+                        }
+                    };
+                    ctime = decode_value.ctime();
+                    etime = decode_value.etime();
+                }
             }
         }
 
@@ -1400,18 +1302,10 @@ impl Redis {
     /// * Ok(false) - if the key doesn't exist or is expired
     /// * Err(RedisErr) - if there's a database error
     pub fn key_exists_live(&self, key: &[u8]) -> Result<bool> {
-        let db = self.db.as_ref().context(OptionNoneSnafu {
-            message: "db is not initialized".to_string(),
-        })?;
-        let string_key = BaseKey::new(key);
-        if let Some(val) = db
-            .get_opt(&string_key.encode()?, &self.read_options)
-            .context(RocksSnafu)?
-        {
-            let meta = ParsedStringsValue::new(&val[..])?;
-            Ok(!meta.is_stale())
-        } else {
-            Ok(false)
+        match self.get_key_type(key) {
+            Ok(_) => Ok(true),
+            Err(crate::error::Error::KeyNotFound { .. }) => Ok(false),
+            Err(err) => Err(err),
         }
     }
 
@@ -1479,19 +1373,17 @@ impl Redis {
         let mut etime: u64 = 0;
 
         if !encode_value.is_empty() {
-            let decode_value = ParsedStringsValue::new(&encode_value[..])?;
-
-            // Check if key is expired first - expired keys are treated as non-existent
-            if !decode_value.is_stale() {
-                // Now check type on live key to match Redis compatibility
-                // Redis returns WRONGTYPE only for live non-string keys
-                self.check_type(encode_value.as_slice(), DataType::String)?;
-
-                existing_value = decode_value.user_value().to_vec();
-                ctime = decode_value.ctime();
-                etime = decode_value.etime();
+            match self.check_type_state(encode_value.as_slice(), DataType::String)? {
+                TypeCheckState::Missing | TypeCheckState::Stale => {
+                    // Keep the create-as-missing path.
+                }
+                TypeCheckState::Match => {
+                    let decode_value = ParsedStringsValue::new(&encode_value[..])?;
+                    existing_value = decode_value.user_value().to_vec();
+                    ctime = decode_value.ctime();
+                    etime = decode_value.etime();
+                }
             }
-            // If expired, treat as empty string (existing_value remains empty)
         }
 
         // Calculate byte and bit positions
@@ -1575,22 +1467,12 @@ impl Redis {
             .context(RocksSnafu)?
             .unwrap_or_else(Vec::new);
 
-        // If key doesn't exist, return 0
-        if encode_value.is_empty() {
-            return Ok(0);
+        match self.check_type_state(encode_value.as_slice(), DataType::String)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(0),
+            TypeCheckState::Match => {}
         }
 
         let decode_value = ParsedStringsValue::new(&encode_value[..])?;
-
-        // Check if key is expired first - expired keys are treated as non-existent
-        if decode_value.is_stale() {
-            return Ok(0);
-        }
-
-        // Now check type on live key to match Redis compatibility
-        // Redis returns WRONGTYPE only for live non-string keys
-        self.check_type(encode_value.as_slice(), DataType::String)?;
-
         let user_value = decode_value.user_value();
 
         // Calculate byte and bit positions
@@ -1638,22 +1520,12 @@ impl Redis {
             .context(RocksSnafu)?
             .unwrap_or_else(Vec::new);
 
-        // If key doesn't exist, return 0
-        if encode_value.is_empty() {
-            return Ok(0);
+        match self.check_type_state(encode_value.as_slice(), DataType::String)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(0),
+            TypeCheckState::Match => {}
         }
 
         let decode_value = ParsedStringsValue::new(&encode_value[..])?;
-
-        // Check if key is expired first - expired keys are treated as non-existent
-        if decode_value.is_stale() {
-            return Ok(0);
-        }
-
-        // Now check type on live key to match Redis compatibility
-        // Redis returns WRONGTYPE only for live non-string keys
-        self.check_type(encode_value.as_slice(), DataType::String)?;
-
         let user_value = decode_value.user_value();
 
         // If no range specified, count all bits
@@ -1750,22 +1622,14 @@ impl Redis {
             .context(RocksSnafu)?
             .unwrap_or_else(Vec::new);
 
-        // If key doesn't exist, return -1 for bit=1, 0 for bit=0 (Redis behavior)
-        if encode_value.is_empty() {
-            return Ok(if bit == 1 { -1 } else { 0 });
+        match self.check_type_state(encode_value.as_slice(), DataType::String)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => {
+                return Ok(if bit == 1 { -1 } else { 0 });
+            }
+            TypeCheckState::Match => {}
         }
 
         let decode_value = ParsedStringsValue::new(&encode_value[..])?;
-
-        // Check if key is expired first - expired keys are treated as non-existent
-        if decode_value.is_stale() {
-            return Ok(if bit == 1 { -1 } else { 0 });
-        }
-
-        // Now check type on live key to match Redis compatibility
-        // Redis returns WRONGTYPE only for live non-string keys
-        self.check_type(encode_value.as_slice(), DataType::String)?;
-
         let user_value = decode_value.user_value();
 
         // If user value is empty, return -1 for bit=1, 0 for bit=0 (Redis behavior)
@@ -1920,6 +1784,25 @@ impl Redis {
                 .unwrap_or_else(Vec::new);
 
             // If source key doesn't exist or is empty, result is an empty string
+            match self.check_type_state(encode_value.as_slice(), DataType::String)? {
+                TypeCheckState::Missing | TypeCheckState::Stale => {
+                    let mut string_value = StringValue::new(vec![]);
+                    string_value.set_ctime(Utc::now().timestamp_micros() as u64);
+                    string_value.set_etime(0);
+
+                    let dest_string_key = BaseKey::new(dest_key);
+                    let mut batch = self.create_batch()?;
+                    batch.put(
+                        ColumnFamilyIndex::MetaCF,
+                        &dest_string_key.encode()?,
+                        &string_value.encode(),
+                    )?;
+                    batch.commit()?;
+                    return Ok(0);
+                }
+                TypeCheckState::Match => {}
+            }
+
             if encode_value.is_empty() {
                 // Store an empty string as the result
                 let mut string_value = StringValue::new(vec![]);
@@ -1938,25 +1821,6 @@ impl Redis {
             }
 
             let decode_value = ParsedStringsValue::new(&encode_value[..])?;
-
-            // Check if key is expired first - expired keys are treated as non-existent
-            if decode_value.is_stale() {
-                // Store an empty string as the result
-                let mut string_value = StringValue::new(vec![]);
-                string_value.set_ctime(Utc::now().timestamp_micros() as u64);
-                string_value.set_etime(0); // No expiration by default
-
-                let dest_string_key = BaseKey::new(dest_key);
-                let mut batch = self.create_batch()?;
-                batch.put(
-                    ColumnFamilyIndex::MetaCF,
-                    &dest_string_key.encode()?,
-                    &string_value.encode(),
-                )?;
-                batch.commit()?;
-                return Ok(0);
-            }
-
             let user_value = decode_value.user_value();
 
             // Apply NOT operation to each byte
@@ -1998,24 +1862,15 @@ impl Redis {
                 .context(RocksSnafu)?
                 .unwrap_or_else(Vec::new);
 
-            // If any source key doesn't exist or is empty, treat as empty string
-            if encode_value.is_empty() {
-                src_values.push(Vec::new());
-                continue;
+            match self.check_type_state(encode_value.as_slice(), DataType::String)? {
+                TypeCheckState::Missing | TypeCheckState::Stale => {
+                    src_values.push(Vec::new());
+                    continue;
+                }
+                TypeCheckState::Match => {}
             }
 
             let decode_value = ParsedStringsValue::new(&encode_value[..])?;
-
-            // Check if key is expired first - expired keys are treated as non-existent
-            if decode_value.is_stale() {
-                src_values.push(Vec::new());
-                continue;
-            }
-
-            // Now check type on live key to match Redis compatibility
-            // Redis returns WRONGTYPE only for live non-string keys
-            self.check_type(encode_value.as_slice(), DataType::String)?;
-
             let user_value = decode_value.user_value();
             max_len = max_len.max(user_value.len());
             src_values.push(user_value.to_vec());
@@ -2093,34 +1948,31 @@ impl Redis {
         let db = self.db.as_ref().context(OptionNoneSnafu {
             message: "db is not initialized".to_string(),
         })?;
-
-        // Get MetaCF handle for reading metadata
-        let cf = self
+        let meta_cf = self
             .get_cf_handle(ColumnFamilyIndex::MetaCF)
             .context(OptionNoneSnafu {
                 message: "MetaCF is not initialized".to_string(),
             })?;
 
-        let meta_key = BaseMetaKey::new(key);
-        if let Some(val) = db
-            .get_cf_opt(&cf, &meta_key.encode()?, &self.read_options)
+        let meta_key = BaseMetaKey::new(key).encode()?;
+        let Some(value) = db
+            .get_cf_opt(&meta_cf, &meta_key, &self.read_options)
             .context(RocksSnafu)?
-        {
-            if val.is_empty() || self.is_stale(&val)? {
-                return Err(crate::error::Error::KeyNotFound {
-                    key: String::from_utf8_lossy(key).to_string(),
-                    location: snafu::location!(),
-                });
-            }
+        else {
+            return Err(crate::error::Error::KeyNotFound {
+                key: String::from_utf8_lossy(key).to_string(),
+                location: snafu::location!(),
+            });
+        };
 
-            return DataType::try_from(val[0]);
+        if value.is_empty() || self.is_stale(&value)? {
+            return Err(crate::error::Error::KeyNotFound {
+                key: String::from_utf8_lossy(key).to_string(),
+                location: snafu::location!(),
+            });
         }
 
-        // Key doesn't exist or all types are stale
-        Err(crate::error::Error::KeyNotFound {
-            key: String::from_utf8_lossy(key).to_string(),
-            location: snafu::location!(),
-        })
+        DataType::try_from(value[0])
     }
 
     /// Delete a key (works for all data types)

--- a/src/storage/src/redis_zsets.rs
+++ b/src/storage/src/redis_zsets.rs
@@ -25,7 +25,7 @@ use crate::error::{OptionNoneSnafu, RocksSnafu};
 use crate::format_base_data_value::{BaseDataValue, ParsedBaseDataValue};
 use crate::format_base_meta_value::{ParsedZSetsMetaValue, ZSetsMetaValue};
 use crate::redis::Redis;
-use crate::{BaseMetaKey, ColumnFamilyIndex, DataType, Result};
+use crate::{BaseMetaKey, ColumnFamilyIndex, DataType, Result, TypeCheckState};
 use kstd::lock_mgr::ScopeRecordLock;
 use rocksdb::{Direction, IteratorMode, ReadOptions};
 use snafu::OptionExt;
@@ -79,108 +79,110 @@ impl Redis {
 
         // ZSet exists, update it
         if !base_meta_val.is_empty() {
-            // Check type
-            self.check_type(&base_meta_val, DataType::ZSet)?;
+            match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+                TypeCheckState::Missing | TypeCheckState::Stale => {}
+                TypeCheckState::Match => {
+                    let mut parsed_zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
 
-            // Parse existing meta
-            let mut parsed_zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
+                    let version;
+                    let valid;
+                    if parsed_zset_meta.is_valid() {
+                        valid = true;
+                        version = parsed_zset_meta.version();
+                    } else {
+                        valid = false;
+                        version = parsed_zset_meta.initial_meta_value();
+                    }
 
-            // Get version and validity
-            let version;
-            let valid;
-            if parsed_zset_meta.is_valid() {
-                valid = true;
-                version = parsed_zset_meta.version();
-            } else {
-                valid = false;
-                version = parsed_zset_meta.initial_meta_value();
-            }
-
-            // Prepare batch write
-            let mut count = 0u64;
-            let mut batch = self.create_batch()?;
-            for sm in &filtered_score_members {
-                let mut not_found = true;
-                let member_key = MemberDataKey::new(key, version, &sm.member).encode()?;
-                if valid {
-                    // Check if member exists
-                    let existing_member_val = db
-                        .get_cf_opt(&cf_data, &member_key, &self.read_options)
-                        .context(RocksSnafu)?
-                        .unwrap_or_else(Vec::new);
-                    if !existing_member_val.is_empty() {
-                        // Member exists, check score
-                        let mut parsed_base_data_val =
-                            ParsedBaseDataValue::new(&existing_member_val[..])?;
-                        parsed_base_data_val.strip_suffix();
-                        not_found = false;
-                        match String::from_utf8_lossy(&parsed_base_data_val.user_value())
-                            .parse::<f64>()
-                        {
-                            Ok(existing_score) => {
-                                if (existing_score - sm.score).abs() < f64::EPSILON {
-                                    // Score is the same, skip
-                                    continue;
-                                } else {
-                                    // Score is different, delete old score key
-                                    let old_score_key = ZSetsScoreKey::new(
-                                        key,
-                                        version,
-                                        existing_score,
-                                        &sm.member,
-                                    )
-                                    .encode()?;
-                                    batch
-                                        .delete(ColumnFamilyIndex::ZsetsScoreCF, &old_score_key)?;
-                                    statistic += 1;
+                    let mut count = 0u64;
+                    let mut batch = self.create_batch()?;
+                    for sm in &filtered_score_members {
+                        let mut not_found = true;
+                        let member_key = MemberDataKey::new(key, version, &sm.member).encode()?;
+                        if valid {
+                            let existing_member_val = db
+                                .get_cf_opt(&cf_data, &member_key, &self.read_options)
+                                .context(RocksSnafu)?
+                                .unwrap_or_else(Vec::new);
+                            if !existing_member_val.is_empty() {
+                                let mut parsed_base_data_val =
+                                    ParsedBaseDataValue::new(&existing_member_val[..])?;
+                                parsed_base_data_val.strip_suffix();
+                                not_found = false;
+                                match String::from_utf8_lossy(&parsed_base_data_val.user_value())
+                                    .parse::<f64>()
+                                {
+                                    Ok(existing_score) => {
+                                        if (existing_score - sm.score).abs() < f64::EPSILON {
+                                            continue;
+                                        }
+                                        let old_score_key = ZSetsScoreKey::new(
+                                            key,
+                                            version,
+                                            existing_score,
+                                            &sm.member,
+                                        )
+                                        .encode()?;
+                                        batch.delete(
+                                            ColumnFamilyIndex::ZsetsScoreCF,
+                                            &old_score_key,
+                                        )?;
+                                        statistic += 1;
+                                    }
+                                    Err(_) => {
+                                        return Err(RedisErr {
+                                            message: "invalid score format".to_string(),
+                                            location: Default::default(),
+                                        });
+                                    }
                                 }
                             }
-                            Err(_) => {
-                                return Err(RedisErr {
-                                    message: "invalid score format".to_string(),
-                                    location: Default::default(),
-                                });
-                            }
+                        }
+
+                        let score_key =
+                            ZSetsScoreKey::new(key, version, sm.score, &sm.member).encode()?;
+                        let member_value = BaseDataValue::new(format!("{}", sm.score));
+                        let score_value = BaseDataValue::new("");
+                        batch.put(
+                            ColumnFamilyIndex::ZsetsDataCF,
+                            &member_key,
+                            &member_value.encode(),
+                        )?;
+                        batch.put(
+                            ColumnFamilyIndex::ZsetsScoreCF,
+                            &score_key,
+                            &score_value.encode(),
+                        )?;
+                        if not_found {
+                            count += 1;
                         }
                     }
-                }
 
-                // Insert new member and score
-                let score_key = ZSetsScoreKey::new(key, version, sm.score, &sm.member).encode()?;
-                let member_value = BaseDataValue::new(format!("{}", sm.score));
-                let score_value = BaseDataValue::new("");
-                batch.put(
-                    ColumnFamilyIndex::ZsetsDataCF,
-                    &member_key,
-                    &member_value.encode(),
-                )?;
-                batch.put(
-                    ColumnFamilyIndex::ZsetsScoreCF,
-                    &score_key,
-                    &score_value.encode(),
-                )?;
-                if not_found {
-                    count += 1;
+                    if !parsed_zset_meta.check_modify_count(count) {
+                        return Err(RedisErr {
+                            message: "zset size overflow".to_string(),
+                            location: Default::default(),
+                        });
+                    }
+                    parsed_zset_meta.modify_count(count);
+                    batch.put(
+                        ColumnFamilyIndex::MetaCF,
+                        &base_meta_key.encode()?,
+                        parsed_zset_meta.encoded(),
+                    )?;
+                    batch.commit()?;
+                    *ret = count as i32;
+                    self.update_specific_key_statistics(
+                        DataType::ZSet,
+                        &key_str,
+                        statistic as u64,
+                    )?;
+                    return Ok(());
                 }
-                continue;
             }
+        }
 
-            // Update meta
-            if !parsed_zset_meta.check_modify_count(count) {
-                return Err(RedisErr {
-                    message: "zset size overflow".to_string(),
-                    location: Default::default(),
-                });
-            }
-            parsed_zset_meta.modify_count(count);
-            batch.put(
-                ColumnFamilyIndex::MetaCF,
-                &base_meta_key.encode()?,
-                parsed_zset_meta.encoded(),
-            )?;
-            batch.commit()?;
-            *ret = count as i32;
-        } else {
+        {
             // ZSet does not exist, create new one
             let mut zset_meta = ZSetsMetaValue::new(bytes::Bytes::copy_from_slice(
                 &(filtered_score_members.len() as u64).to_le_bytes(),
@@ -237,7 +239,10 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(()),
+            TypeCheckState::Match => {}
+        }
 
         let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
         if !zset_meta.is_valid() {
@@ -270,7 +275,10 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(()),
+            TypeCheckState::Match => {}
+        }
 
         let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
         if !zset_meta.is_valid() {
@@ -341,97 +349,95 @@ impl Redis {
         let mut new_score = increment;
 
         if !base_meta_val.is_empty() {
-            // ZSet exists, check if member exists
-            self.check_type(&base_meta_val, DataType::ZSet)?;
+            match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+                TypeCheckState::Missing | TypeCheckState::Stale => {}
+                TypeCheckState::Match => {
+                    let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
+                    if !zset_meta.is_valid() {
+                        let score_member = ScoreMember::new(new_score, member.to_vec());
+                        let mut count = 0;
+                        std::mem::drop(_lock);
+                        self.zadd(key, &[score_member], &mut count)?;
+                        *ret = format!("{}", new_score).into_bytes();
+                        return Ok(());
+                    }
 
-            let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
-            if !zset_meta.is_valid() {
-                // ZSet is invalid, treat as if it doesn't exist
-                let score_member = ScoreMember::new(new_score, member.to_vec());
-                let mut count = 0;
-                std::mem::drop(_lock);
-                self.zadd(key, &[score_member], &mut count)?;
-                *ret = format!("{}", new_score).into_bytes();
-                return Ok(());
-            }
+                    let version = zset_meta.version();
+                    let member_key = MemberDataKey::new(key, version, member).encode()?;
+                    let existing_member_val = db
+                        .get_cf_opt(&cf_data, &member_key, &self.read_options)
+                        .context(RocksSnafu)?
+                        .unwrap_or_else(Vec::new);
 
-            let version = zset_meta.version();
-            let member_key = MemberDataKey::new(key, version, member).encode()?;
+                    if !existing_member_val.is_empty() {
+                        let mut parsed_base_data_val =
+                            ParsedBaseDataValue::new(&existing_member_val[..])?;
+                        parsed_base_data_val.strip_suffix();
 
-            // Check if member exists
-            let existing_member_val = db
-                .get_cf_opt(&cf_data, &member_key, &self.read_options)
-                .context(RocksSnafu)?
-                .unwrap_or_else(Vec::new);
+                        match String::from_utf8_lossy(&parsed_base_data_val.user_value())
+                            .parse::<f64>()
+                        {
+                            Ok(current_score) => {
+                                new_score = current_score + increment;
+                                if new_score.is_nan() || new_score.is_infinite() {
+                                    return Err(RedisErr {
+                                        message: "ERR increment would produce NaN or Infinity"
+                                            .to_string(),
+                                        location: Default::default(),
+                                    });
+                                }
 
-            if !existing_member_val.is_empty() {
-                // Member exists, get current score and increment it
-                let mut parsed_base_data_val = ParsedBaseDataValue::new(&existing_member_val[..])?;
-                parsed_base_data_val.strip_suffix();
+                                let mut batch = self.create_batch()?;
+                                let old_score_key =
+                                    ZSetsScoreKey::new(key, version, current_score, member)
+                                        .encode()?;
+                                batch.delete(ColumnFamilyIndex::ZsetsScoreCF, &old_score_key)?;
 
-                match String::from_utf8_lossy(&parsed_base_data_val.user_value()).parse::<f64>() {
-                    Ok(current_score) => {
-                        new_score = current_score + increment;
+                                let new_score_key =
+                                    crate::format_zset_score_key::ZSetsScoreKey::new(
+                                        key, version, new_score, member,
+                                    )
+                                    .encode()?;
+                                let member_value = BaseDataValue::new(format!("{}", new_score));
+                                let score_value = BaseDataValue::new("");
 
-                        // Check for valid float (not NaN or infinite)
-                        if new_score.is_nan() || new_score.is_infinite() {
-                            return Err(RedisErr {
-                                message: "ERR increment would produce NaN or Infinity".to_string(),
-                                location: Default::default(),
-                            });
+                                batch.put(
+                                    ColumnFamilyIndex::ZsetsDataCF,
+                                    &member_key,
+                                    &member_value.encode(),
+                                )?;
+                                batch.put(
+                                    ColumnFamilyIndex::ZsetsScoreCF,
+                                    &new_score_key,
+                                    &score_value.encode(),
+                                )?;
+
+                                batch.commit()?;
+                            }
+                            Err(_) => {
+                                return Err(RedisErr {
+                                    message: "invalid score format".to_string(),
+                                    location: Default::default(),
+                                });
+                            }
                         }
-
-                        // Update the member with new score
-                        let mut batch = self.create_batch()?;
-
-                        // Delete old score key
-                        let old_score_key =
-                            ZSetsScoreKey::new(key, version, current_score, member).encode()?;
-                        batch.delete(ColumnFamilyIndex::ZsetsScoreCF, &old_score_key)?;
-
-                        // Add new score key and update member value
-                        let new_score_key = crate::format_zset_score_key::ZSetsScoreKey::new(
-                            key, version, new_score, member,
-                        )
-                        .encode()?;
-                        let member_value = BaseDataValue::new(format!("{}", new_score));
-                        let score_value = BaseDataValue::new("");
-
-                        batch.put(
-                            ColumnFamilyIndex::ZsetsDataCF,
-                            &member_key,
-                            &member_value.encode(),
-                        )?;
-                        batch.put(
-                            ColumnFamilyIndex::ZsetsScoreCF,
-                            &new_score_key,
-                            &score_value.encode(),
-                        )?;
-
-                        batch.commit()?;
+                    } else {
+                        let score_member = ScoreMember::new(new_score, member.to_vec());
+                        let mut count = 0;
+                        std::mem::drop(_lock);
+                        self.zadd(key, &[score_member], &mut count)?;
                     }
-                    Err(_) => {
-                        return Err(RedisErr {
-                            message: "invalid score format".to_string(),
-                            location: Default::default(),
-                        });
-                    }
+
+                    *ret = format!("{}", new_score).into_bytes();
+                    return Ok(());
                 }
-            } else {
-                // Member doesn't exist, add it with the increment as the score
-                let score_member = ScoreMember::new(new_score, member.to_vec());
-                let mut count = 0;
-                std::mem::drop(_lock);
-                self.zadd(key, &[score_member], &mut count)?;
             }
-        } else {
-            // ZSet doesn't exist, create it with the member and increment as score
-            let score_member = ScoreMember::new(new_score, member.to_vec());
-            let mut count = 0;
-            std::mem::drop(_lock);
-            self.zadd(key, &[score_member], &mut count)?;
         }
 
+        let score_member = ScoreMember::new(new_score, member.to_vec());
+        let mut count = 0;
+        std::mem::drop(_lock);
+        self.zadd(key, &[score_member], &mut count)?;
         *ret = format!("{}", new_score).into_bytes();
         Ok(())
     }
@@ -461,7 +467,10 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(()),
+            TypeCheckState::Match => {}
+        }
 
         let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
         if !zset_meta.is_valid() {
@@ -516,7 +525,10 @@ impl Redis {
             return Ok((0, Vec::new()));
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok((0, Vec::new())),
+            TypeCheckState::Match => {}
+        }
 
         let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
         if !zset_meta.is_valid() {
@@ -618,7 +630,10 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(()),
+            TypeCheckState::Match => {}
+        }
 
         let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
         if !zset_meta.is_valid() {
@@ -710,7 +725,10 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(()),
+            TypeCheckState::Match => {}
+        }
 
         let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
         if !zset_meta.is_valid() {
@@ -802,7 +820,10 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(()),
+            TypeCheckState::Match => {}
+        }
 
         let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
         if !zset_meta.is_valid() {
@@ -894,7 +915,10 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(()),
+            TypeCheckState::Match => {}
+        }
 
         let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
         if !zset_meta.is_valid() {
@@ -982,7 +1006,10 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(()),
+            TypeCheckState::Match => {}
+        }
 
         let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
         if !zset_meta.is_valid() {
@@ -1148,8 +1175,15 @@ impl Redis {
                 continue;
             }
 
-            // Check type
-            self.check_type(&base_meta_val, DataType::ZSet)?;
+            match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+                TypeCheckState::Missing | TypeCheckState::Stale => {
+                    if is_inter {
+                        return Ok(0);
+                    }
+                    continue;
+                }
+                TypeCheckState::Match => {}
+            }
 
             let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
             if !zset_meta.is_valid() {
@@ -1219,39 +1253,44 @@ impl Redis {
 
         let mut batch = self.create_batch()?;
 
-        // Delete existing destination data if it exists
+        // Delete existing destination data if it exists.
+        // ZINTERSTORE/ZUNIONSTORE always overwrite the destination, so we must not
+        // fail with WRONGTYPE when the destination holds a different data type.
         if !dest_meta_val.is_empty() {
-            self.check_type(&dest_meta_val, DataType::ZSet)?;
-            let dest_meta = ParsedZSetsMetaValue::new(&dest_meta_val[..])?;
-            if dest_meta.is_valid() {
-                let dest_version = dest_meta.version();
+            // If the destination is a parseable ZSet, clean up its score/member data.
+            if let Ok(dest_meta) = ParsedZSetsMetaValue::new(&dest_meta_val[..]) {
+                if dest_meta.is_valid() {
+                    let dest_version = dest_meta.version();
 
-                // Delete all score keys and member keys
-                let min_score_key =
-                    ZSetsScoreKey::new(destination, dest_version, f64::NEG_INFINITY, &[])
-                        .encode_seek_key()?;
-                let iter = db.iterator_cf_opt(
-                    &cf_score,
-                    ReadOptions::default(),
-                    IteratorMode::From(&min_score_key, Direction::Forward),
-                );
+                    // Delete all score keys and member keys
+                    let min_score_key =
+                        ZSetsScoreKey::new(destination, dest_version, f64::NEG_INFINITY, &[])
+                            .encode_seek_key()?;
+                    let iter = db.iterator_cf_opt(
+                        &cf_score,
+                        ReadOptions::default(),
+                        IteratorMode::From(&min_score_key, Direction::Forward),
+                    );
 
-                for item in iter {
-                    let (raw_key, _) = item.context(RocksSnafu)?;
-                    let score_key = ParsedZSetsScoreKey::new(&raw_key)?;
+                    for item in iter {
+                        let (raw_key, _) = item.context(RocksSnafu)?;
+                        let score_key = ParsedZSetsScoreKey::new(&raw_key)?;
 
-                    if destination != score_key.key() || dest_version != score_key.version() {
-                        break;
+                        if destination != score_key.key() || dest_version != score_key.version() {
+                            break;
+                        }
+
+                        // Delete score key and member key
+                        batch.delete(ColumnFamilyIndex::ZsetsScoreCF, &raw_key)?;
+                        let member_key =
+                            MemberDataKey::new(destination, dest_version, score_key.member())
+                                .encode()?;
+                        batch.delete(ColumnFamilyIndex::ZsetsDataCF, &member_key)?;
                     }
-
-                    // Delete score key and member key
-                    batch.delete(ColumnFamilyIndex::ZsetsScoreCF, &raw_key)?;
-                    let member_key =
-                        MemberDataKey::new(destination, dest_version, score_key.member())
-                            .encode()?;
-                    batch.delete(ColumnFamilyIndex::ZsetsDataCF, &member_key)?;
                 }
             }
+            // Remove the old destination meta key so the new result can replace it.
+            batch.delete(ColumnFamilyIndex::MetaCF, &dest_meta_key.encode()?)?;
         }
 
         // Add new result members or delete meta if empty
@@ -1334,7 +1373,10 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(()),
+            TypeCheckState::Match => {}
+        }
 
         let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
         if !zset_meta.is_valid() {
@@ -1434,7 +1476,10 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(()),
+            TypeCheckState::Match => {}
+        }
 
         let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
         if !zset_meta.is_valid() {
@@ -1517,7 +1562,10 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(()),
+            TypeCheckState::Match => {}
+        }
 
         let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
         if !zset_meta.is_valid() {
@@ -1626,7 +1674,10 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(()),
+            TypeCheckState::Match => {}
+        }
 
         let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
         if !zset_meta.is_valid() {
@@ -1756,7 +1807,10 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(()),
+            TypeCheckState::Match => {}
+        }
 
         let mut zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
         if !zset_meta.is_valid() {
@@ -1856,7 +1910,10 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(()),
+            TypeCheckState::Match => {}
+        }
 
         let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
         if !zset_meta.is_valid() {
@@ -1955,7 +2012,10 @@ impl Redis {
             return Ok(());
         }
 
-        self.check_type(&base_meta_val, DataType::ZSet)?;
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(()),
+            TypeCheckState::Match => {}
+        }
 
         let zset_meta = ParsedZSetsMetaValue::new(&base_meta_val[..])?;
         if !zset_meta.is_valid() {

--- a/src/storage/tests/redis_basic_test.rs
+++ b/src/storage/tests/redis_basic_test.rs
@@ -21,10 +21,12 @@
 mod redis_basic_test {
     use std::sync::{Arc, atomic::Ordering};
 
+    use bytes::Bytes;
     use kstd::lock_mgr::LockMgr;
     use storage::{
-        BgTaskHandler, ColumnFamilyIndex, Redis, StorageOptions, safe_cleanup_test_db,
-        unique_test_db_path,
+        BgTaskHandler, ColumnFamilyIndex, DataType, Redis, StorageOptions, TypeCheckState,
+        format_base_meta_value::BaseMetaValue, format_strings_value::StringValue,
+        safe_cleanup_test_db, unique_test_db_path,
     };
 
     #[test]
@@ -38,6 +40,74 @@ mod redis_basic_test {
         assert!(redis.is_starting.load(Ordering::SeqCst));
         assert!(redis.db.is_none());
         assert_eq!(redis.handles.len(), 0);
+    }
+
+    #[test]
+    fn test_check_type_state_reports_missing_stale_match_and_wrongtype() {
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+
+        assert_eq!(
+            redis.check_type_state(&[], DataType::String).unwrap(),
+            TypeCheckState::Missing
+        );
+
+        let string_raw = StringValue::new(b"value".to_vec()).encode();
+        assert_eq!(
+            redis
+                .check_type_state(string_raw.as_ref(), DataType::String)
+                .unwrap(),
+            TypeCheckState::Match
+        );
+
+        let mut stale_raw = StringValue::new(b"value".to_vec()).encode().to_vec();
+        let etime_start = stale_raw.len() - 8;
+        stale_raw[etime_start..].copy_from_slice(&1u64.to_le_bytes());
+        assert_eq!(
+            redis
+                .check_type_state(stale_raw.as_ref(), DataType::String)
+                .unwrap(),
+            TypeCheckState::Stale
+        );
+
+        let mut set_meta = BaseMetaValue::new(Bytes::from(1u64.to_le_bytes().to_vec()));
+        set_meta.inner.data_type = DataType::Set;
+        let set_raw = set_meta.encode();
+        let err = redis
+            .check_type_state(set_raw.as_ref(), DataType::String)
+            .unwrap_err();
+        assert!(err.to_string().contains("WRONGTYPE"));
+    }
+
+    #[test]
+    fn test_check_type_wrapper_treats_stale_foreign_type_as_missing() {
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+
+        let mut set_meta = BaseMetaValue::new(Bytes::from(1u64.to_le_bytes().to_vec()));
+        set_meta.inner.data_type = DataType::Set;
+        let mut stale_set_raw = set_meta.encode().to_vec();
+        let etime_start = stale_set_raw.len() - 8;
+        stale_set_raw[etime_start..].copy_from_slice(&1u64.to_le_bytes());
+
+        redis
+            .check_type(stale_set_raw.as_ref(), DataType::String)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_key_exists_live_propagates_non_key_not_found_errors() {
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+
+        let err = redis.key_exists_live(b"missing-db").unwrap_err();
+        assert!(err.to_string().contains("db is not initialized"));
     }
 
     #[test]

--- a/src/storage/tests/redis_hash_test.rs
+++ b/src/storage/tests/redis_hash_test.rs
@@ -23,8 +23,35 @@ mod redis_hash_test {
 
     use kstd::lock_mgr::LockMgr;
     use storage::{
-        BgTaskHandler, Redis, StorageOptions, safe_cleanup_test_db, unique_test_db_path,
+        BaseMetaKey, BgTaskHandler, ColumnFamilyIndex, Redis, StorageOptions, safe_cleanup_test_db,
+        unique_test_db_path,
     };
+
+    #[test]
+    fn test_hash_commands_wrongtype_and_expired_wrongtype() {
+        let test_db_path = unique_test_db_path();
+        safe_cleanup_test_db(&test_db_path);
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+        redis.open(test_db_path.to_str().unwrap()).unwrap();
+
+        let live_wrongtype = b"hash_live_wrongtype";
+        redis.set(live_wrongtype, b"value").unwrap();
+        let err = redis.hlen(live_wrongtype).unwrap_err();
+        assert!(err.to_string().contains("WRONGTYPE"));
+
+        let expired_wrongtype = b"hash_expired_wrongtype";
+        redis.set(expired_wrongtype, b"value").unwrap();
+        assert!(redis.set_key_etime(expired_wrongtype, 1).unwrap());
+        assert_eq!(redis.hlen(expired_wrongtype).unwrap(), 0);
+
+        redis.set_need_close(true);
+        drop(redis);
+        safe_cleanup_test_db(&test_db_path);
+    }
 
     #[test]
     fn test_hset_hget_hexists_basic() {
@@ -94,6 +121,39 @@ mod redis_hash_test {
             retrieved_value.unwrap(),
             String::from_utf8_lossy(expected_val).to_string()
         );
+
+        redis.set_need_close(true);
+        drop(redis);
+
+        safe_cleanup_test_db(&test_db_path);
+    }
+
+    #[test]
+    fn test_hset_recovers_from_empty_meta_value() {
+        let test_db_path = unique_test_db_path();
+        safe_cleanup_test_db(&test_db_path);
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+
+        let result = redis.open(test_db_path.to_str().unwrap());
+        assert!(result.is_ok(), "open redis db failed: {:?}", result.err());
+
+        let key = b"empty_hash_meta";
+        let field = b"field1";
+        let value = b"value1";
+
+        {
+            let db = redis.db.as_ref().unwrap();
+            let cf = redis.get_cf_handle(ColumnFamilyIndex::MetaCF).unwrap();
+            let encoded_key = BaseMetaKey::new(key).encode().unwrap();
+            db.put_cf(&cf, &encoded_key, &[]).unwrap();
+        }
+
+        assert_eq!(redis.hset(key, field, value).unwrap(), 1);
+        assert_eq!(redis.hget(key, field).unwrap(), Some("value1".to_string()));
 
         redis.set_need_close(true);
         drop(redis);

--- a/src/storage/tests/redis_list_test.rs
+++ b/src/storage/tests/redis_list_test.rs
@@ -22,10 +22,11 @@
 #[cfg(test)]
 mod redis_list_test {
     use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use kstd::lock_mgr::LockMgr;
     use storage::{
-        BeforeOrAfter, BgTaskHandler, Redis, StorageOptions, safe_cleanup_test_db,
+        BeforeOrAfter, BgTaskHandler, DataType, Redis, StorageOptions, safe_cleanup_test_db,
         unique_test_db_path,
     };
 
@@ -42,7 +43,15 @@ mod redis_list_test {
         let result = redis.open(test_db_path.to_str().unwrap());
         assert!(result.is_ok(), "open redis db failed: {:?}", result.err());
 
+        redis.set_need_close(true);
         redis
+    }
+
+    fn current_micros() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_micros() as u64
     }
 
     #[tokio::test]
@@ -69,6 +78,68 @@ mod redis_list_test {
 
         let len = redis.llen(key).expect("llen should succeed");
         assert_eq!(len, 3);
+    }
+
+    #[tokio::test]
+    async fn test_list_wrongtype_returns_error() {
+        let redis = create_test_redis();
+        let key = b"wrongtype_list";
+
+        redis
+            .hset(key, b"field", b"value")
+            .expect("hset should succeed");
+
+        let len_result = redis.llen(key);
+        assert!(len_result.is_err(), "llen should fail on non-list key");
+        assert!(
+            len_result.unwrap_err().to_string().contains("WRONGTYPE"),
+            "llen should return WRONGTYPE"
+        );
+
+        let lpush_result = redis.lpush(key, &[b"value".to_vec()]);
+        assert!(lpush_result.is_err(), "lpush should fail on non-list key");
+        assert!(
+            lpush_result.unwrap_err().to_string().contains("WRONGTYPE"),
+            "lpush should return WRONGTYPE"
+        );
+
+        let lrange_result = redis.lrange(key, 0, -1);
+        assert!(lrange_result.is_err(), "lrange should fail on non-list key");
+        assert!(
+            lrange_result.unwrap_err().to_string().contains("WRONGTYPE"),
+            "lrange should return WRONGTYPE"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_expired_wrongtype_is_treated_as_missing() {
+        let redis = create_test_redis();
+        let key = b"expired_wrongtype_list";
+
+        redis
+            .hset(key, b"field", b"value")
+            .expect("hset should succeed");
+        assert!(redis.set_key_etime(key, current_micros() - 1).unwrap());
+
+        let len = redis
+            .lpush(key, &[b"value1".to_vec()])
+            .expect("lpush should succeed");
+        assert_eq!(len, 1);
+        assert_eq!(redis.get_key_type(key).unwrap(), DataType::List);
+    }
+
+    #[tokio::test]
+    async fn test_lrange_expired_wrongtype_returns_empty() {
+        let redis = create_test_redis();
+        let key = b"lrange_expired_wrongtype";
+
+        redis
+            .hset(key, b"field", b"value")
+            .expect("hset should succeed");
+        assert!(redis.set_key_etime(key, current_micros() - 1).unwrap());
+
+        let values = redis.lrange(key, 0, -1).expect("lrange should succeed");
+        assert!(values.is_empty());
     }
 
     #[tokio::test]

--- a/src/storage/tests/redis_set_test.rs
+++ b/src/storage/tests/redis_set_test.rs
@@ -20,12 +20,13 @@
 #[cfg(test)]
 mod redis_set_test {
     use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use bytes::BufMut;
     use kstd::lock_mgr::LockMgr;
     use storage::{
-        BaseMetaKey, BgTaskHandler, ColumnFamilyIndex, Redis, StorageOptions, safe_cleanup_test_db,
-        unique_test_db_path,
+        BaseMetaKey, BgTaskHandler, ColumnFamilyIndex, DataType, Redis, StorageOptions,
+        safe_cleanup_test_db, unique_test_db_path,
     };
 
     // Build a valid Set meta bytes:
@@ -44,6 +45,39 @@ mod redis_set_test {
         buf.put_u64_le(0);
         buf.put_u64_le(0);
         buf
+    }
+
+    fn current_micros() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_micros() as u64
+    }
+
+    #[test]
+    fn test_set_commands_wrongtype_and_expired_wrongtype() {
+        let test_db_path = unique_test_db_path();
+        safe_cleanup_test_db(&test_db_path);
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+        redis.open(test_db_path.to_str().unwrap()).unwrap();
+
+        let live_wrongtype = b"set_live_wrongtype";
+        redis.set(live_wrongtype, b"value").unwrap();
+        let err = redis.scard(live_wrongtype).unwrap_err();
+        assert!(err.to_string().contains("WRONGTYPE"));
+
+        let expired_wrongtype = b"set_expired_wrongtype";
+        redis.set(expired_wrongtype, b"value").unwrap();
+        assert!(redis.set_key_etime(expired_wrongtype, 1).unwrap());
+        assert!(redis.smembers(expired_wrongtype).unwrap().is_empty());
+
+        redis.set_need_close(true);
+        drop(redis);
+        safe_cleanup_test_db(&test_db_path);
     }
 
     #[test]
@@ -145,6 +179,34 @@ mod redis_set_test {
         // scard on missing key should error
         let scard_missing = redis.scard(b"missing_key");
         assert!(scard_missing.is_err());
+
+        redis.set_need_close(true);
+        drop(redis);
+
+        safe_cleanup_test_db(&test_db_path);
+    }
+
+    #[test]
+    fn test_sadd_on_expired_wrongtype_key_is_allowed() {
+        let test_db_path = unique_test_db_path();
+
+        safe_cleanup_test_db(&test_db_path);
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+
+        let result = redis.open(test_db_path.to_str().unwrap());
+        assert!(result.is_ok(), "open redis db failed: {:?}", result.err());
+
+        let key = b"expired_wrongtype_set";
+        redis.hset(key, b"field", b"value").unwrap();
+        assert!(redis.set_key_etime(key, current_micros() - 1).unwrap());
+
+        let added = redis.sadd(key, &[b"member1"]).expect("sadd should succeed");
+        assert_eq!(added, 1);
+        assert_eq!(redis.get_key_type(key).unwrap(), DataType::Set);
 
         redis.set_need_close(true);
         drop(redis);

--- a/src/storage/tests/redis_string_test.rs
+++ b/src/storage/tests/redis_string_test.rs
@@ -19,12 +19,19 @@
 
 #[cfg(test)]
 mod redis_string_test {
-    use std::{sync::Arc, thread, time::Duration};
+    use std::{path::Path, sync::Arc, thread, time::Duration};
 
     use kstd::lock_mgr::LockMgr;
     use storage::{
-        BgTaskHandler, Redis, StorageOptions, safe_cleanup_test_db, unique_test_db_path,
+        BgTaskHandler, DataType, Redis, StorageOptions, safe_cleanup_test_db, unique_test_db_path,
     };
+
+    fn cleanup_redis(redis: Redis, test_db_path: &Path) {
+        redis.set_need_close(true);
+        drop(redis);
+        thread::sleep(Duration::from_millis(10));
+        safe_cleanup_test_db(test_db_path);
+    }
 
     #[test]
     fn test_redis_set() {
@@ -62,10 +69,7 @@ mod redis_string_test {
             String::from_utf8_lossy(value).to_string()
         );
 
-        redis.set_need_close(true);
-        drop(redis);
-
-        safe_cleanup_test_db(&test_db_path);
+        cleanup_redis(redis, &test_db_path);
     }
 
     #[test]
@@ -98,10 +102,7 @@ mod redis_string_test {
             );
         }
 
-        redis.set_need_close(true);
-        drop(redis);
-
-        safe_cleanup_test_db(&test_db_path);
+        cleanup_redis(redis, &test_db_path);
     }
 
     #[test]
@@ -132,10 +133,7 @@ mod redis_string_test {
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "好".as_bytes());
 
-        redis.set_need_close(true);
-        drop(redis);
-
-        safe_cleanup_test_db(&test_db_path);
+        cleanup_redis(redis, &test_db_path);
     }
 
     #[test]
@@ -168,10 +166,7 @@ mod redis_string_test {
         let value = redis.get(key).unwrap();
         assert_eq!(value.as_bytes(), b"Hello Rust Programming");
 
-        redis.set_need_close(true);
-        drop(redis);
-
-        safe_cleanup_test_db(&test_db_path);
+        cleanup_redis(redis, &test_db_path);
     }
 
     #[test]
@@ -207,10 +202,7 @@ mod redis_string_test {
         // After replacing bytes 0-9 with "\x00\x00\x00\x00\x00Redis", bytes 10-14 ("World") remain
         assert_eq!(value.as_bytes(), b"\x00\x00\x00\x00\x00RedisWorld");
 
-        redis.set_need_close(true);
-        drop(redis);
-
-        safe_cleanup_test_db(&test_db_path);
+        cleanup_redis(redis, &test_db_path);
     }
 
     #[test]
@@ -260,10 +252,7 @@ mod redis_string_test {
             }
         }
 
-        redis.set_need_close(true);
-        drop(redis);
-
-        safe_cleanup_test_db(&test_db_path);
+        cleanup_redis(redis, &test_db_path);
     }
 
     #[test]
@@ -289,10 +278,7 @@ mod redis_string_test {
         let value = redis.get(key).unwrap();
         assert_eq!(value.as_bytes(), b"\x00\x00\x00Hi");
 
-        redis.set_need_close(true);
-        drop(redis);
-
-        safe_cleanup_test_db(&test_db_path);
+        cleanup_redis(redis, &test_db_path);
     }
 
     #[test]
@@ -321,10 +307,7 @@ mod redis_string_test {
         let result = redis.setrange(key, 0, b"test");
         assert!(result.is_err(), "setrange should fail for non-string type");
 
-        redis.set_need_close(true);
-        drop(redis);
-
-        safe_cleanup_test_db(&test_db_path);
+        cleanup_redis(redis, &test_db_path);
     }
 
     #[test]
@@ -352,10 +335,7 @@ mod redis_string_test {
         let value = redis.get(key).unwrap();
         assert_eq!(value.as_bytes(), b"Hel\x00\x00\x00World");
 
-        redis.set_need_close(true);
-        drop(redis);
-
-        safe_cleanup_test_db(&test_db_path);
+        cleanup_redis(redis, &test_db_path);
     }
 
     #[test]
@@ -412,10 +392,7 @@ mod redis_string_test {
             "Key should be expired and return error"
         );
 
-        redis.set_need_close(true);
-        drop(redis);
-
-        safe_cleanup_test_db(&test_db_path);
+        cleanup_redis(redis, &test_db_path);
     }
 
     #[test]
@@ -472,10 +449,7 @@ mod redis_string_test {
             "Key should be expired and return error"
         );
 
-        redis.set_need_close(true);
-        drop(redis);
-
-        safe_cleanup_test_db(&test_db_path);
+        cleanup_redis(redis, &test_db_path);
     }
 
     #[test]
@@ -523,10 +497,10 @@ mod redis_string_test {
         }
 
         if let Ok(redis) = Arc::try_unwrap(redis_arc) {
-            redis.set_need_close(true);
+            cleanup_redis(redis, &test_db_path);
+        } else {
+            safe_cleanup_test_db(&test_db_path);
         }
-
-        safe_cleanup_test_db(&test_db_path);
     }
 
     #[test]
@@ -575,10 +549,7 @@ mod redis_string_test {
         let result = redis.getbit(key, i64::MAX);
         assert!(result.is_err(), "getbit should fail with very large offset");
 
-        redis.set_need_close(true);
-        drop(redis);
-
-        safe_cleanup_test_db(&test_db_path);
+        cleanup_redis(redis, &test_db_path);
     }
 
     #[test]
@@ -615,10 +586,7 @@ mod redis_string_test {
             "original bit value should be 0 for expired key"
         );
 
-        redis.set_need_close(true);
-        drop(redis);
-
-        safe_cleanup_test_db(&test_db_path);
+        cleanup_redis(redis, &test_db_path);
     }
 
     #[test]
@@ -685,10 +653,7 @@ mod redis_string_test {
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 0, "bitcount should be 0 for empty string");
 
-        redis.set_need_close(true);
-        drop(redis);
-
-        safe_cleanup_test_db(&test_db_path);
+        cleanup_redis(redis, &test_db_path);
     }
 
     #[test]
@@ -718,10 +683,7 @@ mod redis_string_test {
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 14, "bitcount should be 14 for \"llo\"");
 
-        redis.set_need_close(true);
-        drop(redis);
-
-        safe_cleanup_test_db(&test_db_path);
+        cleanup_redis(redis, &test_db_path);
     }
 
     #[test]
@@ -757,10 +719,7 @@ mod redis_string_test {
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 17, "bitcount should be 17 for \"test\"");
 
-        redis.set_need_close(true);
-        drop(redis);
-
-        safe_cleanup_test_db(&test_db_path);
+        cleanup_redis(redis, &test_db_path);
     }
 
     #[test]
@@ -788,9 +747,113 @@ mod redis_string_test {
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 0, "bitcount should be 0 for expired key");
 
-        redis.set_need_close(true);
-        drop(redis);
+        cleanup_redis(redis, &test_db_path);
+    }
+
+    #[test]
+    fn test_redis_strlen_and_getrange_wrongtype() {
+        let test_db_path = unique_test_db_path();
 
         safe_cleanup_test_db(&test_db_path);
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+
+        let result = redis.open(test_db_path.to_str().unwrap());
+        assert!(result.is_ok(), "open redis db failed: {:?}", result.err());
+
+        let key = b"wrongtype_string_meta";
+        redis.hset(key, b"field", b"value").unwrap();
+
+        let get_result = redis.get(key);
+        assert!(get_result.is_err(), "get should fail on non-string key");
+        assert!(
+            get_result.unwrap_err().to_string().contains("WRONGTYPE"),
+            "get should return WRONGTYPE"
+        );
+
+        let mget_result = redis.mget(&[key.to_vec()]).unwrap();
+        assert_eq!(mget_result, vec![None]);
+
+        let strlen_result = redis.strlen(key);
+        assert!(
+            strlen_result.is_err(),
+            "strlen should fail on non-string key"
+        );
+        assert!(
+            strlen_result.unwrap_err().to_string().contains("WRONGTYPE"),
+            "strlen should return WRONGTYPE"
+        );
+
+        let getrange_result = redis.getrange(key, 0, 2);
+        assert!(
+            getrange_result.is_err(),
+            "getrange should fail on non-string key"
+        );
+        assert!(
+            getrange_result
+                .unwrap_err()
+                .to_string()
+                .contains("WRONGTYPE"),
+            "getrange should return WRONGTYPE"
+        );
+
+        cleanup_redis(redis, &test_db_path);
+    }
+
+    #[test]
+    fn test_getbit_wrongtype_and_expired_wrongtype() {
+        let test_db_path = unique_test_db_path();
+        safe_cleanup_test_db(&test_db_path);
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+        redis.open(test_db_path.to_str().unwrap()).unwrap();
+
+        let live_wrongtype = b"getbit_live_wrongtype";
+        redis.hset(live_wrongtype, b"field", b"value").unwrap();
+        let err = redis.getbit(live_wrongtype, 0).unwrap_err();
+        assert!(err.to_string().contains("WRONGTYPE"));
+
+        let expired_wrongtype = b"getbit_expired_wrongtype";
+        redis.hset(expired_wrongtype, b"field", b"value").unwrap();
+        assert!(redis.set_key_etime(expired_wrongtype, 1).unwrap());
+        assert_eq!(redis.getbit(expired_wrongtype, 0).unwrap(), 0);
+
+        cleanup_redis(redis, &test_db_path);
+    }
+
+    #[test]
+    fn test_setnx_and_msetnx_keep_live_any_type_existence_semantics() {
+        let test_db_path = unique_test_db_path();
+        safe_cleanup_test_db(&test_db_path);
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+        redis.open(test_db_path.to_str().unwrap()).unwrap();
+
+        let key = b"setnx_existing_hash";
+        redis.hset(key, b"field", b"value").unwrap();
+
+        assert_eq!(redis.setnx(key, b"new").unwrap(), 0);
+        assert!(!redis.msetnx(&[(key.to_vec(), b"new".to_vec())]).unwrap());
+        let getset_result = redis.getset(key, b"other_value");
+        assert!(
+            getset_result.is_err(),
+            "GETSET should reject non-string keys"
+        );
+        assert!(
+            getset_result.unwrap_err().to_string().contains("WRONGTYPE"),
+            "GETSET should return WRONGTYPE"
+        );
+        assert_eq!(redis.get_key_type(key).unwrap(), DataType::Hash);
+
+        cleanup_redis(redis, &test_db_path);
     }
 }

--- a/src/storage/tests/redis_zset_test.rs
+++ b/src/storage/tests/redis_zset_test.rs
@@ -39,6 +39,7 @@ mod redis_zset_test {
         let result = redis.open(test_db_path.to_str().unwrap());
         assert!(result.is_ok(), "open redis db failed: {:?}", result.err());
 
+        redis.set_need_close(true);
         redis
     }
 
@@ -193,6 +194,25 @@ mod redis_zset_test {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0], ("alpha".to_string(), "1".to_string()));
         assert_eq!(results[1], ("beta".to_string(), "2".to_string()));
+    }
+
+    #[test]
+    fn test_zset_commands_wrongtype_and_expired_wrongtype() {
+        let redis = create_test_redis();
+
+        let live_wrongtype = b"zset_live_wrongtype";
+        redis.set(live_wrongtype, b"value").unwrap();
+        let mut card = 0;
+        let err = redis.zcard(live_wrongtype, &mut card).unwrap_err();
+        assert!(err.to_string().contains("WRONGTYPE"));
+
+        let expired_wrongtype = b"zset_expired_wrongtype";
+        redis.set(expired_wrongtype, b"value").unwrap();
+        assert!(redis.set_key_etime(expired_wrongtype, 1).unwrap());
+
+        let mut expired_card = -1;
+        redis.zcard(expired_wrongtype, &mut expired_card).unwrap();
+        assert_eq!(expired_card, 0);
     }
 
     #[test]
@@ -1312,6 +1332,39 @@ mod redis_zset_test {
         assert!(score.is_none());
 
         // New member should exist
+        let mut score = None;
+        redis.zscore(dest, b"a", &mut score).unwrap();
+        assert_eq!(String::from_utf8(score.unwrap()).unwrap(), "3");
+    }
+
+    #[test]
+    fn test_zinterstore_overwrites_wrongtype_destination() {
+        let redis = create_test_redis();
+
+        let key1 = b"zset1";
+        let key2 = b"zset2";
+        let dest = b"dest";
+
+        // Destination holds a non-ZSet value
+        redis.set(dest, b"string-value").unwrap();
+
+        // Create source sets
+        let score_members1 = vec![ScoreMember::new(1.0, b"a".to_vec())];
+        let score_members2 = vec![ScoreMember::new(2.0, b"a".to_vec())];
+
+        let mut ret = 0;
+        redis.zadd(key1, &score_members1, &mut ret).unwrap();
+        redis.zadd(key2, &score_members2, &mut ret).unwrap();
+
+        // Compute intersection (should overwrite dest regardless of its type)
+        let keys = vec![key1.to_vec(), key2.to_vec()];
+        let mut count = 0;
+        redis
+            .zinterstore(dest, &keys, &[], "SUM", &mut count)
+            .unwrap();
+
+        assert_eq!(count, 1);
+
         let mut score = None;
         redis.zscore(dest, b"a", &mut score).unwrap();
         assert_eq!(String::from_utf8(score.unwrap()).unwrap(), "3");


### PR DESCRIPTION
## 改动内容

- 新增 `TypeCheckState` 和 `check_type_state`，作为统一的 raw value 类型/状态判断入口
- 将 String、Hash、Set、List、ZSet 的命令路径迁移到基于 raw value 的状态判断，去掉重复的 post-read `get_key_type` 检查
- 保留各命令原有的 missing/stale 返回语义，同时把 live `WRONGTYPE` 统一收口
- 补充代表性的回归测试，覆盖 live wrong-type、expired wrong-type 和 empty-meta 恢复场景
- 对 storage crate 做最终一致性清理和验证

## 变更原因

storage 里的 Redis 类型检查已经分裂成两种模式：

- 对已经读出的 raw value 直接判断
- 命令明明已经读到了 top-level value，却又通过 `get_key_type(key)` 再读一次元数据

这种重复让不同命令族在过期判断和类型判断的顺序上变得不一致，也让 string 路径产生了额外读取。这个分支把决策点统一到一个 raw-value state helper 上，同时保留每个命令自己原有的 missing/stale 返回形态。

## 影响

- 去掉已迁移命令路径里的冗余类型查询
- 让 missing / stale / live wrong-type 的处理在各命令族里更明确
- 将 `get_key_type` 限定在真正的 key-only 路径上，例如 `TYPE` 和 `key_exists_live`

## 验证

- `make fmt`
- `make lint`
- `make build`
- `make test`

## 说明

- 本次变更在 storage 类型检查路径上补了更细的针对性验证，但 PR 里统一以仓库标准验证命令为准。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis command behavior for stale/expired keys across hashes, lists, sets, strings, and sorted sets—treating them more like missing data and returning Redis-compatible empty/zero results instead of wrong-type errors.
  * Centralized type-state handling so `WRONGTYPE` is applied consistently only to live mismatched values.
  * Refined `SETNX`/`MSETNX` semantics to rely on type-agnostic key existence.
* **Tests**
  * Added coverage for missing vs stale vs match behavior and additional `WRONGTYPE`/expired-wrongtype cases across data types.
  * Increased test reliability by configuring Rust test parallelism and raising the open-file limit during `cargo test`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->