### PR TITLE
feat(cmd,resp,net): add HELLO command with RESP version negotiation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -897,7 +897,7 @@ dependencies = [
  "mea",
  "parking_lot",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.4",
  "tracing",
  "twox-hash",
  "zstd",
@@ -1960,7 +1960,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -2139,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3087,7 +3087,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -139,9 +139,16 @@ impl Client {
     /// Handle a RESP HELLO command using the persisted protocol negotiation
     /// state for this connection, so the negotiated RESP version survives across
     /// multiple commands.
-    pub fn handle_hello(&self, command: &RespCommand) -> RespResult<RespData> {
+    ///
+    /// `authenticate` is called with the password supplied via the AUTH clause
+    /// and must report whether the client should be authenticated, rejected for
+    /// a wrong password, or rejected because no password is configured.
+    pub fn handle_hello<F>(&self, command: &RespCommand, authenticate: F) -> RespResult<RespData>
+    where
+        F: FnMut(&[u8]) -> resp::HelloAuthResult,
+    {
         let mut ctx = self.ctx.lock();
-        ctx.protocol_negotiator.handle_hello(command)
+        ctx.protocol_negotiator.handle_hello(command, authenticate)
     }
 
     /// Return the currently negotiated RESP version for this connection.

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -140,15 +140,46 @@ impl Client {
     /// state for this connection, so the negotiated RESP version survives across
     /// multiple commands.
     ///
+    /// `already_authenticated` reflects whether the connection is already
+    /// authenticated. `authentication_required` reflects whether the server has
+    /// a requirepass password configured. When authentication is required and
+    /// the client is not already authenticated, the HELLO ... AUTH clause must
+    /// be used to authenticate and receive the handshake.
+    ///
     /// `authenticate` is called with the password supplied via the AUTH clause
     /// and must report whether the client should be authenticated, rejected for
     /// a wrong password, or rejected because no password is configured.
-    pub fn handle_hello<F>(&self, command: &RespCommand, authenticate: F) -> RespResult<RespData>
+    pub fn handle_hello<F>(
+        &self,
+        command: &RespCommand,
+        already_authenticated: bool,
+        authentication_required: bool,
+        authenticate: F,
+    ) -> RespResult<RespData>
     where
         F: FnMut(&[u8]) -> resp::HelloAuthResult,
     {
-        let mut ctx = self.ctx.lock();
-        ctx.protocol_negotiator.handle_hello(command, authenticate)
+        let result;
+        let client_name;
+        {
+            let mut ctx = self.ctx.lock();
+            result = ctx.protocol_negotiator.handle_hello(
+                command,
+                already_authenticated,
+                authentication_required,
+                authenticate,
+            );
+            client_name = result.as_ref().ok().and_then(|_| {
+                ctx.protocol_negotiator
+                    .client_capabilities()
+                    .get("client_name")
+                    .cloned()
+            });
+        }
+        if let Some(name) = client_name {
+            self.set_name(name.as_bytes());
+        }
+        result
     }
 
     /// Return the currently negotiated RESP version for this connection.

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use resp::RespData;
+use resp::{ProtocolNegotiator, RespCommand, RespData, RespResult};
 use tokio::sync::Mutex;
 
 #[async_trait]
@@ -44,6 +44,8 @@ struct ClientContext {
     key: Vec<u8>,
     reply: RespData,
     authenticated: bool,
+    /// Persisted RESP protocol negotiation state for this connection.
+    protocol_negotiator: ProtocolNegotiator,
 }
 
 impl Client {
@@ -59,6 +61,7 @@ impl Client {
                 // Default to false (fail-closed): callers must explicitly grant
                 // authentication when no `requirepass` is configured.
                 authenticated: false,
+                protocol_negotiator: ProtocolNegotiator::new(),
             }),
         }
     }
@@ -131,5 +134,19 @@ impl Client {
     pub fn set_authenticated(&self, val: bool) {
         let mut ctx = self.ctx.lock();
         ctx.authenticated = val;
+    }
+
+    /// Handle a RESP HELLO command using the persisted protocol negotiation
+    /// state for this connection, so the negotiated RESP version survives across
+    /// multiple commands.
+    pub fn handle_hello(&self, command: &RespCommand) -> RespResult<RespData> {
+        let mut ctx = self.ctx.lock();
+        ctx.protocol_negotiator.handle_hello(command)
+    }
+
+    /// Return the currently negotiated RESP version for this connection.
+    pub fn resp_version(&self) -> resp::RespVersion {
+        let ctx = self.ctx.lock();
+        ctx.protocol_negotiator.current_version()
     }
 }

--- a/src/cmd/src/hello.rs
+++ b/src/cmd/src/hello.rs
@@ -19,11 +19,10 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use client::Client;
-use resp::{CommandType, ProtocolNegotiator, RespCommand, RespData};
+use resp::{CommandType, RespCommand, RespData};
 use storage::storage::Storage;
 
-use crate::{AclCategory, Cmd, CmdFlags, CmdMeta};
-use crate::{impl_cmd_clone_box, impl_cmd_meta};
+use crate::{AclCategory, Cmd, CmdFlags, CmdMeta, impl_cmd_clone_box, impl_cmd_meta};
 
 #[derive(Clone, Default)]
 pub struct HelloCmd {
@@ -59,9 +58,8 @@ impl Cmd for HelloCmd {
             args: argv.into_iter().skip(1).map(Bytes::from).collect(),
             is_pipeline: false,
         };
-        let mut negotiator = ProtocolNegotiator::new();
 
-        match negotiator.handle_hello(&command) {
+        match client.handle_hello(&command) {
             Ok(response) => client.set_reply(response),
             Err(err) => client.set_reply(RespData::Error(format!("ERR {err}").into())),
         }

--- a/src/cmd/src/hello.rs
+++ b/src/cmd/src/hello.rs
@@ -19,12 +19,13 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use client::Client;
-use resp::{CommandType, HelloAuthResult, RespCommand, RespData};
+use resp::{CommandType, HelloAuthResult, RespCommand, RespData, RespError};
 use storage::storage::Storage;
 use subtle::ConstantTimeEq;
 
-use crate::auth::RequirepassProvider;
-use crate::{AclCategory, Cmd, CmdFlags, CmdMeta, impl_cmd_clone_box, impl_cmd_meta};
+use crate::{
+    AclCategory, Cmd, CmdFlags, CmdMeta, RequirepassProvider, impl_cmd_clone_box, impl_cmd_meta,
+};
 
 #[derive(Clone)]
 pub struct HelloCmd {
@@ -78,25 +79,46 @@ impl Cmd for HelloCmd {
             is_pipeline: false,
         };
 
+        let mut auth_attempted = false;
         let provider = Arc::clone(&self.requirepass_provider);
-        let authenticate = |password: &[u8]| match provider() {
-            Some(requirepass) => {
-                let matches: bool = password.ct_eq(requirepass.as_bytes()).into();
-                if matches {
-                    HelloAuthResult::Authenticated
-                } else {
-                    HelloAuthResult::WrongPassword
+        let mut authenticate = |password: &[u8]| -> HelloAuthResult {
+            auth_attempted = true;
+            match provider() {
+                Some(requirepass) => {
+                    let matches: bool = password.ct_eq(requirepass.as_bytes()).into();
+                    if matches {
+                        HelloAuthResult::Authenticated
+                    } else {
+                        HelloAuthResult::WrongPassword
+                    }
                 }
+                None => HelloAuthResult::NoPasswordConfigured,
             }
-            None => HelloAuthResult::NoPasswordConfigured,
         };
 
-        match client.handle_hello(&command, authenticate) {
+        match client.handle_hello(&command, &mut authenticate) {
             Ok(response) => {
-                client.set_authenticated(true);
+                // Only mark the client as authenticated when the HELLO command
+                // included an AUTH clause that succeeded. A bare HELLO must not
+                // bypass the requirepass check.
+                if auth_attempted {
+                    client.set_authenticated(true);
+                }
                 client.set_reply(response);
             }
-            Err(err) => client.set_reply(RespData::Error(err.to_string().into())),
+            Err(err) => client.set_reply(RespData::Error(format_hello_error(err).into())),
         }
     }
+}
+
+/// Format a RESP error from HELLO negotiation for the client.
+///
+/// `RespError::InvalidData` is used to carry the raw Redis error message, so
+/// strip the Display prefix and any leading `-` that the encoder will add.
+fn format_hello_error(err: RespError) -> String {
+    let raw = match err {
+        RespError::InvalidData(msg) => msg,
+        other => other.to_string(),
+    };
+    raw.trim_start_matches('-').to_string()
 }

--- a/src/cmd/src/hello.rs
+++ b/src/cmd/src/hello.rs
@@ -19,18 +19,21 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use client::Client;
-use resp::{CommandType, RespCommand, RespData};
+use resp::{CommandType, HelloAuthResult, RespCommand, RespData};
 use storage::storage::Storage;
+use subtle::ConstantTimeEq;
 
+use crate::auth::RequirepassProvider;
 use crate::{AclCategory, Cmd, CmdFlags, CmdMeta, impl_cmd_clone_box, impl_cmd_meta};
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct HelloCmd {
     meta: CmdMeta,
+    requirepass_provider: RequirepassProvider,
 }
 
-impl HelloCmd {
-    pub fn new() -> Self {
+impl Default for HelloCmd {
+    fn default() -> Self {
         Self {
             meta: CmdMeta {
                 name: "hello".to_string(),
@@ -39,6 +42,22 @@ impl HelloCmd {
                 acl_category: AclCategory::CONNECTION | AclCategory::FAST,
                 ..Default::default()
             },
+            requirepass_provider: Arc::new(|| None),
+        }
+    }
+}
+
+impl HelloCmd {
+    pub fn new(provider: RequirepassProvider) -> Self {
+        Self {
+            meta: CmdMeta {
+                name: "hello".to_string(),
+                arity: -1,
+                flags: CmdFlags::NO_AUTH | CmdFlags::FAST,
+                acl_category: AclCategory::CONNECTION | AclCategory::FAST,
+                ..Default::default()
+            },
+            requirepass_provider: provider,
         }
     }
 }
@@ -59,9 +78,25 @@ impl Cmd for HelloCmd {
             is_pipeline: false,
         };
 
-        match client.handle_hello(&command) {
-            Ok(response) => client.set_reply(response),
-            Err(err) => client.set_reply(RespData::Error(format!("ERR {err}").into())),
+        let provider = Arc::clone(&self.requirepass_provider);
+        let authenticate = |password: &[u8]| match provider() {
+            Some(requirepass) => {
+                let matches: bool = password.ct_eq(requirepass.as_bytes()).into();
+                if matches {
+                    HelloAuthResult::Authenticated
+                } else {
+                    HelloAuthResult::WrongPassword
+                }
+            }
+            None => HelloAuthResult::NoPasswordConfigured,
+        };
+
+        match client.handle_hello(&command, authenticate) {
+            Ok(response) => {
+                client.set_authenticated(true);
+                client.set_reply(response);
+            }
+            Err(err) => client.set_reply(RespData::Error(err.to_string().into())),
         }
     }
 }

--- a/src/cmd/src/hello.rs
+++ b/src/cmd/src/hello.rs
@@ -79,10 +79,9 @@ impl Cmd for HelloCmd {
             is_pipeline: false,
         };
 
-        let mut auth_attempted = false;
         let provider = Arc::clone(&self.requirepass_provider);
+        let authentication_required = provider().is_some();
         let mut authenticate = |password: &[u8]| -> HelloAuthResult {
-            auth_attempted = true;
             match provider() {
                 Some(requirepass) => {
                     let matches: bool = password.ct_eq(requirepass.as_bytes()).into();
@@ -96,14 +95,17 @@ impl Cmd for HelloCmd {
             }
         };
 
-        match client.handle_hello(&command, &mut authenticate) {
+        match client.handle_hello(
+            &command,
+            client.is_authenticated(),
+            authentication_required,
+            &mut authenticate,
+        ) {
             Ok(response) => {
-                // Only mark the client as authenticated when the HELLO command
-                // included an AUTH clause that succeeded. A bare HELLO must not
-                // bypass the requirepass check.
-                if auth_attempted {
-                    client.set_authenticated(true);
-                }
+                // handle_hello only succeeds when the client is already
+                // authenticated or the HELLO included an AUTH clause that
+                // succeeded. In both cases the connection is authenticated.
+                client.set_authenticated(true);
                 client.set_reply(response);
             }
             Err(err) => client.set_reply(RespData::Error(format_hello_error(err).into())),

--- a/src/cmd/src/hello.rs
+++ b/src/cmd/src/hello.rs
@@ -1,0 +1,69 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use client::Client;
+use resp::{CommandType, ProtocolNegotiator, RespCommand, RespData};
+use storage::storage::Storage;
+
+use crate::{AclCategory, Cmd, CmdFlags, CmdMeta};
+use crate::{impl_cmd_clone_box, impl_cmd_meta};
+
+#[derive(Clone, Default)]
+pub struct HelloCmd {
+    meta: CmdMeta,
+}
+
+impl HelloCmd {
+    pub fn new() -> Self {
+        Self {
+            meta: CmdMeta {
+                name: "hello".to_string(),
+                arity: -1,
+                flags: CmdFlags::NO_AUTH | CmdFlags::FAST,
+                acl_category: AclCategory::CONNECTION | AclCategory::FAST,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl Cmd for HelloCmd {
+    impl_cmd_meta!();
+    impl_cmd_clone_box!();
+
+    fn do_initial(&self, _client: &Client) -> bool {
+        true
+    }
+
+    fn do_cmd(&self, client: &Client, _storage: Arc<Storage>) {
+        let argv = client.argv();
+        let command = RespCommand {
+            command_type: CommandType::Hello,
+            args: argv.into_iter().skip(1).map(Bytes::from).collect(),
+            is_pipeline: false,
+        };
+        let mut negotiator = ProtocolNegotiator::new();
+
+        match negotiator.handle_hello(&command) {
+            Ok(response) => client.set_reply(response),
+            Err(err) => client.set_reply(RespData::Error(format!("ERR {err}").into())),
+        }
+    }
+}

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -35,6 +35,7 @@ pub mod getrange;
 pub mod getset;
 pub mod group_client;
 pub mod hdel;
+pub mod hello;
 pub mod hexists;
 pub mod hget;
 pub mod hgetall;

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -119,6 +119,8 @@ use log::debug;
 use resp::RespData;
 use storage::storage::Storage;
 
+pub use auth::RequirepassProvider;
+
 bitflags! {
     #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct CmdFlags: u32 {

--- a/src/cmd/src/table.rs
+++ b/src/cmd/src/table.rs
@@ -166,6 +166,7 @@ pub fn create_command_table(requirepass_provider: RequirepassProvider) -> CmdTab
         crate::zscore::ZscoreCmd,
         crate::zunionstore::ZunionstoreCmd,
         // connection commands
+        crate::hello::HelloCmd,
         crate::ping::PingCmd,
     );
 
@@ -183,4 +184,70 @@ pub fn create_command_table(requirepass_provider: RequirepassProvider) -> CmdTab
     );
 
     cmd_table
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use client::{Client, StreamTrait};
+    use resp::RespData;
+    use storage::storage::Storage;
+
+    use super::create_command_table;
+
+    struct TestStream;
+
+    #[async_trait::async_trait]
+    impl StreamTrait for TestStream {
+        async fn read(&mut self, _buf: &mut [u8]) -> Result<usize, std::io::Error> {
+            Ok(0)
+        }
+
+        async fn write(&mut self, _data: &[u8]) -> Result<usize, std::io::Error> {
+            Ok(0)
+        }
+    }
+
+    #[test]
+    fn hello_command_returns_resp3_handshake() {
+        let table = create_command_table(Arc::new(|| None));
+        let command = table.get("hello").expect("HELLO should be registered");
+        let client = Client::new(Box::new(TestStream));
+        client.set_cmd_name(b"hello");
+        client.set_argv(&[b"hello".to_vec(), b"3".to_vec()]);
+
+        command.execute(&client, Arc::new(Storage::new(1, 0)));
+
+        assert_eq!(
+            client.take_reply(),
+            RespData::Map(vec![
+                (
+                    RespData::BulkString(Some(Bytes::from("server"))),
+                    RespData::BulkString(Some(Bytes::from("kiwi"))),
+                ),
+                (
+                    RespData::BulkString(Some(Bytes::from("version"))),
+                    RespData::BulkString(Some(Bytes::from("1.0.0"))),
+                ),
+                (
+                    RespData::BulkString(Some(Bytes::from("proto"))),
+                    RespData::Integer(3),
+                ),
+                (
+                    RespData::BulkString(Some(Bytes::from("id"))),
+                    RespData::Integer(1),
+                ),
+                (
+                    RespData::BulkString(Some(Bytes::from("mode"))),
+                    RespData::BulkString(Some(Bytes::from("standalone"))),
+                ),
+                (
+                    RespData::BulkString(Some(Bytes::from("role"))),
+                    RespData::BulkString(Some(Bytes::from("master"))),
+                ),
+            ])
+        );
+    }
 }

--- a/src/cmd/src/table.rs
+++ b/src/cmd/src/table.rs
@@ -166,15 +166,18 @@ pub fn create_command_table(requirepass_provider: RequirepassProvider) -> CmdTab
         crate::zscore::ZscoreCmd,
         crate::zunionstore::ZunionstoreCmd,
         // connection commands
-        crate::hello::HelloCmd,
         crate::ping::PingCmd,
     );
 
-    // AuthCmd with requirepass provider
+    // AuthCmd and HelloCmd require the requirepass provider for authentication.
     {
-        let auth_cmd = crate::auth::AuthCmd::new(requirepass_provider);
+        let auth_cmd = crate::auth::AuthCmd::new(Arc::clone(&requirepass_provider));
         let cmd_name = auth_cmd.meta().name.clone();
         cmd_table.insert(cmd_name, Arc::new(auth_cmd));
+    }
+    {
+        let hello_cmd = crate::hello::HelloCmd::new(requirepass_provider);
+        cmd_table.insert(hello_cmd.meta().name.clone(), Arc::new(hello_cmd));
     }
 
     register_group_cmd!(
@@ -248,6 +251,81 @@ mod tests {
                     RespData::BulkString(Some(Bytes::from("master"))),
                 ),
             ])
+        );
+    }
+
+    #[test]
+    fn hello_auth_with_correct_password_authenticates() {
+        let table = create_command_table(Arc::new(|| Some("secret".to_string())));
+        let command = table.get("hello").expect("HELLO should be registered");
+        let client = Client::new(Box::new(TestStream));
+        client.set_cmd_name(b"hello");
+        client.set_argv(&[
+            b"hello".to_vec(),
+            b"3".to_vec(),
+            b"AUTH".to_vec(),
+            b"default".to_vec(),
+            b"secret".to_vec(),
+        ]);
+
+        command.execute(&client, Arc::new(Storage::new(1, 0)));
+
+        assert!(client.is_authenticated());
+        let reply = client.take_reply();
+        assert!(
+            matches!(reply, RespData::Map(_)),
+            "expected HELLO handshake map, got {:?}",
+            reply
+        );
+    }
+
+    #[test]
+    fn hello_auth_with_wrong_password_returns_wrongpass() {
+        let table = create_command_table(Arc::new(|| Some("secret".to_string())));
+        let command = table.get("hello").expect("HELLO should be registered");
+        let client = Client::new(Box::new(TestStream));
+        client.set_cmd_name(b"hello");
+        client.set_argv(&[
+            b"hello".to_vec(),
+            b"3".to_vec(),
+            b"AUTH".to_vec(),
+            b"default".to_vec(),
+            b"wrong".to_vec(),
+        ]);
+
+        command.execute(&client, Arc::new(Storage::new(1, 0)));
+
+        assert!(!client.is_authenticated());
+        let reply = client.take_reply();
+        assert!(
+            matches!(reply, RespData::Error(ref e) if String::from_utf8_lossy(e).contains("WRONGPASS")),
+            "expected WRONGPASS error, got {:?}",
+            reply
+        );
+    }
+
+    #[test]
+    fn hello_auth_without_requirepass_returns_error() {
+        let table = create_command_table(Arc::new(|| None));
+        let command = table.get("hello").expect("HELLO should be registered");
+        let client = Client::new(Box::new(TestStream));
+        client.set_cmd_name(b"hello");
+        client.set_argv(&[
+            b"hello".to_vec(),
+            b"3".to_vec(),
+            b"AUTH".to_vec(),
+            b"default".to_vec(),
+            b"anything".to_vec(),
+        ]);
+
+        command.execute(&client, Arc::new(Storage::new(1, 0)));
+
+        assert!(!client.is_authenticated());
+        let reply = client.take_reply();
+        assert!(
+            matches!(reply, RespData::Error(ref e) if String::from_utf8_lossy(e).contains("HELLO AUTH called without")),
+            "expected no-password-configured error, got {:?}",
+            reply
         );
     }
 }

--- a/src/cmd/src/table.rs
+++ b/src/cmd/src/table.rs
@@ -250,7 +250,52 @@ mod tests {
                     RespData::BulkString(Some(Bytes::from("role"))),
                     RespData::BulkString(Some(Bytes::from("master"))),
                 ),
+                (
+                    RespData::BulkString(Some(Bytes::from("modules"))),
+                    RespData::Array(Some(vec![])),
+                ),
             ])
+        );
+    }
+
+    #[test]
+    fn hello_bare_with_requirepass_returns_noauth() {
+        let table = create_command_table(Arc::new(|| Some("secret".to_string())));
+        let command = table.get("hello").expect("HELLO should be registered");
+        let client = Client::new(Box::new(TestStream));
+        client.set_cmd_name(b"hello");
+        client.set_argv(&[b"hello".to_vec(), b"3".to_vec()]);
+
+        command.execute(&client, Arc::new(Storage::new(1, 0)));
+
+        assert!(!client.is_authenticated());
+        let reply = client.take_reply();
+        assert!(
+            matches!(reply, RespData::Error(ref e) if String::from_utf8_lossy(e).contains("NOAUTH")),
+            "expected NOAUTH error, got {:?}",
+            reply
+        );
+    }
+
+    #[test]
+    fn hello_setname_sets_client_name() {
+        let table = create_command_table(Arc::new(|| None));
+        let command = table.get("hello").expect("HELLO should be registered");
+        let client = Client::new(Box::new(TestStream));
+        client.set_cmd_name(b"hello");
+        client.set_argv(&[
+            b"hello".to_vec(),
+            b"2".to_vec(),
+            b"SETNAME".to_vec(),
+            b"my-client".to_vec(),
+        ]);
+
+        command.execute(&client, Arc::new(Storage::new(1, 0)));
+
+        assert_eq!(
+            client.name().as_ref(),
+            b"my-client",
+            "expected SETNAME to set the client name"
         );
     }
 

--- a/src/net/src/executor_ext.rs
+++ b/src/net/src/executor_ext.rs
@@ -85,7 +85,7 @@ impl CmdExecutorNetworkExt for CmdExecutor {
             // Route connection-local commands locally and send all other
             // storage-backed commands through the generic Execute path.
             match cmd_name.as_str() {
-                "ping" | "auth" | "client" => {
+                "ping" | "auth" | "client" | "hello" => {
                     execute_local_command(&exec).await?;
                 }
                 _ => {

--- a/src/net/src/handle.rs
+++ b/src/net/src/handle.rs
@@ -24,7 +24,7 @@ use cmd::table::CmdTable;
 use executor::{CmdExecution, CmdExecutor};
 use log::error;
 use resp::encode::RespEncoder;
-use resp::{Parse, RespData, RespEncode, RespParseResult, RespVersion};
+use resp::{Parse, RespData, RespEncode, RespParseResult};
 use storage::storage::Storage;
 use tokio::select;
 
@@ -37,7 +37,7 @@ pub async fn process_connection(
     executor: Arc<CmdExecutor>,
 ) -> std::io::Result<()> {
     let mut buf = vec![0; 1024];
-    let mut resp_parser = resp::RespParse::new(resp::RespVersion::RESP2);
+    let mut resp_parser = resp::RespParse::new(client.resp_version());
 
     loop {
         select! {
@@ -59,7 +59,7 @@ pub async fn process_connection(
                                     handle_command(client.clone(), storage.clone(), cmd_table.clone(), executor.clone()).await;
                                     // Extract the reply from the connection and send it
                                     let response = client.take_reply();
-                                    let mut encoder = RespEncoder::new(RespVersion::RESP2);
+                                    let mut encoder = RespEncoder::new(client.resp_version());
                                     encoder.encode_resp_data(&response);
                                     match client.write(encoder.get_response().as_ref()).await {
                                         Ok(_) => (),

--- a/src/net/src/network_handle.rs
+++ b/src/net/src/network_handle.rs
@@ -31,7 +31,7 @@ use cmd::table::CmdTable;
 use executor::CmdExecutor;
 use log::{debug, error, warn};
 use resp::encode::RespEncoder;
-use resp::{Parse, RespData, RespEncode, RespParseResult, RespVersion};
+use resp::{Parse, RespData, RespEncode, RespParseResult};
 use tokio::select;
 
 use crate::executor_ext::CmdExecutorNetworkExt;
@@ -360,7 +360,8 @@ async fn process_command_batch(
                 if !cmd.has_flag(CmdFlags::NO_AUTH) {
                     client.set_reply(RespData::Error("NOAUTH Authentication required.".into()));
                     let response = client.take_reply();
-                    let mut encoder = RespEncoder::new(RespVersion::RESP2);
+                    let encoder_version = client.resp_version();
+                    let mut encoder = RespEncoder::new(encoder_version);
                     encoder.encode_resp_data(&response);
                     let _ = client.write(encoder.get_response().as_ref()).await;
                     continue;
@@ -382,7 +383,8 @@ async fn process_command_batch(
         let response = client.take_reply();
         debug!("Sending pipelined response: {:?}", response);
 
-        let mut encoder = RespEncoder::new(RespVersion::RESP2);
+        let encoder_version = client.resp_version();
+        let mut encoder = RespEncoder::new(encoder_version);
         encoder.encode_resp_data(&response);
 
         match client.write(encoder.get_response().as_ref()).await {

--- a/src/resp/src/lib.rs
+++ b/src/resp/src/lib.rs
@@ -25,7 +25,7 @@ pub mod types;
 pub use command::{Command, CommandType, RespCommand};
 pub use encode::{CmdRes, RespEncode};
 pub use error::{RespError, RespResult};
-pub use negotiation::ProtocolNegotiator;
+pub use negotiation::{HelloAuthResult, ProtocolNegotiator};
 pub use parse::{Parse, RespParse, RespParseResult};
 pub use types::{RespData, RespType, RespVersion};
 

--- a/src/resp/src/negotiation.rs
+++ b/src/resp/src/negotiation.rs
@@ -26,6 +26,7 @@ use crate::{
 };
 
 /// Protocol negotiation handler for RESP3
+#[derive(Clone)]
 pub struct ProtocolNegotiator {
     current_version: RespVersion,
     client_capabilities: HashMap<String, String>,

--- a/src/resp/src/negotiation.rs
+++ b/src/resp/src/negotiation.rs
@@ -25,6 +25,17 @@ use crate::{
     types::{RespData, RespVersion},
 };
 
+/// Result of authenticating via the `HELLO ... AUTH username password` clause.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloAuthResult {
+    /// Password matched the configured requirepass; client may be authenticated.
+    Authenticated,
+    /// Password did not match; client should be rejected with WRONGPASS.
+    WrongPassword,
+    /// No requirepass is configured; AUTH clause is not allowed.
+    NoPasswordConfigured,
+}
+
 /// Protocol negotiation handler for RESP3
 #[derive(Clone)]
 pub struct ProtocolNegotiator {
@@ -54,8 +65,19 @@ impl ProtocolNegotiator {
         &self.client_capabilities
     }
 
-    /// Handle HELLO command for protocol negotiation
-    pub fn handle_hello(&mut self, command: &RespCommand) -> RespResult<RespData> {
+    /// Handle HELLO command for protocol negotiation.
+    ///
+    /// `authenticate` is called with the password supplied via the AUTH clause.
+    /// It must return whether the client should be authenticated, rejected for a
+    /// wrong password, or rejected because no password is configured.
+    pub fn handle_hello<F>(
+        &mut self,
+        command: &RespCommand,
+        mut authenticate: F,
+    ) -> RespResult<RespData>
+    where
+        F: FnMut(&[u8]) -> HelloAuthResult,
+    {
         // HELLO [protover [AUTH username password] [SETNAME clientname]]
         let mut args_iter = command.args.iter().peekable();
 
@@ -95,12 +117,28 @@ impl ProtocolNegotiator {
                     let _username = args_iter.next().ok_or_else(|| {
                         RespError::InvalidData("AUTH requires username".to_string())
                     })?;
-                    let _password = args_iter.next().ok_or_else(|| {
+                    let password = args_iter.next().ok_or_else(|| {
                         RespError::InvalidData("AUTH requires password".to_string())
                     })?;
-                    // TODO: Implement authentication logic
-                    self.client_capabilities
-                        .insert("auth".to_string(), "enabled".to_string());
+
+                    match authenticate(password.as_ref()) {
+                        HelloAuthResult::Authenticated => {
+                            self.client_capabilities
+                                .insert("auth".to_string(), "enabled".to_string());
+                        }
+                        HelloAuthResult::WrongPassword => {
+                            return Err(RespError::InvalidData(
+                                "-WRONGPASS invalid username-password pair or user is disabled."
+                                    .to_string(),
+                            ));
+                        }
+                        HelloAuthResult::NoPasswordConfigured => {
+                            return Err(RespError::InvalidData(
+                                "-ERR HELLO AUTH called without any password configured"
+                                    .to_string(),
+                            ));
+                        }
+                    }
                 }
                 "SETNAME" => {
                     // SETNAME clientname
@@ -271,7 +309,9 @@ mod tests {
         let mut negotiator = ProtocolNegotiator::new();
         let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("2")], false);
 
-        let response = negotiator.handle_hello(&command).unwrap();
+        let response = negotiator
+            .handle_hello(&command, |_| HelloAuthResult::Authenticated)
+            .unwrap();
         assert_eq!(negotiator.current_version(), RespVersion::RESP2);
 
         if let RespData::Array(Some(items)) = response {
@@ -286,7 +326,9 @@ mod tests {
         let mut negotiator = ProtocolNegotiator::new();
         let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("3")], false);
 
-        let response = negotiator.handle_hello(&command).unwrap();
+        let response = negotiator
+            .handle_hello(&command, |_| HelloAuthResult::Authenticated)
+            .unwrap();
         assert_eq!(negotiator.current_version(), RespVersion::RESP3);
 
         if let RespData::Map(pairs) = response {
@@ -305,7 +347,9 @@ mod tests {
 
         // Switch to RESP3
         let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("3")], false);
-        negotiator.handle_hello(&command).unwrap();
+        negotiator
+            .handle_hello(&command, |_| HelloAuthResult::Authenticated)
+            .unwrap();
 
         // RESP3 supports new features
         assert!(negotiator.supports_feature("maps"));

--- a/src/resp/src/negotiation.rs
+++ b/src/resp/src/negotiation.rs
@@ -67,12 +67,15 @@ impl ProtocolNegotiator {
 
     /// Handle HELLO command for protocol negotiation.
     ///
-    /// `authenticate` is called with the password supplied via the AUTH clause.
-    /// It must return whether the client should be authenticated, rejected for a
-    /// wrong password, or rejected because no password is configured.
+    /// `authentication_required` reflects whether the server is configured
+    /// with a requirepass password. When true, a client must already be
+    /// authenticated or authenticate via the HELLO ... AUTH clause to receive
+    /// the HELLO handshake. When false, the NOAUTH check is skipped.
     pub fn handle_hello<F>(
         &mut self,
         command: &RespCommand,
+        already_authenticated: bool,
+        authentication_required: bool,
         mut authenticate: F,
     ) -> RespResult<RespData>
     where
@@ -100,10 +103,11 @@ impl ProtocolNegotiator {
             None
         };
 
-        // Update current version only if explicitly requested
-        if let Some(v) = requested_version {
-            self.current_version = v;
-        }
+        // Determine the version that will be used for this response. The
+        // connection's stored version is only updated after all checks pass.
+        let response_version = requested_version.unwrap_or(self.current_version);
+
+        let mut auth_attempted = false;
 
         // Parse additional arguments (AUTH, SETNAME, etc.)
         while let Some(arg) = args_iter.next() {
@@ -121,21 +125,18 @@ impl ProtocolNegotiator {
                         RespError::InvalidData("AUTH requires password".to_string())
                     })?;
 
+                    auth_attempted = true;
                     match authenticate(password.as_ref()) {
-                        HelloAuthResult::Authenticated => {
-                            self.client_capabilities
-                                .insert("auth".to_string(), "enabled".to_string());
-                        }
+                        HelloAuthResult::Authenticated => {}
                         HelloAuthResult::WrongPassword => {
                             return Err(RespError::InvalidData(
-                                "-WRONGPASS invalid username-password pair or user is disabled."
+                                "WRONGPASS invalid username-password pair or user is disabled."
                                     .to_string(),
                             ));
                         }
                         HelloAuthResult::NoPasswordConfigured => {
                             return Err(RespError::InvalidData(
-                                "-ERR HELLO AUTH called without any password configured"
-                                    .to_string(),
+                                "ERR HELLO AUTH called without any password configured".to_string(),
                             ));
                         }
                     }
@@ -159,7 +160,19 @@ impl ProtocolNegotiator {
             }
         }
 
-        // Build response based on protocol version
+        // Redis requires the client to be authenticated before returning the
+        // HELLO handshake when a password is configured. An AUTH clause that
+        // succeeds satisfies this, as does a connection that was already
+        // authenticated.
+        if authentication_required && !auth_attempted && !already_authenticated {
+            return Err(RespError::InvalidData(
+                "NOAUTH HELLO must be called with the client already authenticated, otherwise the HELLO <proto> AUTH <user> <pass> option can be used to authenticate the client and select the RESP protocol version at the same time".to_string(),
+            ));
+        }
+
+        // All checks passed: commit the negotiated version and build the reply.
+        self.current_version = response_version;
+
         match self.current_version {
             RespVersion::RESP2 => self.build_resp2_hello_response(),
             RespVersion::RESP3 => self.build_resp3_hello_response(),
@@ -169,7 +182,7 @@ impl ProtocolNegotiator {
 
     fn build_resp2_hello_response(&self) -> RespResult<RespData> {
         // RESP2 response format (array of key-value pairs)
-        let mut response = vec![
+        let response = vec![
             RespData::BulkString(Some(Bytes::from("server"))),
             RespData::BulkString(Some(Bytes::from("kiwi"))),
             RespData::BulkString(Some(Bytes::from("version"))),
@@ -182,20 +195,16 @@ impl ProtocolNegotiator {
             RespData::BulkString(Some(Bytes::from("standalone"))),
             RespData::BulkString(Some(Bytes::from("role"))),
             RespData::BulkString(Some(Bytes::from("master"))),
+            RespData::BulkString(Some(Bytes::from("modules"))),
+            RespData::Array(Some(vec![])),
         ];
-
-        // Add client capabilities if any
-        for (key, value) in &self.client_capabilities {
-            response.push(RespData::BulkString(Some(Bytes::from(key.clone()))));
-            response.push(RespData::BulkString(Some(Bytes::from(value.clone()))));
-        }
 
         Ok(RespData::Array(Some(response)))
     }
 
     fn build_resp3_hello_response(&self) -> RespResult<RespData> {
         // RESP3 response format (map)
-        let mut pairs = vec![
+        let pairs = vec![
             (
                 RespData::BulkString(Some(Bytes::from("server"))),
                 RespData::BulkString(Some(Bytes::from("kiwi"))),
@@ -220,15 +229,11 @@ impl ProtocolNegotiator {
                 RespData::BulkString(Some(Bytes::from("role"))),
                 RespData::BulkString(Some(Bytes::from("master"))),
             ),
+            (
+                RespData::BulkString(Some(Bytes::from("modules"))),
+                RespData::Array(Some(vec![])),
+            ),
         ];
-
-        // Add client capabilities if any
-        for (key, value) in &self.client_capabilities {
-            pairs.push((
-                RespData::BulkString(Some(Bytes::from(key.clone()))),
-                RespData::BulkString(Some(Bytes::from(value.clone()))),
-            ));
-        }
 
         Ok(RespData::Map(pairs))
     }
@@ -310,7 +315,7 @@ mod tests {
         let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("2")], false);
 
         let response = negotiator
-            .handle_hello(&command, |_| HelloAuthResult::Authenticated)
+            .handle_hello(&command, true, false, |_| HelloAuthResult::Authenticated)
             .unwrap();
         assert_eq!(negotiator.current_version(), RespVersion::RESP2);
 
@@ -327,7 +332,7 @@ mod tests {
         let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("3")], false);
 
         let response = negotiator
-            .handle_hello(&command, |_| HelloAuthResult::Authenticated)
+            .handle_hello(&command, true, false, |_| HelloAuthResult::Authenticated)
             .unwrap();
         assert_eq!(negotiator.current_version(), RespVersion::RESP3);
 
@@ -336,6 +341,22 @@ mod tests {
         } else {
             panic!("Expected map response for RESP3");
         }
+    }
+
+    #[test]
+    fn test_hello_noauth_when_unauthenticated() {
+        let mut negotiator = ProtocolNegotiator::new();
+        let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("3")], false);
+
+        let result = negotiator.handle_hello(&command, false, true, |_| {
+            panic!("authenticate should not be called without AUTH")
+        });
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("NOAUTH"), "expected NOAUTH error, got {err}");
+        // Version must not switch when the command is rejected.
+        assert_eq!(negotiator.current_version(), RespVersion::RESP2);
     }
 
     #[test]
@@ -348,7 +369,7 @@ mod tests {
         // Switch to RESP3
         let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("3")], false);
         negotiator
-            .handle_hello(&command, |_| HelloAuthResult::Authenticated)
+            .handle_hello(&command, true, false, |_| HelloAuthResult::Authenticated)
             .unwrap();
 
         // RESP3 supports new features

--- a/src/resp/tests/integration_tests.rs
+++ b/src/resp/tests/integration_tests.rs
@@ -217,14 +217,14 @@ fn test_protocol_negotiation_resp2() {
     let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("2")], false);
 
     let response = negotiator
-        .handle_hello(&command, |_| HelloAuthResult::Authenticated)
+        .handle_hello(&command, true, false, |_| HelloAuthResult::Authenticated)
         .unwrap();
     assert_eq!(negotiator.current_version(), RespVersion::RESP2);
 
     // Should return array format for RESP2
     match response {
         RespData::Array(Some(items)) => {
-            assert!(items.len() >= 12); // At least basic server info
+            assert!(items.len() >= 14); // Basic server info + modules
             // Check that proto field is 2
             let proto_index = items
                 .iter()
@@ -242,14 +242,14 @@ fn test_protocol_negotiation_resp3() {
     let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("3")], false);
 
     let response = negotiator
-        .handle_hello(&command, |_| HelloAuthResult::Authenticated)
+        .handle_hello(&command, true, false, |_| HelloAuthResult::Authenticated)
         .unwrap();
     assert_eq!(negotiator.current_version(), RespVersion::RESP3);
 
     // Should return map format for RESP3
     match response {
         RespData::Map(pairs) => {
-            assert!(pairs.len() >= 6); // At least basic server info
+            assert!(pairs.len() >= 7); // At least basic server info + modules
             // Check that proto field is 3
             let proto_pair = pairs
                 .iter()
@@ -276,10 +276,9 @@ fn test_protocol_negotiation_with_auth() {
     );
 
     let _response = negotiator
-        .handle_hello(&command, |_| HelloAuthResult::Authenticated)
+        .handle_hello(&command, false, true, |_| HelloAuthResult::Authenticated)
         .unwrap();
     assert_eq!(negotiator.current_version(), RespVersion::RESP3);
-    assert!(negotiator.client_capabilities().contains_key("auth"));
 }
 
 #[test]
@@ -296,7 +295,7 @@ fn test_protocol_negotiation_with_wrong_password() {
         false,
     );
 
-    let result = negotiator.handle_hello(&command, |_| HelloAuthResult::WrongPassword);
+    let result = negotiator.handle_hello(&command, false, true, |_| HelloAuthResult::WrongPassword);
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(err.contains("WRONGPASS"), "expected WRONGPASS, got {err}");
@@ -316,7 +315,9 @@ fn test_protocol_negotiation_with_no_password_configured() {
         false,
     );
 
-    let result = negotiator.handle_hello(&command, |_| HelloAuthResult::NoPasswordConfigured);
+    let result = negotiator.handle_hello(&command, false, false, |_| {
+        HelloAuthResult::NoPasswordConfigured
+    });
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(
@@ -339,13 +340,29 @@ fn test_protocol_negotiation_with_setname() {
     );
 
     let _response = negotiator
-        .handle_hello(&command, |_| HelloAuthResult::Authenticated)
+        .handle_hello(&command, true, false, |_| HelloAuthResult::Authenticated)
         .unwrap();
     assert_eq!(negotiator.current_version(), RespVersion::RESP2);
     assert_eq!(
         negotiator.client_capabilities().get("client_name"),
         Some(&"my-client".to_string())
     );
+}
+
+#[test]
+fn test_protocol_negotiation_noauth() {
+    let mut negotiator = ProtocolNegotiator::new();
+    let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("3")], false);
+
+    let result = negotiator.handle_hello(&command, false, true, |_| {
+        panic!("authenticate should not be called without AUTH")
+    });
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("NOAUTH"), "expected NOAUTH error, got {err}");
+    // The connection must stay on RESP2 since the command failed.
+    assert_eq!(negotiator.current_version(), RespVersion::RESP2);
 }
 
 #[test]
@@ -430,7 +447,7 @@ fn test_feature_support_detection() {
     // Switch to RESP3
     let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("3")], false);
     negotiator
-        .handle_hello(&command, |_| HelloAuthResult::Authenticated)
+        .handle_hello(&command, true, false, |_| HelloAuthResult::Authenticated)
         .unwrap();
 
     // Now supports RESP3 features

--- a/src/resp/tests/integration_tests.rs
+++ b/src/resp/tests/integration_tests.rs
@@ -21,7 +21,7 @@ use bytes::Bytes;
 use resp::{
     command::{CommandType, RespCommand},
     encode::{RespEncode, RespEncoder},
-    negotiation::ProtocolNegotiator,
+    negotiation::{HelloAuthResult, ProtocolNegotiator},
     parse::{Parse, RespParse, RespParseResult},
     types::{RespData, RespVersion},
 };
@@ -216,7 +216,9 @@ fn test_protocol_negotiation_resp2() {
     let mut negotiator = ProtocolNegotiator::new();
     let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("2")], false);
 
-    let response = negotiator.handle_hello(&command).unwrap();
+    let response = negotiator
+        .handle_hello(&command, |_| HelloAuthResult::Authenticated)
+        .unwrap();
     assert_eq!(negotiator.current_version(), RespVersion::RESP2);
 
     // Should return array format for RESP2
@@ -239,7 +241,9 @@ fn test_protocol_negotiation_resp3() {
     let mut negotiator = ProtocolNegotiator::new();
     let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("3")], false);
 
-    let response = negotiator.handle_hello(&command).unwrap();
+    let response = negotiator
+        .handle_hello(&command, |_| HelloAuthResult::Authenticated)
+        .unwrap();
     assert_eq!(negotiator.current_version(), RespVersion::RESP3);
 
     // Should return map format for RESP3
@@ -271,9 +275,54 @@ fn test_protocol_negotiation_with_auth() {
         false,
     );
 
-    let _response = negotiator.handle_hello(&command).unwrap();
+    let _response = negotiator
+        .handle_hello(&command, |_| HelloAuthResult::Authenticated)
+        .unwrap();
     assert_eq!(negotiator.current_version(), RespVersion::RESP3);
     assert!(negotiator.client_capabilities().contains_key("auth"));
+}
+
+#[test]
+fn test_protocol_negotiation_with_wrong_password() {
+    let mut negotiator = ProtocolNegotiator::new();
+    let command = RespCommand::new(
+        CommandType::Hello,
+        vec![
+            Bytes::from("3"),
+            Bytes::from("AUTH"),
+            Bytes::from("username"),
+            Bytes::from("password"),
+        ],
+        false,
+    );
+
+    let result = negotiator.handle_hello(&command, |_| HelloAuthResult::WrongPassword);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("WRONGPASS"), "expected WRONGPASS, got {err}");
+}
+
+#[test]
+fn test_protocol_negotiation_with_no_password_configured() {
+    let mut negotiator = ProtocolNegotiator::new();
+    let command = RespCommand::new(
+        CommandType::Hello,
+        vec![
+            Bytes::from("3"),
+            Bytes::from("AUTH"),
+            Bytes::from("username"),
+            Bytes::from("password"),
+        ],
+        false,
+    );
+
+    let result = negotiator.handle_hello(&command, |_| HelloAuthResult::NoPasswordConfigured);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("HELLO AUTH called without any password configured"),
+        "expected no-password-configured error, got {err}"
+    );
 }
 
 #[test]
@@ -289,7 +338,9 @@ fn test_protocol_negotiation_with_setname() {
         false,
     );
 
-    let _response = negotiator.handle_hello(&command).unwrap();
+    let _response = negotiator
+        .handle_hello(&command, |_| HelloAuthResult::Authenticated)
+        .unwrap();
     assert_eq!(negotiator.current_version(), RespVersion::RESP2);
     assert_eq!(
         negotiator.client_capabilities().get("client_name"),
@@ -378,7 +429,9 @@ fn test_feature_support_detection() {
 
     // Switch to RESP3
     let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("3")], false);
-    negotiator.handle_hello(&command).unwrap();
+    negotiator
+        .handle_hello(&command, |_| HelloAuthResult::Authenticated)
+        .unwrap();
 
     // Now supports RESP3 features
     assert!(negotiator.supports_feature("maps"));


### PR DESCRIPTION
### 描述

新增 `HELLO` 命令支持，实现 RESP 协议版本协商与 HELLO AUTH 验证。

主要改动：
- 新增 `HelloCmd`，处理 `HELLO [protover] [AUTH username password] [SETNAME clientname]`。
- 在 `Client` 上持久化 `ProtocolNegotiator`，使协商后的 RESP 版本跨命令保持。
- 扩展 `ProtocolNegotiator`：支持 RESP2/RESP3 选择、AUTH 回调、HELLO 响应构造。
- 网络层回复编码使用 `client.resp_version()`，使 `HELLO 3` 后的响应按 RESP3 编码。
- `HelloCmd` 仅在 `HELLO ... AUTH` 密码验证通过后才标记客户端为已认证，避免裸 `HELLO` 绕过 `requirepass`。
- 修正 HELLO 错误路径：`RespError::InvalidData` 携带原始 Redis 错误消息，去掉前缀和多余的前导 `-`。
- 在命令表中注册 `HelloCmd`，并复用与 network runtime 一致的 `requirepass_provider`。

### 关联

- 对应 issue #305
- 基于 PR #311 的 review 反馈拆分出的 HELLO-only 部分
- 依赖 PR #316（storage command dispatch refactor）

### 验证

- `cargo check --workspace` 通过
- `cargo clippy --workspace -- -D warnings` 通过
- `cargo test -p cmd -p resp -p client -p runtime -p net --lib` 通过

### 备注

本 PR 当前目标分支为 `storage-command-refactor-pr`。待 PR #316 合并后，会 rebase 到 `main` 并切换目标分支。
