### PR TITLE
fix(hello): align HELLO command with Redis semantics

### DIFF
--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use resp::RespData;
+use resp::{ProtocolNegotiator, RespCommand, RespData, RespResult};
 use tokio::sync::Mutex;
 
 #[async_trait]
@@ -44,6 +44,8 @@ struct ClientContext {
     key: Vec<u8>,
     reply: RespData,
     authenticated: bool,
+    /// Persisted RESP protocol negotiation state for this connection.
+    protocol_negotiator: ProtocolNegotiator,
 }
 
 impl Client {
@@ -59,6 +61,7 @@ impl Client {
                 // Default to false (fail-closed): callers must explicitly grant
                 // authentication when no `requirepass` is configured.
                 authenticated: false,
+                protocol_negotiator: ProtocolNegotiator::new(),
             }),
         }
     }
@@ -131,5 +134,51 @@ impl Client {
     pub fn set_authenticated(&self, val: bool) {
         let mut ctx = self.ctx.lock();
         ctx.authenticated = val;
+    }
+
+    /// Handle a RESP HELLO command using the persisted protocol negotiation
+    /// state for this connection, so the negotiated RESP version survives across
+    /// multiple commands.
+    ///
+    /// `already_authenticated` reflects whether the connection is already
+    /// authenticated. `authentication_required` reflects whether the server has
+    /// a requirepass password configured. When authentication is required and
+    /// the client is not already authenticated, the HELLO ... AUTH clause must
+    /// be used to authenticate and receive the handshake.
+    ///
+    /// `authenticate` is called with the `username` and `password` supplied via
+    /// the AUTH clause and must report whether the client should be
+    /// authenticated, rejected for a wrong username/password pair, or rejected
+    /// because no password is configured.
+    pub fn handle_hello<F>(
+        &self,
+        command: &RespCommand,
+        already_authenticated: bool,
+        authentication_required: bool,
+        authenticate: F,
+    ) -> RespResult<(RespData, Option<String>)>
+    where
+        F: FnMut(&[u8], &[u8]) -> resp::HelloAuthResult,
+    {
+        let result;
+        {
+            let mut ctx = self.ctx.lock();
+            result = ctx.protocol_negotiator.handle_hello(
+                command,
+                already_authenticated,
+                authentication_required,
+                authenticate,
+            );
+        }
+        if let Ok((_, Some(name))) = &result {
+            self.set_name(name.as_bytes());
+        }
+        result
+    }
+
+    /// Return the currently negotiated RESP version for this connection.
+    pub fn resp_version(&self) -> resp::RespVersion {
+        let ctx = self.ctx.lock();
+        ctx.protocol_negotiator.current_version()
     }
 }

--- a/src/cmd/src/hello.rs
+++ b/src/cmd/src/hello.rs
@@ -1,0 +1,228 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use client::Client;
+use resp::{CommandType, HelloAuthResult, RespCommand, RespData, RespError};
+use storage::storage::Storage;
+use subtle::ConstantTimeEq;
+
+use crate::{
+    AclCategory, Cmd, CmdFlags, CmdMeta, RequirepassProvider, impl_cmd_clone_box, impl_cmd_meta,
+};
+
+#[derive(Clone)]
+pub struct HelloCmd {
+    meta: CmdMeta,
+    requirepass_provider: RequirepassProvider,
+}
+
+impl Default for HelloCmd {
+    fn default() -> Self {
+        Self {
+            meta: CmdMeta {
+                name: "hello".to_string(),
+                arity: -1,
+                flags: CmdFlags::NO_AUTH | CmdFlags::FAST,
+                acl_category: AclCategory::CONNECTION | AclCategory::FAST,
+                ..Default::default()
+            },
+            requirepass_provider: Arc::new(|| None),
+        }
+    }
+}
+
+impl HelloCmd {
+    pub fn new(provider: RequirepassProvider) -> Self {
+        Self {
+            meta: CmdMeta {
+                name: "hello".to_string(),
+                arity: -1,
+                flags: CmdFlags::NO_AUTH | CmdFlags::FAST,
+                acl_category: AclCategory::CONNECTION | AclCategory::FAST,
+                ..Default::default()
+            },
+            requirepass_provider: provider,
+        }
+    }
+}
+
+impl Cmd for HelloCmd {
+    impl_cmd_meta!();
+    impl_cmd_clone_box!();
+
+    fn do_initial(&self, _client: &Client) -> bool {
+        true
+    }
+
+    fn do_cmd(&self, client: &Client, _storage: Arc<Storage>) {
+        let argv = client.argv();
+        let command = RespCommand {
+            command_type: CommandType::Hello,
+            args: argv.into_iter().skip(1).map(Bytes::from).collect(),
+            is_pipeline: false,
+        };
+
+        let provider = Arc::clone(&self.requirepass_provider);
+        let authentication_required = provider().is_some();
+        let mut authenticate = |username: &[u8], password: &[u8]| -> HelloAuthResult {
+            // ACL authentication is not supported yet; only the default user
+            // is valid, matching Redis behavior when a single requirepass is
+            // configured.
+            if username != b"default" {
+                return HelloAuthResult::WrongPassword;
+            }
+            match provider() {
+                Some(requirepass) => {
+                    let matches: bool = password.ct_eq(requirepass.as_bytes()).into();
+                    if matches {
+                        HelloAuthResult::Authenticated
+                    } else {
+                        HelloAuthResult::WrongPassword
+                    }
+                }
+                None => HelloAuthResult::NoPasswordConfigured,
+            }
+        };
+
+        match client.handle_hello(
+            &command,
+            client.is_authenticated(),
+            authentication_required,
+            &mut authenticate,
+        ) {
+            Ok((response, _)) => {
+                // handle_hello only succeeds when the client is already
+                // authenticated or the HELLO included an AUTH clause that
+                // succeeded. In both cases the connection is authenticated.
+                client.set_authenticated(true);
+                client.set_reply(response);
+            }
+            Err(err) => client.set_reply(RespData::Error(format_hello_error(err).into())),
+        }
+    }
+}
+
+/// Format a RESP error from HELLO negotiation for the client.
+///
+/// `RespError::InvalidData` is used to carry the raw Redis error message, so
+/// strip the Display prefix and any leading `-` that the encoder will add.
+fn format_hello_error(err: RespError) -> String {
+    let raw = match err {
+        RespError::InvalidData(msg) => msg,
+        other => other.to_string(),
+    };
+    raw.trim_start_matches('-').to_string()
+}
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use client::StreamTrait;
+
+    struct TestStream;
+
+    #[async_trait::async_trait]
+    impl StreamTrait for TestStream {
+        async fn read(&mut self, _buf: &mut [u8]) -> Result<usize, std::io::Error> {
+            Ok(0)
+        }
+
+        async fn write(&mut self, _data: &[u8]) -> Result<usize, std::io::Error> {
+            Ok(0)
+        }
+    }
+
+    fn make_client() -> Arc<Client> {
+        Arc::new(Client::new(Box::new(TestStream)))
+    }
+
+    fn make_storage() -> Arc<Storage> {
+        Arc::new(Storage::new(1, 0))
+    }
+
+    fn hello_cmd_with(password: Option<&str>) -> HelloCmd {
+        let owned = password.map(|s| s.to_string());
+        HelloCmd::new(Arc::new(move || owned.clone()))
+    }
+
+    fn reply_is_error(client: &Client) -> Option<String> {
+        match client.take_reply() {
+            RespData::Error(b) => Some(String::from_utf8_lossy(&b).to_string()),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn hello_auth_default_user_succeeds() {
+        let cmd = hello_cmd_with(Some("secret"));
+        let client = make_client();
+        client.set_argv(&[
+            b"hello".to_vec(),
+            b"3".to_vec(),
+            b"AUTH".to_vec(),
+            b"default".to_vec(),
+            b"secret".to_vec(),
+        ]);
+
+        cmd.do_cmd(&client, make_storage());
+
+        assert!(client.is_authenticated());
+        assert!(
+            reply_is_error(&client).is_none(),
+            "expected a successful HELLO response"
+        );
+    }
+
+    #[test]
+    fn hello_auth_non_default_user_is_rejected() {
+        let cmd = hello_cmd_with(Some("secret"));
+        let client = make_client();
+        client.set_argv(&[
+            b"hello".to_vec(),
+            b"3".to_vec(),
+            b"AUTH".to_vec(),
+            b"other".to_vec(),
+            b"secret".to_vec(),
+        ]);
+
+        cmd.do_cmd(&client, make_storage());
+
+        assert!(!client.is_authenticated());
+        let err = reply_is_error(&client).expect("expected an error reply");
+        assert!(err.starts_with("WRONGPASS"), "unexpected reply: {err}");
+    }
+
+    #[test]
+    fn hello_setname_sets_client_name() {
+        let cmd = hello_cmd_with(None);
+        let client = make_client();
+        client.set_argv(&[
+            b"hello".to_vec(),
+            b"2".to_vec(),
+            b"SETNAME".to_vec(),
+            b"my-client".to_vec(),
+        ]);
+
+        cmd.do_cmd(&client, make_storage());
+
+        assert_eq!(client.name().as_slice(), b"my-client");
+    }
+}

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -35,6 +35,7 @@ pub mod getrange;
 pub mod getset;
 pub mod group_client;
 pub mod hdel;
+pub mod hello;
 pub mod hexists;
 pub mod hget;
 pub mod hgetall;
@@ -117,6 +118,8 @@ use client::Client;
 use log::debug;
 use resp::RespData;
 use storage::storage::Storage;
+
+pub use auth::RequirepassProvider;
 
 bitflags! {
     #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/cmd/src/table.rs
+++ b/src/cmd/src/table.rs
@@ -169,11 +169,15 @@ pub fn create_command_table(requirepass_provider: RequirepassProvider) -> CmdTab
         crate::ping::PingCmd,
     );
 
-    // AuthCmd with requirepass provider
+    // AuthCmd and HelloCmd require the requirepass provider for authentication.
     {
-        let auth_cmd = crate::auth::AuthCmd::new(requirepass_provider);
+        let auth_cmd = crate::auth::AuthCmd::new(Arc::clone(&requirepass_provider));
         let cmd_name = auth_cmd.meta().name.clone();
         cmd_table.insert(cmd_name, Arc::new(auth_cmd));
+    }
+    {
+        let hello_cmd = crate::hello::HelloCmd::new(requirepass_provider);
+        cmd_table.insert(hello_cmd.meta().name.clone(), Arc::new(hello_cmd));
     }
 
     register_group_cmd!(
@@ -183,4 +187,190 @@ pub fn create_command_table(requirepass_provider: RequirepassProvider) -> CmdTab
     );
 
     cmd_table
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use client::{Client, StreamTrait};
+    use resp::RespData;
+    use storage::storage::Storage;
+
+    use super::create_command_table;
+
+    struct TestStream;
+
+    #[async_trait::async_trait]
+    impl StreamTrait for TestStream {
+        async fn read(&mut self, _buf: &mut [u8]) -> Result<usize, std::io::Error> {
+            Ok(0)
+        }
+
+        async fn write(&mut self, _data: &[u8]) -> Result<usize, std::io::Error> {
+            Ok(0)
+        }
+    }
+
+    #[test]
+    fn hello_command_returns_resp3_handshake() {
+        let table = create_command_table(Arc::new(|| None));
+        let command = table.get("hello").expect("HELLO should be registered");
+        let client = Client::new(Box::new(TestStream));
+        client.set_cmd_name(b"hello");
+        client.set_argv(&[b"hello".to_vec(), b"3".to_vec()]);
+
+        command.execute(&client, Arc::new(Storage::new(1, 0)));
+
+        assert_eq!(
+            client.take_reply(),
+            RespData::Map(vec![
+                (
+                    RespData::BulkString(Some(Bytes::from("server"))),
+                    RespData::BulkString(Some(Bytes::from("kiwi"))),
+                ),
+                (
+                    RespData::BulkString(Some(Bytes::from("version"))),
+                    RespData::BulkString(Some(Bytes::from("1.0.0"))),
+                ),
+                (
+                    RespData::BulkString(Some(Bytes::from("proto"))),
+                    RespData::Integer(3),
+                ),
+                (
+                    RespData::BulkString(Some(Bytes::from("id"))),
+                    RespData::Integer(1),
+                ),
+                (
+                    RespData::BulkString(Some(Bytes::from("mode"))),
+                    RespData::BulkString(Some(Bytes::from("standalone"))),
+                ),
+                (
+                    RespData::BulkString(Some(Bytes::from("role"))),
+                    RespData::BulkString(Some(Bytes::from("master"))),
+                ),
+                (
+                    RespData::BulkString(Some(Bytes::from("modules"))),
+                    RespData::Array(Some(vec![])),
+                ),
+            ])
+        );
+    }
+
+    #[test]
+    fn hello_bare_with_requirepass_returns_noauth() {
+        let table = create_command_table(Arc::new(|| Some("secret".to_string())));
+        let command = table.get("hello").expect("HELLO should be registered");
+        let client = Client::new(Box::new(TestStream));
+        client.set_cmd_name(b"hello");
+        client.set_argv(&[b"hello".to_vec(), b"3".to_vec()]);
+
+        command.execute(&client, Arc::new(Storage::new(1, 0)));
+
+        assert!(!client.is_authenticated());
+        let reply = client.take_reply();
+        assert!(
+            matches!(reply, RespData::Error(ref e) if String::from_utf8_lossy(e).contains("NOAUTH")),
+            "expected NOAUTH error, got {:?}",
+            reply
+        );
+    }
+
+    #[test]
+    fn hello_setname_sets_client_name() {
+        let table = create_command_table(Arc::new(|| None));
+        let command = table.get("hello").expect("HELLO should be registered");
+        let client = Client::new(Box::new(TestStream));
+        client.set_cmd_name(b"hello");
+        client.set_argv(&[
+            b"hello".to_vec(),
+            b"2".to_vec(),
+            b"SETNAME".to_vec(),
+            b"my-client".to_vec(),
+        ]);
+
+        command.execute(&client, Arc::new(Storage::new(1, 0)));
+
+        assert_eq!(
+            client.name().as_ref(),
+            b"my-client",
+            "expected SETNAME to set the client name"
+        );
+    }
+
+    #[test]
+    fn hello_auth_with_correct_password_authenticates() {
+        let table = create_command_table(Arc::new(|| Some("secret".to_string())));
+        let command = table.get("hello").expect("HELLO should be registered");
+        let client = Client::new(Box::new(TestStream));
+        client.set_cmd_name(b"hello");
+        client.set_argv(&[
+            b"hello".to_vec(),
+            b"3".to_vec(),
+            b"AUTH".to_vec(),
+            b"default".to_vec(),
+            b"secret".to_vec(),
+        ]);
+
+        command.execute(&client, Arc::new(Storage::new(1, 0)));
+
+        assert!(client.is_authenticated());
+        let reply = client.take_reply();
+        assert!(
+            matches!(reply, RespData::Map(_)),
+            "expected HELLO handshake map, got {:?}",
+            reply
+        );
+    }
+
+    #[test]
+    fn hello_auth_with_wrong_password_returns_wrongpass() {
+        let table = create_command_table(Arc::new(|| Some("secret".to_string())));
+        let command = table.get("hello").expect("HELLO should be registered");
+        let client = Client::new(Box::new(TestStream));
+        client.set_cmd_name(b"hello");
+        client.set_argv(&[
+            b"hello".to_vec(),
+            b"3".to_vec(),
+            b"AUTH".to_vec(),
+            b"default".to_vec(),
+            b"wrong".to_vec(),
+        ]);
+
+        command.execute(&client, Arc::new(Storage::new(1, 0)));
+
+        assert!(!client.is_authenticated());
+        let reply = client.take_reply();
+        assert!(
+            matches!(reply, RespData::Error(ref e) if String::from_utf8_lossy(e).contains("WRONGPASS")),
+            "expected WRONGPASS error, got {:?}",
+            reply
+        );
+    }
+
+    #[test]
+    fn hello_auth_without_requirepass_returns_error() {
+        let table = create_command_table(Arc::new(|| None));
+        let command = table.get("hello").expect("HELLO should be registered");
+        let client = Client::new(Box::new(TestStream));
+        client.set_cmd_name(b"hello");
+        client.set_argv(&[
+            b"hello".to_vec(),
+            b"3".to_vec(),
+            b"AUTH".to_vec(),
+            b"default".to_vec(),
+            b"anything".to_vec(),
+        ]);
+
+        command.execute(&client, Arc::new(Storage::new(1, 0)));
+
+        assert!(!client.is_authenticated());
+        let reply = client.take_reply();
+        assert!(
+            matches!(reply, RespData::Error(ref e) if String::from_utf8_lossy(e).contains("HELLO AUTH called without")),
+            "expected no-password-configured error, got {:?}",
+            reply
+        );
+    }
 }

--- a/src/net/src/executor_ext.rs
+++ b/src/net/src/executor_ext.rs
@@ -85,7 +85,7 @@ impl CmdExecutorNetworkExt for CmdExecutor {
             // Route connection-local commands locally and send all other
             // storage-backed commands through the generic Execute path.
             match cmd_name.as_str() {
-                "ping" | "auth" | "client" => {
+                "ping" | "auth" | "client" | "hello" => {
                     execute_local_command(&exec).await?;
                 }
                 _ => {
@@ -99,7 +99,7 @@ impl CmdExecutorNetworkExt for CmdExecutor {
 }
 
 /// Shared dummy storage for connection-local commands that do not touch real
-/// storage (ping/auth/client). Reused across calls to avoid allocating a
+/// storage (ping/auth/client/hello). Reused across calls to avoid allocating a
 /// throwaway `Storage` on every hot-path invocation.
 static LOCAL_DUMMY_STORAGE: LazyLock<Arc<Storage>> = LazyLock::new(|| Arc::new(Storage::new(1, 0)));
 

--- a/src/net/src/handle.rs
+++ b/src/net/src/handle.rs
@@ -24,7 +24,7 @@ use cmd::table::CmdTable;
 use executor::{CmdExecution, CmdExecutor};
 use log::error;
 use resp::encode::RespEncoder;
-use resp::{Parse, RespData, RespEncode, RespParseResult, RespVersion};
+use resp::{Parse, RespData, RespEncode, RespParseResult};
 use storage::storage::Storage;
 use tokio::select;
 
@@ -37,7 +37,7 @@ pub async fn process_connection(
     executor: Arc<CmdExecutor>,
 ) -> std::io::Result<()> {
     let mut buf = vec![0; 1024];
-    let mut resp_parser = resp::RespParse::new(resp::RespVersion::RESP2);
+    let mut resp_parser = resp::RespParse::new(client.resp_version());
 
     loop {
         select! {
@@ -59,7 +59,7 @@ pub async fn process_connection(
                                     handle_command(client.clone(), storage.clone(), cmd_table.clone(), executor.clone()).await;
                                     // Extract the reply from the connection and send it
                                     let response = client.take_reply();
-                                    let mut encoder = RespEncoder::new(RespVersion::RESP2);
+                                    let mut encoder = RespEncoder::new(client.resp_version());
                                     encoder.encode_resp_data(&response);
                                     match client.write(encoder.get_response().as_ref()).await {
                                         Ok(_) => (),

--- a/src/net/src/network_handle.rs
+++ b/src/net/src/network_handle.rs
@@ -31,7 +31,7 @@ use cmd::table::CmdTable;
 use executor::CmdExecutor;
 use log::{debug, error, warn};
 use resp::encode::RespEncoder;
-use resp::{Parse, RespData, RespEncode, RespParseResult, RespVersion};
+use resp::{Parse, RespData, RespEncode, RespParseResult};
 use tokio::select;
 
 use crate::executor_ext::CmdExecutorNetworkExt;
@@ -52,7 +52,7 @@ pub async fn process_network_connection(
     leader_gate: Option<std::sync::Arc<dyn raft::leader_gate::LeaderGate>>,
 ) -> std::io::Result<()> {
     let mut buf = vec![0; 4096]; // Increased buffer size for better performance
-    let mut resp_parser = resp::RespParse::new(resp::RespVersion::RESP2);
+    let mut resp_parser = resp::RespParse::new(client.resp_version());
     let mut pending_commands = Vec::new();
 
     debug!("Starting network connection processing with pipelining support");
@@ -360,7 +360,8 @@ async fn process_command_batch(
                 if !cmd.has_flag(CmdFlags::NO_AUTH) {
                     client.set_reply(RespData::Error("NOAUTH Authentication required.".into()));
                     let response = client.take_reply();
-                    let mut encoder = RespEncoder::new(RespVersion::RESP2);
+                    let encoder_version = client.resp_version();
+                    let mut encoder = RespEncoder::new(encoder_version);
                     encoder.encode_resp_data(&response);
                     let _ = client.write(encoder.get_response().as_ref()).await;
                     continue;
@@ -382,7 +383,8 @@ async fn process_command_batch(
         let response = client.take_reply();
         debug!("Sending pipelined response: {:?}", response);
 
-        let mut encoder = RespEncoder::new(RespVersion::RESP2);
+        let encoder_version = client.resp_version();
+        let mut encoder = RespEncoder::new(encoder_version);
         encoder.encode_resp_data(&response);
 
         match client.write(encoder.get_response().as_ref()).await {

--- a/src/resp/src/lib.rs
+++ b/src/resp/src/lib.rs
@@ -25,7 +25,7 @@ pub mod types;
 pub use command::{Command, CommandType, RespCommand};
 pub use encode::{CmdRes, RespEncode};
 pub use error::{RespError, RespResult};
-pub use negotiation::ProtocolNegotiator;
+pub use negotiation::{HelloAuthResult, ProtocolNegotiator};
 pub use parse::{Parse, RespParse, RespParseResult};
 pub use types::{RespData, RespType, RespVersion};
 

--- a/src/resp/src/negotiation.rs
+++ b/src/resp/src/negotiation.rs
@@ -25,7 +25,19 @@ use crate::{
     types::{RespData, RespVersion},
 };
 
+/// Result of authenticating via the `HELLO ... AUTH username password` clause.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloAuthResult {
+    /// Password matched the configured requirepass; client may be authenticated.
+    Authenticated,
+    /// Password did not match; client should be rejected with WRONGPASS.
+    WrongPassword,
+    /// No requirepass is configured; AUTH clause is not allowed.
+    NoPasswordConfigured,
+}
+
 /// Protocol negotiation handler for RESP3
+#[derive(Clone)]
 pub struct ProtocolNegotiator {
     current_version: RespVersion,
     client_capabilities: HashMap<String, String>,
@@ -53,8 +65,27 @@ impl ProtocolNegotiator {
         &self.client_capabilities
     }
 
-    /// Handle HELLO command for protocol negotiation
-    pub fn handle_hello(&mut self, command: &RespCommand) -> RespResult<RespData> {
+    /// Handle HELLO command for protocol negotiation.
+    ///
+    /// `authentication_required` reflects whether the server is configured
+    /// with a requirepass password. When true, a client must already be
+    /// authenticated or authenticate via the HELLO ... AUTH clause to receive
+    /// the HELLO handshake. When false, the NOAUTH check is skipped.
+    ///
+    /// `authenticate` is called with the `username` and `password` supplied via
+    /// the AUTH clause. It must report whether the client should be
+    /// authenticated, rejected for a wrong username/password pair, or rejected
+    /// because no password is configured.
+    pub fn handle_hello<F>(
+        &mut self,
+        command: &RespCommand,
+        already_authenticated: bool,
+        authentication_required: bool,
+        mut authenticate: F,
+    ) -> RespResult<(RespData, Option<String>)>
+    where
+        F: FnMut(&[u8], &[u8]) -> HelloAuthResult,
+    {
         // HELLO [protover [AUTH username password] [SETNAME clientname]]
         let mut args_iter = command.args.iter().peekable();
 
@@ -77,10 +108,13 @@ impl ProtocolNegotiator {
             None
         };
 
-        // Update current version only if explicitly requested
-        if let Some(v) = requested_version {
-            self.current_version = v;
-        }
+        // Determine the version that will be used for this response. The
+        // connection's stored version is only updated after all checks pass.
+        let response_version = requested_version.unwrap_or(self.current_version);
+
+        let mut auth_attempted = false;
+
+        let mut pending_set_name: Option<String> = None;
 
         // Parse additional arguments (AUTH, SETNAME, etc.)
         while let Some(arg) = args_iter.next() {
@@ -91,15 +125,28 @@ impl ProtocolNegotiator {
             match arg_str.as_str() {
                 "AUTH" => {
                     // AUTH username password
-                    let _username = args_iter.next().ok_or_else(|| {
+                    let username = args_iter.next().ok_or_else(|| {
                         RespError::InvalidData("AUTH requires username".to_string())
                     })?;
-                    let _password = args_iter.next().ok_or_else(|| {
+                    let password = args_iter.next().ok_or_else(|| {
                         RespError::InvalidData("AUTH requires password".to_string())
                     })?;
-                    // TODO: Implement authentication logic
-                    self.client_capabilities
-                        .insert("auth".to_string(), "enabled".to_string());
+
+                    auth_attempted = true;
+                    match authenticate(username.as_ref(), password.as_ref()) {
+                        HelloAuthResult::Authenticated => {}
+                        HelloAuthResult::WrongPassword => {
+                            return Err(RespError::InvalidData(
+                                "WRONGPASS invalid username-password pair or user is disabled."
+                                    .to_string(),
+                            ));
+                        }
+                        HelloAuthResult::NoPasswordConfigured => {
+                            return Err(RespError::InvalidData(
+                                "ERR HELLO AUTH called without any password configured".to_string(),
+                            ));
+                        }
+                    }
                 }
                 "SETNAME" => {
                     // SETNAME clientname
@@ -108,8 +155,7 @@ impl ProtocolNegotiator {
                     })?;
                     let client_name_str = std::str::from_utf8(client_name)
                         .map_err(|_| RespError::InvalidData("Invalid client name".to_string()))?;
-                    self.client_capabilities
-                        .insert("client_name".to_string(), client_name_str.to_string());
+                    pending_set_name = Some(client_name_str.to_string());
                 }
                 _ => {
                     return Err(RespError::InvalidData(format!(
@@ -120,17 +166,40 @@ impl ProtocolNegotiator {
             }
         }
 
-        // Build response based on protocol version
+        // Redis requires the client to be authenticated before returning the
+        // HELLO handshake when a password is configured. An AUTH clause that
+        // succeeds satisfies this, as does a connection that was already
+        // authenticated.
+        if authentication_required && !auth_attempted && !already_authenticated {
+            return Err(RespError::InvalidData(
+                "NOAUTH HELLO must be called with the client already authenticated, otherwise the HELLO <proto> AUTH <user> <pass> option can be used to authenticate the client and select the RESP protocol version at the same time".to_string(),
+            ));
+        }
+
+        // All checks passed: commit the negotiated version and persist any SETNAME
+        // from this command.
+        self.current_version = response_version;
+        if let Some(name) = pending_set_name.as_ref() {
+            self.client_capabilities
+                .insert("client_name".to_string(), name.clone());
+        }
+
         match self.current_version {
-            RespVersion::RESP2 => self.build_resp2_hello_response(),
-            RespVersion::RESP3 => self.build_resp3_hello_response(),
-            _ => self.build_resp2_hello_response(), // Fallback to RESP2
+            RespVersion::RESP2 => self
+                .build_resp2_hello_response()
+                .map(|data| (data, pending_set_name)),
+            RespVersion::RESP3 => self
+                .build_resp3_hello_response()
+                .map(|data| (data, pending_set_name)),
+            _ => self
+                .build_resp2_hello_response()
+                .map(|data| (data, pending_set_name)), // Fallback to RESP2
         }
     }
 
     fn build_resp2_hello_response(&self) -> RespResult<RespData> {
         // RESP2 response format (array of key-value pairs)
-        let mut response = vec![
+        let response = vec![
             RespData::BulkString(Some(Bytes::from("server"))),
             RespData::BulkString(Some(Bytes::from("kiwi"))),
             RespData::BulkString(Some(Bytes::from("version"))),
@@ -143,20 +212,16 @@ impl ProtocolNegotiator {
             RespData::BulkString(Some(Bytes::from("standalone"))),
             RespData::BulkString(Some(Bytes::from("role"))),
             RespData::BulkString(Some(Bytes::from("master"))),
+            RespData::BulkString(Some(Bytes::from("modules"))),
+            RespData::Array(Some(vec![])),
         ];
-
-        // Add client capabilities if any
-        for (key, value) in &self.client_capabilities {
-            response.push(RespData::BulkString(Some(Bytes::from(key.clone()))));
-            response.push(RespData::BulkString(Some(Bytes::from(value.clone()))));
-        }
 
         Ok(RespData::Array(Some(response)))
     }
 
     fn build_resp3_hello_response(&self) -> RespResult<RespData> {
         // RESP3 response format (map)
-        let mut pairs = vec![
+        let pairs = vec![
             (
                 RespData::BulkString(Some(Bytes::from("server"))),
                 RespData::BulkString(Some(Bytes::from("kiwi"))),
@@ -181,15 +246,11 @@ impl ProtocolNegotiator {
                 RespData::BulkString(Some(Bytes::from("role"))),
                 RespData::BulkString(Some(Bytes::from("master"))),
             ),
+            (
+                RespData::BulkString(Some(Bytes::from("modules"))),
+                RespData::Array(Some(vec![])),
+            ),
         ];
-
-        // Add client capabilities if any
-        for (key, value) in &self.client_capabilities {
-            pairs.push((
-                RespData::BulkString(Some(Bytes::from(key.clone()))),
-                RespData::BulkString(Some(Bytes::from(value.clone()))),
-            ));
-        }
 
         Ok(RespData::Map(pairs))
     }
@@ -259,7 +320,6 @@ impl ProtocolNegotiator {
     }
 }
 
-#[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -270,7 +330,10 @@ mod tests {
         let mut negotiator = ProtocolNegotiator::new();
         let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("2")], false);
 
-        let response = negotiator.handle_hello(&command).unwrap();
+        let response = negotiator
+            .handle_hello(&command, true, false, |_, _| HelloAuthResult::Authenticated)
+            .expect("handle_hello should succeed")
+            .0;
         assert_eq!(negotiator.current_version(), RespVersion::RESP2);
 
         if let RespData::Array(Some(items)) = response {
@@ -285,7 +348,10 @@ mod tests {
         let mut negotiator = ProtocolNegotiator::new();
         let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("3")], false);
 
-        let response = negotiator.handle_hello(&command).unwrap();
+        let response = negotiator
+            .handle_hello(&command, true, false, |_, _| HelloAuthResult::Authenticated)
+            .expect("handle_hello should succeed")
+            .0;
         assert_eq!(negotiator.current_version(), RespVersion::RESP3);
 
         if let RespData::Map(pairs) = response {
@@ -293,6 +359,24 @@ mod tests {
         } else {
             panic!("Expected map response for RESP3");
         }
+    }
+
+    #[test]
+    fn test_hello_noauth_when_unauthenticated() {
+        let mut negotiator = ProtocolNegotiator::new();
+        let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("3")], false);
+
+        let result = negotiator.handle_hello(&command, false, true, |_, _| {
+            panic!("authenticate should not be called without AUTH")
+        });
+
+        assert!(result.is_err());
+        let err = result
+            .expect_err("handle_hello should fail for unauthenticated client")
+            .to_string();
+        assert!(err.contains("NOAUTH"), "expected NOAUTH error, got {err}");
+        // Version must not switch when the command is rejected.
+        assert_eq!(negotiator.current_version(), RespVersion::RESP2);
     }
 
     #[test]
@@ -304,7 +388,9 @@ mod tests {
 
         // Switch to RESP3
         let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("3")], false);
-        negotiator.handle_hello(&command).unwrap();
+        negotiator
+            .handle_hello(&command, true, false, |_, _| HelloAuthResult::Authenticated)
+            .expect("handle_hello should succeed");
 
         // RESP3 supports new features
         assert!(negotiator.supports_feature("maps"));

--- a/src/resp/tests/integration_tests.rs
+++ b/src/resp/tests/integration_tests.rs
@@ -21,7 +21,7 @@ use bytes::Bytes;
 use resp::{
     command::{CommandType, RespCommand},
     encode::{RespEncode, RespEncoder},
-    negotiation::ProtocolNegotiator,
+    negotiation::{HelloAuthResult, ProtocolNegotiator},
     parse::{Parse, RespParse, RespParseResult},
     types::{RespData, RespVersion},
 };
@@ -216,13 +216,16 @@ fn test_protocol_negotiation_resp2() {
     let mut negotiator = ProtocolNegotiator::new();
     let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("2")], false);
 
-    let response = negotiator.handle_hello(&command).unwrap();
+    let response = negotiator
+        .handle_hello(&command, true, false, |_, _| HelloAuthResult::Authenticated)
+        .unwrap()
+        .0;
     assert_eq!(negotiator.current_version(), RespVersion::RESP2);
 
     // Should return array format for RESP2
     match response {
         RespData::Array(Some(items)) => {
-            assert!(items.len() >= 12); // At least basic server info
+            assert!(items.len() >= 14); // Basic server info + modules
             // Check that proto field is 2
             let proto_index = items
                 .iter()
@@ -239,13 +242,16 @@ fn test_protocol_negotiation_resp3() {
     let mut negotiator = ProtocolNegotiator::new();
     let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("3")], false);
 
-    let response = negotiator.handle_hello(&command).unwrap();
+    let response = negotiator
+        .handle_hello(&command, true, false, |_, _| HelloAuthResult::Authenticated)
+        .unwrap()
+        .0;
     assert_eq!(negotiator.current_version(), RespVersion::RESP3);
 
     // Should return map format for RESP3
     match response {
         RespData::Map(pairs) => {
-            assert!(pairs.len() >= 6); // At least basic server info
+            assert!(pairs.len() >= 7); // At least basic server info + modules
             // Check that proto field is 3
             let proto_pair = pairs
                 .iter()
@@ -271,9 +277,56 @@ fn test_protocol_negotiation_with_auth() {
         false,
     );
 
-    let _response = negotiator.handle_hello(&command).unwrap();
+    let _response = negotiator
+        .handle_hello(&command, false, true, |_, _| HelloAuthResult::Authenticated)
+        .unwrap();
     assert_eq!(negotiator.current_version(), RespVersion::RESP3);
-    assert!(negotiator.client_capabilities().contains_key("auth"));
+}
+
+#[test]
+fn test_protocol_negotiation_with_wrong_password() {
+    let mut negotiator = ProtocolNegotiator::new();
+    let command = RespCommand::new(
+        CommandType::Hello,
+        vec![
+            Bytes::from("3"),
+            Bytes::from("AUTH"),
+            Bytes::from("username"),
+            Bytes::from("password"),
+        ],
+        false,
+    );
+
+    let result =
+        negotiator.handle_hello(&command, false, true, |_, _| HelloAuthResult::WrongPassword);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("WRONGPASS"), "expected WRONGPASS, got {err}");
+}
+
+#[test]
+fn test_protocol_negotiation_with_no_password_configured() {
+    let mut negotiator = ProtocolNegotiator::new();
+    let command = RespCommand::new(
+        CommandType::Hello,
+        vec![
+            Bytes::from("3"),
+            Bytes::from("AUTH"),
+            Bytes::from("username"),
+            Bytes::from("password"),
+        ],
+        false,
+    );
+
+    let result = negotiator.handle_hello(&command, false, false, |_, _| {
+        HelloAuthResult::NoPasswordConfigured
+    });
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("HELLO AUTH called without any password configured"),
+        "expected no-password-configured error, got {err}"
+    );
 }
 
 #[test]
@@ -289,12 +342,60 @@ fn test_protocol_negotiation_with_setname() {
         false,
     );
 
-    let _response = negotiator.handle_hello(&command).unwrap();
+    let (_, set_name) = negotiator
+        .handle_hello(&command, true, false, |_, _| HelloAuthResult::Authenticated)
+        .unwrap();
     assert_eq!(negotiator.current_version(), RespVersion::RESP2);
+    assert_eq!(set_name, Some("my-client".to_string()));
     assert_eq!(
         negotiator.client_capabilities().get("client_name"),
         Some(&"my-client".to_string())
     );
+}
+
+#[test]
+fn test_protocol_negotiation_setname_not_persisted_on_failure() {
+    let mut negotiator = ProtocolNegotiator::new();
+    let command = RespCommand::new(
+        CommandType::Hello,
+        vec![
+            Bytes::from("3"),
+            Bytes::from("AUTH"),
+            Bytes::from("username"),
+            Bytes::from("password"),
+            Bytes::from("SETNAME"),
+            Bytes::from("my-client"),
+        ],
+        false,
+    );
+
+    let result =
+        negotiator.handle_hello(&command, false, true, |_, _| HelloAuthResult::WrongPassword);
+    assert!(result.is_err());
+    assert!(
+        negotiator
+            .client_capabilities()
+            .get("client_name")
+            .is_none(),
+        "client_name must not be persisted when HELLO fails"
+    );
+    assert_eq!(negotiator.current_version(), RespVersion::RESP2);
+}
+
+#[test]
+fn test_protocol_negotiation_noauth() {
+    let mut negotiator = ProtocolNegotiator::new();
+    let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("3")], false);
+
+    let result = negotiator.handle_hello(&command, false, true, |_, _| {
+        panic!("authenticate should not be called without AUTH")
+    });
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("NOAUTH"), "expected NOAUTH error, got {err}");
+    // The connection must stay on RESP2 since the command failed.
+    assert_eq!(negotiator.current_version(), RespVersion::RESP2);
 }
 
 #[test]
@@ -378,7 +479,9 @@ fn test_feature_support_detection() {
 
     // Switch to RESP3
     let command = RespCommand::new(CommandType::Hello, vec![Bytes::from("3")], false);
-    negotiator.handle_hello(&command).unwrap();
+    negotiator
+        .handle_hello(&command, true, false, |_, _| HelloAuthResult::Authenticated)
+        .unwrap();
 
     // Now supports RESP3 features
     assert!(negotiator.supports_feature("maps"));


### PR DESCRIPTION
本 PR 修复了 #311 中 HELLO 命令与 RESP 协议协商的 Redis 兼容性问题。

## 改动点

- **NOAUTH 校验**：当服务器配置了 `requirepass` 且客户端未认证、也没有通过 `HELLO ... AUTH` 提供密码时，返回 Redis 兼容的 `NOAUTH` 错误。
- **延迟切换 RESP 版本**：在所有认证和参数检查通过之后，才正式将连接的 RESP 版本切换到协商值。
- **SETNAME 生效**：`HELLO ... SETNAME <name>` 现在会真正设置客户端名称。
- **响应字段对齐**：移除 HELLO 响应里的自定义 `auth` / `client_name` 字段，新增 `modules` 空数组。
- **错误信息整理**：去掉内部错误消息里多余的 `-` 前缀。
- **旧连接处理**：`src/net/src/handle.rs` 使用 `client.resp_version()` 替代硬编码的 `RESP2`。
- **回归测试**：新增 NOAUTH 和 SETNAME 相关测试。

## 验证方式

```bash
make fmt
make lint
make build
make test
```

全部通过。

相关 PR：#311


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `HELLO` command, including protocol negotiation, optional authentication, and client name setup.
  * Client connections now use the negotiated RESP version for both reading requests and sending replies.

* **Bug Fixes**
  * Improved handling of unauthenticated connections with clearer `NOAUTH` and `WRONGPASS` responses.
  * Preserves negotiated protocol settings across commands on the same connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->