### PR TITLE
docs(agents): define subagent delegation policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,3 +173,13 @@ For multi-step tasks, state a brief plan:
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
+## Subagent Policy
+
+This project permits and requires the use of subagents when a task contains two or more independent, bounded workstreams that can be executed in parallel. The lead agent should delegate those workstreams without requesting separate approval for each delegation. Tasks that cannot be safely or usefully decomposed do not require a subagent.
+
+Using subagents does not expand the scope of the user's request or authorize additional state-changing actions. The lead agent remains responsible for defining non-overlapping ownership, coordinating the work, independently verifying material conclusions, resolving duplicate or conflicting findings, and producing the final result.
+
+For pull request reviews, all subagents must remain read-only unless the user explicitly requests fixes. They may inspect the diff and source code, trace callers and implementations, assess tests, and run non-modifying static checks or tests. Subagents must not post GitHub comments or independently issue the final severity or merge decision; the lead agent must verify and submit all inline comments and the final conclusion.
+
+Authorization to implement fixes does not authorize commit, push, merge, rebase, closing the pull request, or resolving review threads. Those actions require the authorization specified by the applicable review protocol.


### PR DESCRIPTION
## Summary
- define when independent workstreams should be delegated to subagents
- keep delegation within the user's authorization scope
- require read-only subagents during PR review unless fixes are explicitly requested
- reserve GitHub comments, severity, and merge decisions for the lead agent

## Validation
- `git diff --check`
- confirmed the commit changes only `CLAUDE.md`; `AGENTS.md` remains a symlink to it
- code tests not run because this is a documentation-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on when subagents may be used and the lead agent’s coordination responsibilities.
  * Clarified review permissions and restrictions, including limits on commenting, merging, committing, pushing, rebasing, and resolving review threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->