### PR TITLE
upgrade(storage): use rust-rocksdb maintenance tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2331,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "rust-librocksdb-sys"
 version = "0.47.1+11.1.2"
-source = "git+https://github.com/arana-db/rust-rocksdb?rev=dd1ac21a1c7176e5d71e145a0e4b941ec84ccf68#dd1ac21a1c7176e5d71e145a0e4b941ec84ccf68"
+source = "git+https://github.com/arana-db/rust-rocksdb?tag=v0.51.0-arana.1#971c792f3d6312204a5e162bd60d4d3c84a9e8a8"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2348,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "rust-rocksdb"
 version = "0.51.0"
-source = "git+https://github.com/arana-db/rust-rocksdb?rev=dd1ac21a1c7176e5d71e145a0e4b941ec84ccf68#dd1ac21a1c7176e5d71e145a0e4b941ec84ccf68"
+source = "git+https://github.com/arana-db/rust-rocksdb?tag=v0.51.0-arana.1#971c792f3d6312204a5e162bd60d4d3c84a9e8a8"
 dependencies = [
  "libc",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,9 @@ syn = { version = "3.0", features = ["extra-traits", "full"] }
 env_logger = "0.11"
 log = "0.4"
 # Kiwi uses the Arana-maintained arana-db/rust-rocksdb fork to provide the
-# TableProperties Collector/Factory FFI required by Storage LogIndex. Pinning an
-# exact revision keeps native dependency builds auditable and reproducible.
-rocksdb = { package = "rust-rocksdb", git = "https://github.com/arana-db/rust-rocksdb", rev = "dd1ac21a1c7176e5d71e145a0e4b941ec84ccf68", features = ["multi-threaded-cf"] }
+# TableProperties Collector/Factory FFI required by Storage LogIndex. The
+# maintenance tag names the baseline; Cargo.lock records the resolved commit.
+rocksdb = { package = "rust-rocksdb", git = "https://github.com/arana-db/rust-rocksdb", tag = "v0.51.0-arana.1", features = ["multi-threaded-cf"] }
 thiserror = "2.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ See [docs/cluster.md](docs/cluster.md) for the manual step-by-step procedure and
 
 ### RocksDB (Arana-maintained Fork)
 
-Kiwi uses the [Arana-maintained rust-rocksdb fork](https://github.com/arana-db/rust-rocksdb) to provide the TableProperties Collector/Factory FFI required by Storage LogIndex. The dependency is pinned to an exact revision so native builds are auditable and reproducible.
+Kiwi uses the [Arana-maintained rust-rocksdb fork](https://github.com/arana-db/rust-rocksdb) to provide the TableProperties Collector/Factory FFI required by Storage LogIndex. The dependency uses the maintenance release tag [`v0.51.0-arana.1`](https://github.com/arana-db/rust-rocksdb/tree/v0.51.0-arana.1). Published release tags must not be moved, and `Cargo.lock` records the exact resolved commit for auditable and reproducible builds.
 
 ## Contributing
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -114,9 +114,9 @@ redis-cli -p 7379 get foo         # "bar"
 
 ## 依赖说明
 
-### RocksDB（临时 Fork）
+### RocksDB（Arana 维护的 Fork）
 
-本项目使用 [rust-rocksdb 的自定义 fork](https://github.com/arana-db/rust-rocksdb/tree/addtableproperties)，因为官方 crate 尚不支持 Raft 模块所需的 TablePropertiesCollector FFI 函数。一旦官方 [rust-rocksdb](https://github.com/rust-rocksdb/rust-rocksdb) 支持所需功能，我们将切换回官方 crate。
+Kiwi 使用 [Arana 维护的 rust-rocksdb fork](https://github.com/arana-db/rust-rocksdb) 提供 Storage LogIndex 所需的 TableProperties Collector/Factory FFI。依赖使用维护发布标签 [`v0.51.0-arana.1`](https://github.com/arana-db/rust-rocksdb/tree/v0.51.0-arana.1)。已发布的标签不得移动，同时由 `Cargo.lock` 记录解析后的精确提交，保证构建可审计、可复现。
 
 ## 贡献
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -124,5 +124,5 @@ Storage tests use `tempfile::tempdir()` for isolated RocksDB instances.
 
 ## Gotchas
 
-- **RocksDB fork**: The project uses `arana-db/rust-rocksdb` (pinned to a specific rev), not the official `rust-rocksdb` crate. This fork adds TablePropertiesCollector FFI functions required by the Raft module.
+- **RocksDB fork**: The project uses the `v0.51.0-arana.1` maintenance release tag from `arana-db/rust-rocksdb`, not the official `rust-rocksdb` crate. Published release tags must not be moved. This fork adds the TableProperties Collector/Factory FFI required by Storage LogIndex, and `Cargo.lock` records the exact resolved commit.
 - **Binary name is `kiwi`**, not `server` — defined in `src/server/Cargo.toml` as `[[bin]] name = "kiwi"`.


### PR DESCRIPTION
## Summary

- switch the Arana-maintained `rust-rocksdb` dependency from the raw `dd1ac21` revision to the published `v0.51.0-arana.1` maintenance tag
- lock both `rust-rocksdb` and `rust-librocksdb-sys` to the tag's exact `971c792f3d6312204a5e162bd60d4d3c84a9e8a8` commit
- update the English, Chinese, and development documentation to describe the release-tag and lockfile policy

## Release baseline

- tag: [`v0.51.0-arana.1`](https://github.com/arana-db/rust-rocksdb/tree/v0.51.0-arana.1)
- commit: `971c792f3d6312204a5e162bd60d4d3c84a9e8a8`
- `rust-rocksdb`: `0.51.0`
- `rust-librocksdb-sys`: `0.47.1+11.1.2`
- RocksDB: `11.1.2`

Published maintenance tags must not be moved. `Cargo.lock` retains the exact resolved commit for `--locked` builds.

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- WSL/Linux: `cargo check -p storage --locked`
- WSL/Linux: `cargo test -p storage --lib logindex::table_properties --locked` — 6 passed
- WSL/Linux: `cargo test -p raft --test logindex_integration --locked` — 1 passed
- `git diff --check`

Full workspace tests, Clippy, and the platform matrix are left to GitHub CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated dependency documentation to reference the Arana-maintained RocksDB release tag `v0.51.0-arana.1`.
  * Clarified that published tags remain immutable and exact commits are recorded for auditable, reproducible builds.
  * Documented the fork’s required TableProperties FFI support for Storage LogIndex.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->