### PR TITLE
upgrade(storage): use rust-rocksdb v0.51.0-arana.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2331,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "rust-librocksdb-sys"
 version = "0.47.1+11.1.2"
-source = "git+https://github.com/arana-db/rust-rocksdb?tag=v0.51.0-arana.1#971c792f3d6312204a5e162bd60d4d3c84a9e8a8"
+source = "git+https://github.com/arana-db/rust-rocksdb?tag=v0.51.0-arana.2#d256effe16ad56702864c115ebed1e8c8f2dfda4"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2348,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "rust-rocksdb"
 version = "0.51.0"
-source = "git+https://github.com/arana-db/rust-rocksdb?tag=v0.51.0-arana.1#971c792f3d6312204a5e162bd60d4d3c84a9e8a8"
+source = "git+https://github.com/arana-db/rust-rocksdb?tag=v0.51.0-arana.2#d256effe16ad56702864c115ebed1e8c8f2dfda4"
 dependencies = [
  "libc",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ log = "0.4"
 # Kiwi uses the Arana-maintained arana-db/rust-rocksdb fork to provide the
 # TableProperties Collector/Factory FFI required by Storage LogIndex. The
 # maintenance tag names the baseline; Cargo.lock records the resolved commit.
-rocksdb = { package = "rust-rocksdb", git = "https://github.com/arana-db/rust-rocksdb", tag = "v0.51.0-arana.1", features = ["multi-threaded-cf"] }
+rocksdb = { package = "rust-rocksdb", git = "https://github.com/arana-db/rust-rocksdb", tag = "v0.51.0-arana.2", features = ["multi-threaded-cf"] }
 thiserror = "2.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ See [docs/cluster.md](docs/cluster.md) for the manual step-by-step procedure and
 
 ### RocksDB (Arana-maintained Fork)
 
-Kiwi uses the [Arana-maintained rust-rocksdb fork](https://github.com/arana-db/rust-rocksdb) to provide the TableProperties Collector/Factory FFI required by Storage LogIndex. The dependency uses the maintenance release tag [`v0.51.0-arana.1`](https://github.com/arana-db/rust-rocksdb/tree/v0.51.0-arana.1). Published release tags must not be moved, and `Cargo.lock` records the exact resolved commit for auditable and reproducible builds.
+Kiwi uses the [Arana-maintained rust-rocksdb fork](https://github.com/arana-db/rust-rocksdb) to provide the TableProperties Collector/Factory FFI required by Storage LogIndex. The dependency uses the maintenance release tag [`v0.51.0-arana.2`](https://github.com/arana-db/rust-rocksdb/tree/v0.51.0-arana.2). Published release tags must not be moved, and `Cargo.lock` records the exact resolved commit for auditable and reproducible builds.
 
 ## Contributing
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -116,7 +116,7 @@ redis-cli -p 7379 get foo         # "bar"
 
 ### RocksDB（Arana 维护的 Fork）
 
-Kiwi 使用 [Arana 维护的 rust-rocksdb fork](https://github.com/arana-db/rust-rocksdb) 提供 Storage LogIndex 所需的 TableProperties Collector/Factory FFI。依赖使用维护发布标签 [`v0.51.0-arana.1`](https://github.com/arana-db/rust-rocksdb/tree/v0.51.0-arana.1)。已发布的标签不得移动，同时由 `Cargo.lock` 记录解析后的精确提交，保证构建可审计、可复现。
+Kiwi 使用 [Arana 维护的 rust-rocksdb fork](https://github.com/arana-db/rust-rocksdb) 提供 Storage LogIndex 所需的 TableProperties Collector/Factory FFI。依赖使用维护发布标签 [`v0.51.0-arana.2`](https://github.com/arana-db/rust-rocksdb/tree/v0.51.0-arana.2)。已发布的标签不得移动，同时由 `Cargo.lock` 记录解析后的精确提交，保证构建可审计、可复现。
 
 ## 贡献
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -124,5 +124,5 @@ Storage tests use `tempfile::tempdir()` for isolated RocksDB instances.
 
 ## Gotchas
 
-- **RocksDB fork**: The project uses the `v0.51.0-arana.1` maintenance release tag from `arana-db/rust-rocksdb`, not the official `rust-rocksdb` crate. Published release tags must not be moved. This fork adds the TableProperties Collector/Factory FFI required by Storage LogIndex, and `Cargo.lock` records the exact resolved commit.
+- **RocksDB fork**: The project uses the `v0.51.0-arana.2` maintenance release tag from `arana-db/rust-rocksdb`, not the official `rust-rocksdb` crate. Published release tags must not be moved. This fork adds the TableProperties Collector/Factory FFI required by Storage LogIndex, and `Cargo.lock` records the exact resolved commit.
 - **Binary name is `kiwi`**, not `server` — defined in `src/server/Cargo.toml` as `[[bin]] name = "kiwi"`.


### PR DESCRIPTION
## Summary

- update Kiwi's Arana-maintained `rust-rocksdb` dependency from `v0.51.0-arana.1` to `v0.51.0-arana.2`
- lock both `rust-rocksdb` and `rust-librocksdb-sys` to the tag target commit `d256effe16ad56702864c115ebed1e8c8f2dfda4`
- update the English, Chinese, and development documentation to match the active maintenance baseline

## Release baseline

- tag: [`v0.51.0-arana.2`](https://github.com/arana-db/rust-rocksdb/tree/v0.51.0-arana.2)
- annotated tag object: `81b6826c8bc8250471246bcc190fd6903cabd34a`
- target commit: `d256effe16ad56702864c115ebed1e8c8f2dfda4`
- `rust-rocksdb`: `0.51.0`
- `rust-librocksdb-sys`: `0.47.1+11.1.2`
- RocksDB: `11.1.2`

The `.1` to `.2` release contains maintenance CI, metadata, documentation, and test-watchdog changes; it does not change the fork's production Rust/C++ implementation. Published maintenance tags remain immutable, while `Cargo.lock` records the exact resolved commit for `--locked` builds.

## Requirements context

- preserves the Arana fork and TableProperties Collector/Factory FFI used by the Storage/Raft persistence boundary (`REQ-STORAGE-001`, `REQ-STORAGE-002`)
- no Kiwi runtime behavior, data format, or requirement completion status changes

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- WSL/Linux: `cargo check -p storage --locked`
- WSL/Linux: `cargo test -p storage --lib logindex::table_properties --locked` — 6 passed
- WSL/Linux: `cargo test -p raft --test logindex_integration --locked` — 1 passed
- `git diff --check`
- exact five-file path-set audit; no active `.1` tag or `971c792...` lock reference remains

Full workspace tests, Clippy, and the platform matrix are left to GitHub CI.

## AI assistance

- AI assistance: code, documentation, validation, and PR preparation
- Human verification required before merge: review the full diff and required CI results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated dependency guidance to reference the latest Arana-maintained RocksDB release tag.
  * Updated English and Chinese README documentation and development guidance for consistency.
  * Preserved instructions for reproducible builds using the locked dependency revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->