### PR TITLE
build: pin Rust 1.97.1 toolchain baseline

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Setup toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
 
       - name: Install protoc
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Setup toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           components: rustfmt
 
       - name: Check formatting
@@ -84,7 +83,6 @@ jobs:
       - name: Setup toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           components: clippy
 
       - name: Configure sccache
@@ -152,8 +150,6 @@ jobs:
 
       - name: Setup toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
 
       - name: Configure sccache
         run: |
@@ -222,8 +218,6 @@ jobs:
 
       - name: Setup toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
 
       - name: Cache Cargo registry
         uses: actions/cache@v6
@@ -258,6 +252,8 @@ jobs:
   sanitizers:
     name: Sanitizers (${{ matrix.sanitizer }})
     runs-on: ubuntu-latest
+    env:
+      SANITIZER_TOOLCHAIN: nightly-2026-07-17
     strategy:
       fail-fast: false
       matrix:
@@ -268,7 +264,7 @@ jobs:
       - name: Setup Rust nightly with sanitizer support
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ env.SANITIZER_TOOLCHAIN }}
           components: rust-src
 
       - name: Install protoc
@@ -296,7 +292,7 @@ jobs:
             # the rest of the workspace and storage unit tests; regular tests and
             # ASan still cover the RocksDB-backed integration tests.
             {
-              cargo +nightly test -Z build-std --target x86_64-unknown-linux-gnu \
+              cargo +${SANITIZER_TOOLCHAIN} test -Z build-std --target x86_64-unknown-linux-gnu \
                 --workspace --exclude storage \
                 -- --skip cursor_snapshot_roundtrip \
                 --skip install_snapshot_with_existing_data \
@@ -305,11 +301,11 @@ jobs:
                 --skip test_on_binlog_write_updates_collector \
                 --skip test_collector_state_export_restore \
                 --skip storage_command_e2e_
-              cargo +nightly test -Z build-std --target x86_64-unknown-linux-gnu \
+              cargo +${SANITIZER_TOOLCHAIN} test -Z build-std --target x86_64-unknown-linux-gnu \
                 -p storage --lib
             } 2>&1 | tee sanitizer.log
           else
-            cargo +nightly test -Z build-std --target x86_64-unknown-linux-gnu 2>&1 | tee sanitizer.log
+            cargo +${SANITIZER_TOOLCHAIN} test -Z build-std --target x86_64-unknown-linux-gnu 2>&1 | tee sanitizer.log
           fi
 
       - name: Upload results on failure
@@ -351,8 +347,6 @@ jobs:
 
       - name: Setup toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
 
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,7 +349,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        run: cargo install cargo-audit --version 0.22.2 --locked
 
       - name: Security audit
         run: cargo audit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
 
       - name: Install protoc
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,6 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
         with:
-          toolchain: stable
           target: ${{ matrix.target }}
 
       - name: Install cross-compilation tools (Linux ARM64)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,8 +39,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        run: cargo install cargo-audit --version 0.22.2 --locked
 
       - name: Run cargo audit
         run: cargo audit
@@ -54,8 +57,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
       - name: Install cargo-deny
-        run: cargo install cargo-deny
+        run: cargo install cargo-deny --version 0.20.2 --locked
 
       - name: Check advisories and licenses
         run: cargo deny check advisories licenses

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,18 @@ make -C tests test-python
 
 ## Toolchain & Build Notes
 
-- The Rust toolchain is pinned in `rust-toolchain.toml` to `nightly-2025-08-20`.
+- Normal development, CI, and release builds use Rust 1.97.1 stable. The root
+  `rust-toolchain.toml` selects the exact toolchain automatically; verify it with
+  `rustup show active-toolchain` and `rustc --version --verbose`.
+- The source remains on Rust 2021 Edition. Rust 2024 Edition migration is a
+  separate follow-up change; do not treat it as part of the baseline update.
+- Dated nightly toolchains are reserved for specialized checks such as
+  Sanitizers and do not define the normal development baseline.
 - The first build compiles `librocksdb-sys` from source and can take ~18 minutes. Incremental builds with `sccache` are typically 30 seconds–2 minutes.
 - The project depends on a forked RocksDB crate (`arana-db/rust-rocksdb`) because upstream does not yet expose the `TablePropertiesCollector` FFI functions required by the Raft module. Do not switch to the official `rust-rocksdb` crate.
-- `protoc` (protobuf compiler) is required.
+- `protoc` (protobuf compiler) is required. Windows builds use the Rust MSVC
+  target and Visual Studio C++ build tools; Linux and macOS builds need the
+  project's native C/C++ build dependencies.
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,25 @@ Thank you for your interest in contributing to Kiwi!
 
 For development environment setup, build commands, and architecture overview, see [docs/development.md](docs/development.md).
 
+## Development Baseline
+
+Normal development, CI, and release builds use Rust 1.97.1 stable. The repository
+root contains `rust-toolchain.toml`, so rustup selects the exact toolchain
+automatically. Verify it with:
+
+```bash
+rustup show active-toolchain
+rustc --version --verbose
+```
+
+The source currently remains on Rust 2021 Edition. Migrating to Rust 2024 Edition
+is a separate follow-up change and is not part of the toolchain baseline update.
+Dated nightly toolchains are limited to specialized checks such as Sanitizers.
+
+`protoc` is required. Windows builds use the Rust MSVC target and the Visual
+Studio C++ build tools; Linux and macOS builds require the native C/C++ tooling
+documented in [docs/development.md](docs/development.md).
+
 ## Pull Request Workflow
 
 1. Fork the repository and clone your fork

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ description = "An enhanced Redis server implemented in Rust"
 readme = "README.md"
 repository = "https://github.com/arana-db/kiwi"
 edition = "2021"
+rust-version = "1.97.1"
 
 [workspace.lints.clippy]
 dbg_macro = "warn"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust:1.95-bookworm AS builder
+FROM rust:1.97.1-bookworm AS builder
 
 WORKDIR /kiwi
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,18 @@ Client → TCP accept [network runtime] → RESP parse → Command lookup
 
 ### Prerequisites
 
+Kiwi's normal development, CI, and release baseline is Rust 1.97.1 stable. After
+you clone the repository, `rust-toolchain.toml` makes rustup select that exact
+toolchain automatically. The source remains on Rust 2021 Edition; the Rust 2024
+Edition migration is a separate follow-up change.
+
+`protoc` and the native C/C++ tools needed to build RocksDB are also required.
+On Windows, use the Rust MSVC target and install the Visual Studio C++ build
+tools. On Linux and macOS, install the platform C/C++ build dependencies used by
+the project in addition to `protoc`.
+
 ```bash
-# Rust toolchain
+# Install rustup; rust-toolchain.toml selects Rust 1.97.1 stable in this repo
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 # protobuf compiler (macOS)
@@ -72,11 +82,18 @@ brew install protobuf
 apt install protobuf-compiler
 ```
 
+Dated nightly toolchains are reserved for specialized checks such as
+Sanitizers. They do not define the normal development or release baseline.
+
 ### Get the Code
 
 ```bash
 git clone https://github.com/arana-db/kiwi.git
 cd kiwi
+
+# Verify the compiler selected by this checkout
+rustup show active-toolchain
+rustc --version --verbose
 ```
 
 ### Standalone Mode

--- a/README_CN.md
+++ b/README_CN.md
@@ -61,8 +61,16 @@ Client → TCP accept [网络运行时] → RESP 解析 → 命令查找
 
 ### 环境要求
 
+Kiwi 的普通开发、CI 和发布基线是精确固定的 Rust 1.97.1 stable。克隆仓库后，
+`rust-toolchain.toml` 会让 rustup 自动选择该工具链。当前源码仍使用 Rust 2021
+Edition；Rust 2024 Edition 迁移将在后续独立变更中完成。
+
+项目还必须安装 `protoc`，以及编译 RocksDB 所需的原生 C/C++ 工具。Windows
+使用 Rust MSVC target，并安装 Visual Studio C++ 构建工具；Linux 和 macOS 除
+`protoc` 外，还需安装项目在对应平台使用的 C/C++ 构建依赖。
+
 ```bash
-# Rust 工具链
+# 安装 rustup；进入本仓库后由 rust-toolchain.toml 选择 Rust 1.97.1 stable
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 # protobuf 编译器 (macOS)
@@ -72,11 +80,17 @@ brew install protobuf
 apt install protobuf-compiler
 ```
 
+固定日期的 nightly 只用于 Sanitizer 等专项检查，不定义普通开发或发布基线。
+
 ### 获取代码
 
 ```bash
 git clone https://github.com/arana-db/kiwi.git
 cd kiwi
+
+# 核验当前 checkout 实际选择的编译器
+rustup show active-toolchain
+rustc --version --verbose
 ```
 
 ### 单机模式

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -6,7 +6,7 @@
 
 ## 环境要求
 
-- Rust 工具链（stable）和 `protoc`（参见项目 README / `docs/development.md`）。
+- Rust 1.97.1 工具链（由根 `rust-toolchain.toml` 自动选择）和 `protoc`（参见项目 README / `docs/development.md`）。
 - `redis-cli` — 用于操作 RESP 端口（`brew install redis` / `apt install redis-tools`）。
 - `grpcurl` — 用于调用 Raft admin gRPC API 进行集群初始化（`brew install grpcurl`）。
   Raft gRPC 服务已启用反射，无需 `.proto` 文件。

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,16 +2,44 @@
 
 ## Prerequisites
 
+Normal development, CI, and release builds use the exact Rust 1.97.1 stable
+toolchain pinned in the repository root. After rustup is installed,
+`rust-toolchain.toml` selects it automatically whenever commands run inside this
+repository. The source currently uses Rust 2021 Edition. Rust 2024 Edition is a
+separate follow-up migration, not part of this toolchain baseline.
+
+Kiwi also requires `protoc` and a native C/C++ toolchain because RocksDB is built
+from source:
+
+- Windows: use the Rust MSVC target and install Visual Studio Build Tools with
+  the C++ workload.
+- Linux: install `clang`, CMake, libclang/LLVM development packages,
+  `pkg-config`, and `protobuf-compiler` as required by the project build.
+- macOS: install the Xcode Command Line Tools and the corresponding project build
+  dependencies; Homebrew provides `protobuf` and CMake.
+
 ```bash
-# Rust toolchain
+# Install rustup; rust-toolchain.toml selects Rust 1.97.1 stable in this repo
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
-# protobuf compiler (macOS)
-brew install protobuf
+# macOS
+xcode-select --install
+brew install protobuf cmake
 
-# protobuf compiler (Linux)
-apt install protobuf-compiler
+# Debian/Ubuntu Linux
+sudo apt install clang cmake libclang-dev llvm-dev pkg-config protobuf-compiler
 ```
+
+Verify the compiler selected for the current checkout:
+
+```bash
+rustup show active-toolchain
+rustc --version --verbose
+```
+
+Dated nightly toolchains are used only by specialized checks such as
+Sanitizers. Do not use a floating `stable` channel or a nightly toolchain as the
+normal project baseline.
 
 ## Quick Start
 

--- a/docs/superpowers/plans/2026-07-25-rust-2024-edition.md
+++ b/docs/superpowers/plans/2026-07-25-rust-2024-edition.md
@@ -1,0 +1,49 @@
+# Rust 2024 Edition 迁移实现计划
+
+> **面向 AI 代理的工作者：** 必需子技能：使用 superpowers:subagent-driven-development（推荐）或 superpowers:executing-plans 逐任务实现此计划。步骤使用复选框（`- [ ]`）语法来跟踪进度。
+
+**目标：** 在 Rust 1.97.1 工具链基线 PR 之上，将所有 Kiwi 自有 crate 从 Rust 2021 Edition 迁移到 Rust 2024 Edition。
+
+**架构：** 所有 member 已经继承 workspace edition，因此语言代际只在根 `Cargo.toml` 切换。先由编译器在 2021 Edition 下应用保守迁移 lint，再切换 Edition，并逐项审查所有源码 Diff。
+
+**技术栈：** Rust 1.97.1 stable、Rust 2024 Edition、Cargo edition migration lint、Rustfmt 2024 style、Windows MSVC/Visual Studio C++ 构建工具、Linux/macOS 原生 C/C++ 工具链、Protoc 27.1。
+
+---
+
+### 任务 1：从 PR 1 的已验证 Head 建立 stacked 分支
+
+- [ ] 确认 PR 1 工作树干净、记录确切 Head，从该 Head 创建 `codex/rust-2024-edition` 隔离 worktree。
+- [ ] 运行 `rustup show active-toolchain` 和 `rustc --version --verbose`，确认 stacked checkout 仍使用 PR 1 固定的 Rust 1.97.1 stable。
+- [ ] 运行 `cargo metadata --locked --format-version 1 --no-deps` 和 `cargo fmt --all -- --check`，确认初始状态为 Edition 2021 / Rust 1.97.1。
+
+### 任务 2：生成并审计保守迁移 Diff
+
+**文件：**
+- 可能修改：`src/**/*.rs`
+
+- [ ] 在 Edition 2021 manifest、Windows MSVC + Protoc 27.1 环境运行 `cargo fix --edition --workspace --all-targets --all-features --allow-dirty --locked`，不使用 `--broken-code`。
+- [ ] 分文件审查 `git diff -- src`，重点检查 unsafe/FFI、宏 fragment、临时值/drop 顺序、环境变量 API 和 Prelude 方法解析。
+- [ ] 在 Edition 2021 下重跑 fmt、check 和严格 Clippy，通过后提交 `refactor: prepare code for Rust 2024`；如无源码变更，不创建空提交。
+
+### 任务 3：切换 workspace 到 Edition 2024
+
+**文件：**
+- 修改：`Cargo.toml`
+- 修改：`README.md`
+- 修改：`README_CN.md`
+- 修改：`CONTRIBUTING.md`
+- 修改：`CLAUDE.md`
+- 修改：`docs/development.md`
+
+- [ ] 将 workspace `edition = "2024"`，保持 `rust-version = "1.97.1"`。
+- [ ] 运行 `cargo metadata --locked --format-version 1 --no-deps`，确认所有 workspace package 都是 edition 2024 / rust_version 1.97.1。
+- [ ] 更新生效文档，删除 Edition 2021 过渡表述，保留工具链和 Nightly 边界。
+- [ ] 扫描生效配置和开发文档中的 Edition 2021 残留，提交 `build: migrate Kiwi to Rust 2024 edition`。
+
+### 任务 4：完整验证 PR 2
+
+- [ ] Windows MSVC + Protoc 27.1 执行 fmt、workspace check、严格 Clippy 和 workspace tests。
+- [ ] WSL/Linux 使用独立 target 重复 check、Clippy 和 tests。
+- [ ] 重建 Docker builder，确认 Edition 迁移不影响 release build。
+- [ ] 对 `<PR1_HEAD>...HEAD` 执行 `git diff --check`和变更集审计；PR 2 不得改工具链版本、Docker base、nightly 日期、依赖版本或业务功能。
+- [ ] 保存验证证据；不 push、不创建 GitHub PR，等待用户单独授权。

--- a/docs/superpowers/plans/2026-07-25-rust-toolchain-baseline.md
+++ b/docs/superpowers/plans/2026-07-25-rust-toolchain-baseline.md
@@ -1,0 +1,66 @@
+# Rust 1.97.1 工具链基线实现计划
+
+> **面向 AI 代理的工作者：** 必需子技能：使用 superpowers:subagent-driven-development（推荐）或 superpowers:executing-plans 逐任务实现此计划。步骤使用复选框（`- [ ]`）语法来跟踪进度。
+
+**目标：** 将 Kiwi 普通开发、CI、Docker 和发布工具链统一到 Rust 1.97.1 stable，同时保持 Rust 2021 Edition。
+
+**架构：** `rust-toolchain.toml` 定义实际工具链，workspace `rust-version` 定义 Cargo 合同，所有 member 继承合同。普通 Actions job 直接读取工具链文件，Sanitizer 使用独立 dated nightly。
+
+**技术栈：** Rust 1.97.1 stable、Cargo workspace、GitHub Actions、Docker Bookworm、Windows MSVC/Visual Studio C++ 构建工具、Linux/macOS 原生 C/C++ 工具链、Protoc 27.1。
+
+---
+
+### 任务 1：统一 Cargo workspace 和本地工具链
+
+**文件：**
+- 修改：`rust-toolchain.toml`
+- 修改：`Cargo.toml`
+- 修改：所有 workspace member `Cargo.toml`
+
+- [ ] 将 `rust-toolchain.toml` 设为 `channel = "1.97.1"`、`profile = "minimal"`、`components = ["rustfmt", "clippy"]`。
+- [ ] 在 `[workspace.package]` 保持 `edition = "2021"`，新增 `rust-version = "1.97.1"`。
+- [ ] 所有 member 使用 `edition.workspace = true` 和 `rust-version.workspace = true`；`client`/`cmd` 去掉显式 2021，不改变语义。
+- [ ] 运行 `cargo metadata --locked --format-version 1 --no-deps`，断言所有 `workspace_members` 对应 package 均为 edition 2021 / rust_version 1.97.1。
+- [ ] 运行 `cargo fmt --all -- --check` 和 `cargo check --workspace --all-features --locked`。
+- [ ] 只提交工具链和 manifest：`build: pin Rust 1.97.1 toolchain`。
+
+### 任务 2：统一 CI、Sanitizer 和 Docker
+
+**文件：**
+- 修改：`.github/workflows/ci.yml`
+- 修改：`.github/workflows/benchmark.yml`
+- 修改：`.github/workflows/codeql.yml`
+- 修改：`.github/workflows/release.yml`
+- 修改：`Dockerfile`
+
+- [ ] 普通 setup-rust-toolchain 步骤删除 `toolchain: stable`，由 action 读取根 `rust-toolchain.toml`。
+- [ ] Sanitizer job 定义 `SANITIZER_TOOLCHAIN: nightly-2026-07-17`，action input 使用 `${{ env.SANITIZER_TOOLCHAIN }}`，所有 `cargo +nightly` 改为 `cargo +${SANITIZER_TOOLCHAIN}`。
+- [ ] 确认 `https://static.rust-lang.org/dist/2026-07-17/channel-rust-nightly.toml` 存在。
+- [ ] Docker builder 改为 `FROM rust:1.97.1-bookworm AS builder`。
+- [ ] 运行 GitHub Actions YAML 语法检查，并人工审查全部 setup-rust-toolchain 和 Cargo override 行。
+- [ ] 提交：`ci: align builds with pinned Rust toolchain`。
+
+### 任务 3：更新开发者合同文档
+
+**文件：**
+- 修改：`README.md`
+- 修改：`README_CN.md`
+- 修改：`CONTRIBUTING.md`
+- 修改：`CLAUDE.md`
+- 修改：`docs/development.md`
+- 创建：本设计和两个计划文档
+
+- [ ] 记录 Rust 1.97.1 stable、Edition 2021 过渡状态、Nightly 专项边界、Protoc、Windows MSVC/Visual Studio C++ 工具链及 Linux/macOS 原生构建要求。
+- [ ] 记录 `rustup show active-toolchain` 和 `rustc --version --verbose`，用于核验当前 checkout 自动选择的工具链。
+- [ ] 删除生效文档中 `nightly-2025-08-20` 和浮动 stable 是标准的表述；历史 plan 证据不改写。
+- [ ] 运行 `rg` 残留扫描、`git diff --check`，并提交：`docs: define the Kiwi Rust baseline`。
+
+### 任务 4：完整验证 PR 1
+
+- [ ] 运行 `rustup show active-toolchain` 和 `rustc --version --verbose`，确认当前 checkout 使用 Rust 1.97.1 stable。
+- [ ] Windows 验证必须在 Visual Studio Developer Command Prompt 或已加载等价 VS C++ 环境的终端中执行；`rustc --version --verbose` 必须严格包含 `host: x86_64-pc-windows-msvc`，且 `where cl`（PowerShell 使用 `where.exe cl`）必须解析到可执行的 MSVC `cl.exe`。任一条件不满足时立即停止，不得把后续结果记为 Windows MSVC 验证。
+- [ ] Windows MSVC + Protoc 27.1：`cargo fmt --all -- --check`、`cargo check --workspace --all-features --locked`、`cargo clippy --all-features --workspace -- -D warnings -D clippy::unwrap_used`、`cargo test --workspace --all-features --locked`。
+- [ ] WSL/Linux 使用独立 target 重复 check、Clippy 和 test，不与 Windows 共享 native artifacts。
+- [ ] 运行 `docker build --target builder -t kiwi-rust-1.97.1-builder .`。
+- [ ] 运行 `git diff --check origin/main...HEAD`并确认无 Edition 2024 语义迁移或业务源码改动。
+- [ ] 保存验证证据；不 push、不创建 GitHub PR，等待用户单独授权。

--- a/docs/superpowers/plans/2026-07-25-rust-toolchain-baseline.md
+++ b/docs/superpowers/plans/2026-07-25-rust-toolchain-baseline.md
@@ -59,7 +59,7 @@
 
 - [ ] 运行 `rustup show active-toolchain` 和 `rustc --version --verbose`，确认当前 checkout 使用 Rust 1.97.1 stable。
 - [ ] Windows 验证必须在 Visual Studio Developer Command Prompt 或已加载等价 VS C++ 环境的终端中执行；`rustc --version --verbose` 必须严格包含 `host: x86_64-pc-windows-msvc`，且 `where cl`（PowerShell 使用 `where.exe cl`）必须解析到可执行的 MSVC `cl.exe`。任一条件不满足时立即停止，不得把后续结果记为 Windows MSVC 验证。
-- [ ] Windows MSVC + Protoc 27.1：`cargo fmt --all -- --check`、`cargo check --workspace --all-features --locked`、`cargo clippy --all-features --workspace -- -D warnings -D clippy::unwrap_used`、`cargo test --workspace --all-features --locked`。
+- [ ] Windows MSVC + Protoc 27.1：`cargo fmt --all -- --check`、`cargo check --workspace --all-features --locked`、`cargo clippy --locked --all-features --workspace -- -D warnings -D clippy::unwrap_used`、`cargo test --workspace --all-features --locked`。
 - [ ] WSL/Linux 使用独立 target 重复 check、Clippy 和 test，不与 Windows 共享 native artifacts。
 - [ ] 运行 `docker build --target builder -t kiwi-rust-1.97.1-builder .`。
 - [ ] 运行 `git diff --check origin/main...HEAD`并确认无 Edition 2024 语义迁移或业务源码改动。

--- a/docs/superpowers/specs/2026-07-25-rust-standard-design.md
+++ b/docs/superpowers/specs/2026-07-25-rust-standard-design.md
@@ -1,0 +1,58 @@
+# Kiwi Rust 语言标准设计
+
+## 决策
+
+Kiwi 的长期语言标准为 Rust 2024 Edition；当前普通开发、CI、Docker 和发布使用精确固定的 Rust 1.97.1 stable 工具链。
+
+工具链统一和 Edition 迁移拆成两个原子 PR：
+
+1. PR 1 将开发、CI、Docker 和发布工具链统一到 Rust 1.97.1 stable，声明 `rust-version = "1.97.1"`，但保持 Rust 2021 Edition。
+2. PR 2 只负责将 Kiwi 自有 workspace 迁移到 Rust 2024 Edition，并审计编译器迁移产生的源码变更。
+
+PR 2 基于 PR 1 的 Head；PR 1 合并前，PR 2 作为 stacked PR 审查。PR 1 合并后，PR 2 再基于最新 `main` 复核。
+
+## 工具链合同
+
+- `rust-toolchain.toml` 是普通开发和构建工具链的唯一真值源。
+- stable channel 必须使用完整三段版本号，禁止浮动 `stable`。
+- workspace `rust-version` 与批准工具链保持一致。如果未来需要承诺更低 MSRV，必须增加独立 MSRV CI 后再调整。
+- 所有 workspace package 通过 `edition.workspace = true` 和 `rust-version.workspace = true` 继承合同。Cargo 对实际 workspace 范围的判定以 `cargo metadata` 为准。
+- 普通 GitHub Actions job 不指定 `stable`，由 `actions-rust-lang/setup-rust-toolchain` 读取根目录工具链文件。
+- Docker builder 明确使用 `rust:1.97.1-bookworm`，修改时与工具链文件在同一工具链升级 PR 中复核。
+- Sanitizer 保留独立、精确日期的 nightly；它是质量工具，不定义产品语言标准。
+- `Cargo.lock` 继续提交，构建和发布使用 `--locked`。
+
+## 门禁设计
+
+门禁使用工具本身的权威语义：
+
+- `rustup show active-toolchain` 和 `rustc --version --verbose` 证明实际工具链。
+- `cargo metadata --locked --format-version 1 --no-deps` 证明每个 workspace package 的 Edition 和 `rust_version`。
+- GitHub Actions 安装步骤读取 `rust-toolchain.toml`，后续 Cargo 命令使用该 override。
+- Docker 执行真实 builder 构建，而不是只做文本匹配。
+- 静态残留扫描只作为人工审查证据，不能替代实际工具链、CI 或 Docker 验证。
+
+## 开发环境合同
+
+- `protoc` 是所有平台的必需依赖。
+- Windows 使用 Rust MSVC target 和 Visual Studio C++ 构建工具。
+- Linux 和 macOS 安装项目原生 RocksDB 构建所需的 C/C++ 工具链；各平台以项目开发文档和 CI 配置为准。
+- 开发者可运行 `rustup show active-toolchain` 和 `rustc --version --verbose` 核验当前 checkout 实际使用的编译器。
+
+## 验证边界
+
+PR 1 必须完成 Rust 1.97.1 的 fmt、Clippy、workspace check/test，Windows MSVC + Protoc 27.1 原生构建，WSL/Linux 独立 target 构建测试，以及 Docker builder 构建。
+
+PR 2 必须在相同工具链上重复全部门禁，另外执行 Edition 迁移 lint，并人工审计 `unsafe`、FFI、宏 fragment、临时值/drop 顺序和环境变量 API 的变更。
+
+## 升级政策
+
+- 每个 stable 发布后评估一次，通过独立 PR 显式升级。
+- point release 包含安全、误编译或重大正确性修复时优先升级。
+- 工具链升级 PR 不夹带业务功能、依赖大版本升级或 Edition 迁移。
+- 只有 Linux、macOS、Windows 的必需 checks 均通过，才更新批准基线。
+
+## 交付授权边界
+
+两个 PR 的本地实现、验证和提交不自动授权 push、创建或更新 GitHub PR、merge
+或关闭 Issue。每项远端写操作必须等待用户单独授权。

--- a/docs/superpowers/specs/2026-07-25-rust-standard-design.md
+++ b/docs/superpowers/specs/2026-07-25-rust-standard-design.md
@@ -20,7 +20,7 @@ PR 2 基于 PR 1 的 Head；PR 1 合并前，PR 2 作为 stacked PR 审查。PR 
 - 普通 GitHub Actions job 不指定 `stable`，由 `actions-rust-lang/setup-rust-toolchain` 读取根目录工具链文件。
 - Docker builder 明确使用 `rust:1.97.1-bookworm`，修改时与工具链文件在同一工具链升级 PR 中复核。
 - Sanitizer 保留独立、精确日期的 nightly；它是质量工具，不定义产品语言标准。
-- `Cargo.lock` 继续提交，构建和发布使用 `--locked`。
+- `Cargo.lock` 继续提交；发布、Docker 构建和本设计定义的基线验证命令使用 `--locked`。普通开发命令不强制该参数。
 
 ## 门禁设计
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,5 +16,6 @@
 # limitations under the License.
 
 [toolchain]
-channel = "nightly-2025-08-20"
-components = ["rustfmt", "clippy", "rust-src", "miri", "rust-analyzer"]
+channel = "1.97.1"
+profile = "minimal"
+components = ["rustfmt", "clippy"]

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "client"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "cmd"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/common/macro/Cargo.toml
+++ b/src/common/macro/Cargo.toml
@@ -2,6 +2,7 @@
 name = "common-macro"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/src/common/runtime/Cargo.toml
+++ b/src/common/runtime/Cargo.toml
@@ -3,6 +3,7 @@ name = "runtime"
 version.workspace = true
 description = "Dual runtime architecture for Kiwi database"
 edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "runtime"

--- a/src/conf/Cargo.toml
+++ b/src/conf/Cargo.toml
@@ -2,6 +2,7 @@
 name = "conf"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/src/executor/Cargo.toml
+++ b/src/executor/Cargo.toml
@@ -5,6 +5,7 @@ description.workspace = true
 readme.workspace = true
 repository.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 tokio = { workspace = true }

--- a/src/kstd/Cargo.toml
+++ b/src/kstd/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kstd"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true 

--- a/src/kstd/src/lock_mgr.rs
+++ b/src/kstd/src/lock_mgr.rs
@@ -241,11 +241,12 @@ impl<'a> Drop for ScopeRecordMultiLock<'a> {
 #[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicI32, AtomicI64, AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier};
     use std::thread;
     use std::time::Duration;
+
+    use super::*;
 
     #[test]
     fn test_basic_lock_unlock() {
@@ -447,17 +448,23 @@ mod tests {
     fn test_parallel_try_multi_lock() {
         let mgr = Arc::new(LockMgr::new(16));
         let counter = Arc::new(AtomicUsize::new(0));
+        let start = Arc::new(Barrier::new(4));
+        let attempted = Arc::new(Barrier::new(4));
 
         let handles: Vec<_> = (0..4)
             .map(|_| {
                 let mgr = mgr.clone();
                 let counter = counter.clone();
+                let start = start.clone();
+                let attempted = attempted.clone();
                 thread::spawn(move || {
-                    if let Some(_guard) = ScopeRecordMultiLock::try_new(&mgr, ["p", "q"]) {
+                    start.wait();
+                    let guard = ScopeRecordMultiLock::try_new(&mgr, ["p", "q"]);
+                    if guard.is_some() {
                         counter.fetch_add(1, Ordering::SeqCst);
-                        thread::sleep(Duration::from_millis(50));
-                        // guard is only released when it leaves the scope
                     }
+                    attempted.wait();
+                    drop(guard);
                 })
             })
             .collect();

--- a/src/net/Cargo.toml
+++ b/src/net/Cargo.toml
@@ -2,6 +2,7 @@
 name = "net"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true 

--- a/src/raft/Cargo.toml
+++ b/src/raft/Cargo.toml
@@ -2,6 +2,7 @@
 name = "raft"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 openraft = { workspace = true, features = ["storage-v2", "serde"] }

--- a/src/resp/Cargo.toml
+++ b/src/resp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "resp"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -5,6 +5,7 @@ description.workspace = true
 readme.workspace = true
 repository.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [[bin]]
 name = "kiwi"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -2,6 +2,7 @@
 name = "storage"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [features]
 test-fault-injection = []


### PR DESCRIPTION
## Summary

- pin the ordinary Kiwi development toolchain and workspace `rust-version` to Rust 1.97.1 while keeping Cargo Edition 2021
- align GitHub Actions, the dated sanitizer nightly, Docker builder, security audit tools, and developer documentation with the fixed baseline
- stabilize the existing multi-lock contention test so the Windows gate no longer depends on scheduler timing

This is PR 1 of a two-PR migration. Rust 2024 Edition is intentionally deferred to the stacked follow-up PR.

## Toolchain contract

- stable toolchain: `1.97.1`
- workspace Edition: `2021`
- sanitizer exception: `nightly-2026-07-17`
- Docker builder: `rust:1.97.1-bookworm`
- cargo-audit: `0.22.2 --locked`
- cargo-deny: `0.20.2 --locked`

## Verification

### WSL/Linux — passed

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-features --locked`
- `cargo clippy --locked --all-features --workspace -- -D warnings -D clippy::unwrap_used`
- `cargo test --workspace --all-features --locked`
  - 42 test/doc-test suites
  - 997 passed
  - 0 failed
  - 2 ignored

### Windows/MSVC — partial pass with confirmed Base failure

Passed with Rust 1.97.1 MSVC and Protoc 27.1:

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-features --locked`
- `cargo clippy --locked --all-features --workspace -- -D warnings -D clippy::unwrap_used`

`cargo test --workspace --all-features --locked` exits 101 after 188 passed / 8 failed. All failures are existing `storage_command_e2e_*` startup failures at `storage_command_e2e_tests.rs:158` (`server did not become connectable`).

The exact E2E test was repeated under three combinations:

| Source | Toolchain | Result |
|---|---|---:|
| PR Head | Rust 1.97.1 MSVC | 0/3 passed |
| `origin/main` | Rust 1.97.1 MSVC | 0/3 passed |
| `origin/main` | original `nightly-2025-08-20` MSVC | 0/3 passed |

The test, network server/runtime sources, and `Cargo.lock` have identical Base/Head blobs. The Windows failure is therefore not introduced by this PR or by Rust 1.97.1. It remains a repository baseline issue and is intentionally not hidden or reported as passing.

### Static/configuration checks — passed

- `cargo metadata --locked --format-version 1 --no-deps`: all 12 workspace packages are Edition 2021 with `rust_version = 1.97.1`
- actionlint v1.7.12 across all 9 workflow files
- `git diff --check`
- no `Cargo.lock` change
- no active Cargo Edition 2024 migration

## Local verification boundaries

- Docker builder was not run locally because no Docker daemon was available.
- macOS and GitHub-hosted runner execution are delegated to remote CI.
- Python integration tests requiring a running Kiwi server were not run locally.

## Base movement after local verification

The full local validation above used Base `89bd840919a4650ea718ea39f27cde869f49da74`. Before creating this Draft PR, `main` advanced to `7ed58dd10d8c98c7e3fa69e91f60c4889e783e8d` through `upgrade(storage): use rust-rocksdb v0.51.0-arana.2 (#369)`.

A three-way merge-tree check found no conflicts. The new Base overlaps this PR in `Cargo.toml`, `README.md`, `README_CN.md`, and `docs/development.md`; therefore the authoritative combined validation is the GitHub merge-ref CI for this Draft PR. The branch has not been rebased automatically, avoiding an unrequested rewrite of the verified commits.

## Review status

Draft: do not merge until required checks complete and the final merge ref has been reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build & Compatibility**
  - Standardized development, CI, Docker, and release builds on Rust 1.97.1 stable.
  - Added a minimum supported Rust version requirement for workspace components.
  - Kept Rust 2021 Edition as the current baseline.

- **Security & Quality**
  - Improved consistency by pinning security audit tool versions.
  - Made sanitizer checks use a configurable nightly toolchain.

- **Documentation**
  - Expanded setup guidance, including protobuf and platform-specific native build requirements.
  - Added instructions for verifying the active Rust toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->