### PR TITLE
test(compat): add Redis 8.8.1 manifest foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,6 +1447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kiwi-compat"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "thiserror 2.0.19",
+ "yaml_serde",
+]
+
+[[package]]
 name = "kstd"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,12 @@ members = [
 	"src/client",
 	"src/raft",
 	"tools/runtime-baseline",
+	"tools/compat",
 ]
 
-# Keep ordinary root builds on the twelve production crates. The benchmark
-# harness opts in explicitly so its future runtime feature cannot unify into
-# the normal server build.
+# Keep the runtime benchmark harness opt-in so its future runtime feature cannot
+# unify into normal server builds. Include compatibility tooling so ordinary
+# root tests exercise its manifest contracts.
 default-members = [
 	"src/storage",
 	"src/kstd",
@@ -32,6 +33,7 @@ default-members = [
 	"src/executor",
 	"src/client",
 	"src/raft",
+	"tools/compat",
 ]
 
 [workspace.package]
@@ -68,6 +70,7 @@ rocksdb = { package = "rust-rocksdb", git = "https://github.com/arana-db/rust-ro
 thiserror = "2.0"
 serde = "1.0"
 serde_json = "1.0"
+yaml_serde = "0.10.4"
 once_cell = "1.21"
 nom = "8.0.0"
 num_cpus = "1.15"

--- a/tests/compat/redis-8.8.1/manifest.yaml
+++ b/tests/compat/redis-8.8.1/manifest.yaml
@@ -1,3 +1,20 @@
+# Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 schema: kiwi-redis-compat/v1
 profile: redis_8_8_1_core
 redis:

--- a/tests/compat/redis-8.8.1/manifest.yaml
+++ b/tests/compat/redis-8.8.1/manifest.yaml
@@ -1,0 +1,6 @@
+schema: kiwi-redis-compat/v1
+profile: redis_8_8_1_core
+redis:
+  tag: 8.8.1
+  commit: 77b6c308396c9700672390a210143a8496fb4b10
+commands: []

--- a/tests/compat/redis-8.8.1/manifest.yaml
+++ b/tests/compat/redis-8.8.1/manifest.yaml
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 schema: kiwi-redis-compat/v1
-profile: redis_8_8_1_core
+profile: redis_8_8_1_standalone_cache_off
 redis:
   tag: 8.8.1
   commit: 77b6c308396c9700672390a210143a8496fb4b10

--- a/tools/compat/Cargo.toml
+++ b/tools/compat/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "kiwi-compat"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
+yaml_serde.workspace = true
+
+[lints]
+workspace = true

--- a/tools/compat/src/lib.rs
+++ b/tools/compat/src/lib.rs
@@ -1,0 +1,18 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod manifest;

--- a/tools/compat/src/manifest.rs
+++ b/tools/compat/src/manifest.rs
@@ -16,8 +16,10 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::fmt;
 
-use serde::Deserialize;
+use serde::de::{Error as _, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer};
 use thiserror::Error;
 
 pub const MANIFEST_SCHEMA: &str = "kiwi-redis-compat/v1";
@@ -27,7 +29,7 @@ pub const REDIS_COMMIT: &str = "77b6c308396c9700672390a210143a8496fb4b10";
 #[derive(Debug, PartialEq, Eq)]
 pub struct CompatibilityManifest {
     schema: String,
-    profile: String,
+    profile: Profile,
     redis: RedisBaseline,
     commands: Vec<CommandContract>,
 }
@@ -42,8 +44,8 @@ impl CompatibilityManifest {
         &self.schema
     }
 
-    pub fn profile(&self) -> &str {
-        &self.profile
+    pub fn profile(&self) -> Profile {
+        self.profile
     }
 
     pub fn redis(&self) -> &RedisBaseline {
@@ -83,11 +85,48 @@ impl CompatibilityManifest {
                 });
             }
 
-            if raw_command.modes.is_empty() {
+            if raw_command.modes.0.is_empty() {
                 return Err(ManifestError::EmptyModes { index });
             }
             if raw_command.protocols.is_empty() {
                 return Err(ManifestError::EmptyProtocols { index });
+            }
+            let requires_test_evidence = raw_command.classification.is_required()
+                || raw_command
+                    .modes
+                    .0
+                    .values()
+                    .any(RawClassification::is_required);
+            if requires_test_evidence && raw_command.tests.is_empty() {
+                return Err(ManifestError::EmptyTests { index });
+            }
+            let requires_known_difference = raw_command.classification.is_known_difference()
+                || raw_command
+                    .modes
+                    .0
+                    .values()
+                    .any(RawClassification::is_known_difference);
+            if requires_known_difference && raw_command.known_differences.is_empty() {
+                return Err(ManifestError::MissingKnownDifferences { index });
+            }
+            if !requires_known_difference && !raw_command.known_differences.is_empty() {
+                return Err(ManifestError::UnexpectedKnownDifferences { index });
+            }
+            for (difference_index, difference) in raw_command.known_differences.iter().enumerate() {
+                for (field, value) in [
+                    ("owner", difference.owner.as_str()),
+                    ("issue", difference.issue.as_str()),
+                    ("reason", difference.reason.as_str()),
+                    ("remove_when", difference.remove_when.as_str()),
+                ] {
+                    if value.trim().is_empty() {
+                        return Err(ManifestError::EmptyKnownDifferenceField {
+                            index,
+                            difference_index,
+                            field,
+                        });
+                    }
+                }
             }
             if raw_command.owner.trim().is_empty() {
                 return Err(ManifestError::EmptyOwner { index });
@@ -98,17 +137,28 @@ impl CompatibilityManifest {
                 classification: raw_command.classification.into(),
                 modes: raw_command
                     .modes
+                    .0
                     .into_iter()
                     .map(|(mode, classification)| (mode.into(), classification.into()))
                     .collect(),
                 protocols: raw_command.protocols.into_iter().map(Into::into).collect(),
+                arguments: raw_command.arguments.into(),
+                reply_schema: raw_command.reply_schema.into(),
+                errors: raw_command.errors.into(),
+                ttl_semantics: raw_command.ttl_semantics.into(),
+                tests: raw_command.tests.into_iter().map(Into::into).collect(),
+                known_differences: raw_command
+                    .known_differences
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
                 owner: raw_command.owner,
             });
         }
 
         Ok(Self {
             schema: raw.schema,
-            profile: raw.profile,
+            profile: raw.profile.into(),
             redis: RedisBaseline {
                 tag: raw.redis.tag,
                 commit: raw.redis.commit,
@@ -116,6 +166,18 @@ impl CompatibilityManifest {
             commands,
         })
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Profile {
+    Redis881CoreResp2,
+    Redis881CoreResp3,
+    Redis881Runtime,
+    Redis881ClientEcosystem,
+    Redis881StandaloneCacheOff,
+    Redis881RaftSingleGroupCacheOff,
+    KiwiRocksdbAuthorityV1,
+    KiwiRedisraftPublicV1,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -140,6 +202,12 @@ pub struct CommandContract {
     classification: Classification,
     modes: BTreeMap<Mode, Classification>,
     protocols: Vec<Protocol>,
+    arguments: ArgumentSemantics,
+    reply_schema: ReplySchema,
+    errors: ErrorSemantics,
+    ttl_semantics: TtlSemantics,
+    tests: Vec<TestEvidence>,
+    known_differences: Vec<KnownDifference>,
     owner: String,
 }
 
@@ -158,6 +226,30 @@ impl CommandContract {
 
     pub fn protocols(&self) -> &[Protocol] {
         &self.protocols
+    }
+
+    pub fn arguments(&self) -> ArgumentSemantics {
+        self.arguments
+    }
+
+    pub fn reply_schema(&self) -> ReplySchema {
+        self.reply_schema
+    }
+
+    pub fn errors(&self) -> ErrorSemantics {
+        self.errors
+    }
+
+    pub fn ttl_semantics(&self) -> TtlSemantics {
+        self.ttl_semantics
+    }
+
+    pub fn tests(&self) -> &[TestEvidence] {
+        &self.tests
+    }
+
+    pub fn known_differences(&self) -> &[KnownDifference] {
+        &self.known_differences
     }
 
     pub fn owner(&self) -> &str {
@@ -185,13 +277,100 @@ pub enum Protocol {
     Resp3,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ArgumentSemantics {
+    Exact,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReplySchema {
+    Exact,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ErrorSemantics {
+    ExactPrefix,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TtlSemantics {
+    Applicable,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TestEvidence {
+    WireDifferential,
+    FinalState,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct KnownDifference {
+    owner: String,
+    issue: String,
+    reason: String,
+    remove_when: String,
+}
+
+impl KnownDifference {
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+
+    pub fn issue(&self) -> &str {
+        &self.issue
+    }
+
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+
+    pub fn remove_when(&self) -> &str {
+        &self.remove_when
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawCompatibilityManifest {
     schema: String,
-    profile: String,
+    profile: RawProfile,
     redis: RawRedisBaseline,
     commands: Vec<RawCommandContract>,
+}
+
+#[derive(Debug, Deserialize)]
+enum RawProfile {
+    #[serde(rename = "redis_8_8_1_core_resp2")]
+    Redis881CoreResp2,
+    #[serde(rename = "redis_8_8_1_core_resp3")]
+    Redis881CoreResp3,
+    #[serde(rename = "redis_8_8_1_runtime")]
+    Redis881Runtime,
+    #[serde(rename = "redis_8_8_1_client_ecosystem")]
+    Redis881ClientEcosystem,
+    #[serde(rename = "redis_8_8_1_standalone_cache_off")]
+    Redis881StandaloneCacheOff,
+    #[serde(rename = "redis_8_8_1_raft_single_group_cache_off")]
+    Redis881RaftSingleGroupCacheOff,
+    #[serde(rename = "kiwi_rocksdb_authority_v1")]
+    KiwiRocksdbAuthorityV1,
+    #[serde(rename = "kiwi_redisraft_public_v1")]
+    KiwiRedisraftPublicV1,
+}
+
+impl From<RawProfile> for Profile {
+    fn from(raw: RawProfile) -> Self {
+        match raw {
+            RawProfile::Redis881CoreResp2 => Self::Redis881CoreResp2,
+            RawProfile::Redis881CoreResp3 => Self::Redis881CoreResp3,
+            RawProfile::Redis881Runtime => Self::Redis881Runtime,
+            RawProfile::Redis881ClientEcosystem => Self::Redis881ClientEcosystem,
+            RawProfile::Redis881StandaloneCacheOff => Self::Redis881StandaloneCacheOff,
+            RawProfile::Redis881RaftSingleGroupCacheOff => Self::Redis881RaftSingleGroupCacheOff,
+            RawProfile::KiwiRocksdbAuthorityV1 => Self::KiwiRocksdbAuthorityV1,
+            RawProfile::KiwiRedisraftPublicV1 => Self::KiwiRedisraftPublicV1,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -206,9 +385,51 @@ struct RawRedisBaseline {
 struct RawCommandContract {
     command: String,
     classification: RawClassification,
-    modes: BTreeMap<RawMode, RawClassification>,
+    modes: RawModes,
     protocols: Vec<RawProtocol>,
+    arguments: RawArgumentSemantics,
+    reply_schema: RawReplySchema,
+    errors: RawErrorSemantics,
+    ttl_semantics: RawTtlSemantics,
+    tests: Vec<RawTestEvidence>,
+    known_differences: Vec<RawKnownDifference>,
     owner: String,
+}
+
+#[derive(Debug)]
+struct RawModes(BTreeMap<RawMode, RawClassification>);
+
+impl<'de> Deserialize<'de> for RawModes {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(RawModesVisitor)
+    }
+}
+
+struct RawModesVisitor;
+
+impl<'de> Visitor<'de> for RawModesVisitor {
+    type Value = RawModes;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a mapping of unique compatibility modes to classifications")
+    }
+
+    fn visit_map<A>(self, mut entries: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut modes = BTreeMap::new();
+        while let Some((mode, classification)) = entries.next_entry()? {
+            if modes.contains_key(&mode) {
+                return Err(A::Error::custom(format!("duplicate mode {mode:?}")));
+            }
+            modes.insert(mode, classification);
+        }
+        Ok(RawModes(modes))
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -218,6 +439,16 @@ enum RawClassification {
     KnownDifference,
     Deferred,
     Unsupported,
+}
+
+impl RawClassification {
+    fn is_required(&self) -> bool {
+        matches!(self, Self::Required)
+    }
+
+    fn is_known_difference(&self) -> bool {
+        matches!(self, Self::KnownDifference)
+    }
 }
 
 impl From<RawClassification> for Classification {
@@ -263,6 +494,98 @@ impl From<RawProtocol> for Protocol {
     }
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum RawArgumentSemantics {
+    Exact,
+}
+
+impl From<RawArgumentSemantics> for ArgumentSemantics {
+    fn from(raw: RawArgumentSemantics) -> Self {
+        match raw {
+            RawArgumentSemantics::Exact => Self::Exact,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum RawReplySchema {
+    Exact,
+}
+
+impl From<RawReplySchema> for ReplySchema {
+    fn from(raw: RawReplySchema) -> Self {
+        match raw {
+            RawReplySchema::Exact => Self::Exact,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum RawErrorSemantics {
+    ExactPrefix,
+}
+
+impl From<RawErrorSemantics> for ErrorSemantics {
+    fn from(raw: RawErrorSemantics) -> Self {
+        match raw {
+            RawErrorSemantics::ExactPrefix => Self::ExactPrefix,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum RawTtlSemantics {
+    Applicable,
+}
+
+impl From<RawTtlSemantics> for TtlSemantics {
+    fn from(raw: RawTtlSemantics) -> Self {
+        match raw {
+            RawTtlSemantics::Applicable => Self::Applicable,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum RawTestEvidence {
+    WireDifferential,
+    FinalState,
+}
+
+impl From<RawTestEvidence> for TestEvidence {
+    fn from(raw: RawTestEvidence) -> Self {
+        match raw {
+            RawTestEvidence::WireDifferential => Self::WireDifferential,
+            RawTestEvidence::FinalState => Self::FinalState,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawKnownDifference {
+    owner: String,
+    issue: String,
+    reason: String,
+    remove_when: String,
+}
+
+impl From<RawKnownDifference> for KnownDifference {
+    fn from(raw: RawKnownDifference) -> Self {
+        Self {
+            owner: raw.owner,
+            issue: raw.issue,
+            reason: raw.reason,
+            remove_when: raw.remove_when,
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum ManifestError {
     #[error("failed to parse compatibility manifest: {0}")]
@@ -288,6 +611,22 @@ pub enum ManifestError {
     EmptyModes { index: usize },
     #[error("commands[{index}].protocols must not be empty")]
     EmptyProtocols { index: usize },
+    #[error("commands[{index}].tests must not be empty when the command is required")]
+    EmptyTests { index: usize },
+    #[error(
+        "commands[{index}].known_differences must not be empty when the command has a known difference"
+    )]
+    MissingKnownDifferences { index: usize },
+    #[error(
+        "commands[{index}].known_differences must be empty unless the command has a known_difference classification"
+    )]
+    UnexpectedKnownDifferences { index: usize },
+    #[error("commands[{index}].known_differences[{difference_index}].{field} must not be empty")]
+    EmptyKnownDifferenceField {
+        index: usize,
+        difference_index: usize,
+        field: &'static str,
+    },
     #[error("commands[{index}].owner must not be empty")]
     EmptyOwner { index: usize },
 }

--- a/tools/compat/src/manifest.rs
+++ b/tools/compat/src/manifest.rs
@@ -1,0 +1,293 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+use thiserror::Error;
+
+pub const MANIFEST_SCHEMA: &str = "kiwi-redis-compat/v1";
+pub const REDIS_TAG: &str = "8.8.1";
+pub const REDIS_COMMIT: &str = "77b6c308396c9700672390a210143a8496fb4b10";
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct CompatibilityManifest {
+    schema: String,
+    profile: String,
+    redis: RedisBaseline,
+    commands: Vec<CommandContract>,
+}
+
+impl CompatibilityManifest {
+    pub fn from_yaml(input: &str) -> Result<Self, ManifestError> {
+        let raw: RawCompatibilityManifest = yaml_serde::from_str(input)?;
+        Self::validate(raw)
+    }
+
+    pub fn schema(&self) -> &str {
+        &self.schema
+    }
+
+    pub fn profile(&self) -> &str {
+        &self.profile
+    }
+
+    pub fn redis(&self) -> &RedisBaseline {
+        &self.redis
+    }
+
+    pub fn commands(&self) -> &[CommandContract] {
+        &self.commands
+    }
+
+    fn validate(raw: RawCompatibilityManifest) -> Result<Self, ManifestError> {
+        if raw.schema != MANIFEST_SCHEMA {
+            return Err(ManifestError::InvalidSchema { actual: raw.schema });
+        }
+
+        if raw.redis.tag != REDIS_TAG || raw.redis.commit != REDIS_COMMIT {
+            return Err(ManifestError::InvalidRedisIdentity {
+                actual_tag: raw.redis.tag,
+                actual_commit: raw.redis.commit,
+            });
+        }
+
+        let mut command_indexes = BTreeMap::new();
+        let mut commands = Vec::with_capacity(raw.commands.len());
+        for (index, raw_command) in raw.commands.into_iter().enumerate() {
+            let mut command = raw_command.command;
+            if command.is_empty() || !command.bytes().all(|byte| (b'!'..=b'~').contains(&byte)) {
+                return Err(ManifestError::InvalidCommand { command, index });
+            }
+            command.make_ascii_uppercase();
+
+            if let Some(first_index) = command_indexes.insert(command.clone(), index) {
+                return Err(ManifestError::DuplicateCommand {
+                    command,
+                    first_index,
+                    index,
+                });
+            }
+
+            if raw_command.modes.is_empty() {
+                return Err(ManifestError::EmptyModes { index });
+            }
+            if raw_command.protocols.is_empty() {
+                return Err(ManifestError::EmptyProtocols { index });
+            }
+            if raw_command.owner.trim().is_empty() {
+                return Err(ManifestError::EmptyOwner { index });
+            }
+
+            commands.push(CommandContract {
+                command,
+                classification: raw_command.classification.into(),
+                modes: raw_command
+                    .modes
+                    .into_iter()
+                    .map(|(mode, classification)| (mode.into(), classification.into()))
+                    .collect(),
+                protocols: raw_command.protocols.into_iter().map(Into::into).collect(),
+                owner: raw_command.owner,
+            });
+        }
+
+        Ok(Self {
+            schema: raw.schema,
+            profile: raw.profile,
+            redis: RedisBaseline {
+                tag: raw.redis.tag,
+                commit: raw.redis.commit,
+            },
+            commands,
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct RedisBaseline {
+    tag: String,
+    commit: String,
+}
+
+impl RedisBaseline {
+    pub fn tag(&self) -> &str {
+        &self.tag
+    }
+
+    pub fn commit(&self) -> &str {
+        &self.commit
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct CommandContract {
+    command: String,
+    classification: Classification,
+    modes: BTreeMap<Mode, Classification>,
+    protocols: Vec<Protocol>,
+    owner: String,
+}
+
+impl CommandContract {
+    pub fn command(&self) -> &str {
+        &self.command
+    }
+
+    pub fn classification(&self) -> Classification {
+        self.classification
+    }
+
+    pub fn modes(&self) -> &BTreeMap<Mode, Classification> {
+        &self.modes
+    }
+
+    pub fn protocols(&self) -> &[Protocol] {
+        &self.protocols
+    }
+
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Classification {
+    Required,
+    KnownDifference,
+    Deferred,
+    Unsupported,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Mode {
+    StandaloneCacheOff,
+    RaftSingleGroupCacheOff,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Protocol {
+    Resp2,
+    Resp3,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawCompatibilityManifest {
+    schema: String,
+    profile: String,
+    redis: RawRedisBaseline,
+    commands: Vec<RawCommandContract>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawRedisBaseline {
+    tag: String,
+    commit: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawCommandContract {
+    command: String,
+    classification: RawClassification,
+    modes: BTreeMap<RawMode, RawClassification>,
+    protocols: Vec<RawProtocol>,
+    owner: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RawClassification {
+    Required,
+    KnownDifference,
+    Deferred,
+    Unsupported,
+}
+
+impl From<RawClassification> for Classification {
+    fn from(raw: RawClassification) -> Self {
+        match raw {
+            RawClassification::Required => Self::Required,
+            RawClassification::KnownDifference => Self::KnownDifference,
+            RawClassification::Deferred => Self::Deferred,
+            RawClassification::Unsupported => Self::Unsupported,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+enum RawMode {
+    StandaloneCacheOff,
+    RaftSingleGroupCacheOff,
+}
+
+impl From<RawMode> for Mode {
+    fn from(raw: RawMode) -> Self {
+        match raw {
+            RawMode::StandaloneCacheOff => Self::StandaloneCacheOff,
+            RawMode::RaftSingleGroupCacheOff => Self::RaftSingleGroupCacheOff,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum RawProtocol {
+    Resp2,
+    Resp3,
+}
+
+impl From<RawProtocol> for Protocol {
+    fn from(raw: RawProtocol) -> Self {
+        match raw {
+            RawProtocol::Resp2 => Self::Resp2,
+            RawProtocol::Resp3 => Self::Resp3,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ManifestError {
+    #[error("failed to parse compatibility manifest: {0}")]
+    Parse(#[from] yaml_serde::Error),
+    #[error("schema must equal {MANIFEST_SCHEMA}, got {actual:?}")]
+    InvalidSchema { actual: String },
+    #[error(
+        "redis identity must equal tag {REDIS_TAG} and commit {REDIS_COMMIT}, got tag {actual_tag:?} and commit {actual_commit:?}"
+    )]
+    InvalidRedisIdentity {
+        actual_tag: String,
+        actual_commit: String,
+    },
+    #[error("commands[{index}].command duplicates commands[{first_index}].command {command:?}")]
+    DuplicateCommand {
+        command: String,
+        first_index: usize,
+        index: usize,
+    },
+    #[error("commands[{index}].command must be a non-empty printable ASCII token, got {command:?}")]
+    InvalidCommand { command: String, index: usize },
+    #[error("commands[{index}].modes must not be empty")]
+    EmptyModes { index: usize },
+    #[error("commands[{index}].protocols must not be empty")]
+    EmptyProtocols { index: usize },
+    #[error("commands[{index}].owner must not be empty")]
+    EmptyOwner { index: usize },
+}

--- a/tools/compat/tests/manifest.rs
+++ b/tools/compat/tests/manifest.rs
@@ -16,24 +16,31 @@
 // limitations under the License.
 
 use kiwi_compat::manifest::{
-    Classification, CompatibilityManifest, Mode, Protocol, REDIS_COMMIT, REDIS_TAG,
+    ArgumentSemantics, Classification, CompatibilityManifest, ErrorSemantics, Mode, Profile,
+    Protocol, REDIS_COMMIT, REDIS_TAG, ReplySchema, TestEvidence, TtlSemantics,
 };
 
 const VALID_MANIFEST: &str = r#"
 schema: kiwi-redis-compat/v1
-profile: redis_8_8_1_core
+profile: redis_8_8_1_standalone_cache_off
 redis:
   tag: 8.8.1
   commit: 77b6c308396c9700672390a210143a8496fb4b10
 commands:
   - command: get
-    classification: known_difference
+    classification: required
     modes:
       standalone_cache_off: required
       raft_single_group_cache_off: deferred
     protocols:
       - resp2
       - resp3
+    arguments: exact
+    reply_schema: exact
+    errors: exact-prefix
+    ttl_semantics: applicable
+    tests: [wire-differential, final-state]
+    known_differences: []
     owner: cmd-string
 "#;
 
@@ -60,10 +67,21 @@ fn rejects_a_manifest_with_an_incorrect_schema() {
 #[test]
 fn rejects_an_unknown_top_level_field() {
     let yaml = VALID_MANIFEST.replace(
-        "profile: redis_8_8_1_core",
-        "profile: redis_8_8_1_core\nunexpected: true",
+        "profile: redis_8_8_1_standalone_cache_off",
+        "profile: redis_8_8_1_standalone_cache_off\nunexpected: true",
     );
     assert_error_contains(&yaml, "unknown field");
+}
+
+#[test]
+fn rejects_empty_or_unknown_profiles() {
+    for profile in ["''", "redis_8_8_1_typo"] {
+        let yaml = VALID_MANIFEST.replace(
+            "profile: redis_8_8_1_standalone_cache_off",
+            &format!("profile: {profile}"),
+        );
+        assert_error_contains(&yaml, "profile");
+    }
 }
 
 #[test]
@@ -131,6 +149,12 @@ fn rejects_duplicate_commands_after_ascii_canonicalization() {
     modes:
       standalone_cache_off: required
     protocols: [resp2]
+    arguments: exact
+    reply_schema: exact
+    errors: exact-prefix
+    ttl_semantics: applicable
+    tests: [wire-differential]
+    known_differences: []
     owner: cmd-string
 "#;
     let yaml = VALID_MANIFEST.replace(
@@ -139,6 +163,25 @@ fn rejects_duplicate_commands_after_ascii_canonicalization() {
     );
     assert_error_contains(&yaml, "duplicates");
     assert_error_contains(&yaml, "GET");
+}
+
+#[test]
+fn rejects_duplicate_modes_before_they_can_override_required_or_known_difference() {
+    for first_classification in ["required", "known_difference"] {
+        let yaml = VALID_MANIFEST
+            .replace("classification: required", "classification: deferred")
+            .replace(
+                "      standalone_cache_off: required\n      raft_single_group_cache_off: deferred",
+                &format!(
+                    "      standalone_cache_off: {first_classification}\n      standalone_cache_off: deferred\n      raft_single_group_cache_off: deferred"
+                ),
+            )
+            .replace(
+                "tests: [wire-differential, final-state]",
+                "tests: []",
+            );
+        assert_error_contains(&yaml, "duplicate");
+    }
 }
 
 #[test]
@@ -194,6 +237,37 @@ fn rejects_empty_protocols() {
 }
 
 #[test]
+fn rejects_empty_test_evidence_for_a_required_command() {
+    let yaml = VALID_MANIFEST.replace("tests: [wire-differential, final-state]", "tests: []");
+    assert_error_contains(&yaml, "tests");
+}
+
+#[test]
+fn rejects_empty_test_evidence_when_only_a_mode_is_required() {
+    let yaml = VALID_MANIFEST
+        .replace("classification: required", "classification: deferred")
+        .replace("tests: [wire-differential, final-state]", "tests: []");
+    assert_error_contains(&yaml, "tests");
+}
+
+#[test]
+fn accepts_test_evidence_when_only_a_mode_is_required() {
+    let yaml = VALID_MANIFEST.replace("classification: required", "classification: deferred");
+    let manifest = parse_valid(&yaml);
+
+    assert_eq!(
+        first_command(&manifest).classification(),
+        Classification::Deferred
+    );
+    assert_eq!(
+        first_command(&manifest)
+            .modes()
+            .get(&Mode::StandaloneCacheOff),
+        Some(&Classification::Required)
+    );
+}
+
+#[test]
 fn rejects_an_empty_owner_after_trimming() {
     let yaml = VALID_MANIFEST.replace("owner: cmd-string", "owner: '   '");
     assert_error_contains(&yaml, "owner");
@@ -201,11 +275,107 @@ fn rejects_an_empty_owner_after_trimming() {
 
 #[test]
 fn rejects_an_unsupported_classification() {
-    let yaml = VALID_MANIFEST.replace(
-        "classification: known_difference",
-        "classification: partial",
-    );
+    let yaml = VALID_MANIFEST.replace("classification: required", "classification: partial");
     assert_error_contains(&yaml, "classification");
+}
+
+#[test]
+fn rejects_a_known_difference_without_governance_metadata() {
+    let yaml = VALID_MANIFEST.replace(
+        "classification: required",
+        "classification: known_difference",
+    );
+    assert_error_contains(&yaml, "known_differences");
+}
+
+#[test]
+fn rejects_missing_governance_when_only_a_mode_has_a_known_difference() {
+    let yaml = VALID_MANIFEST
+        .replace("classification: required", "classification: deferred")
+        .replace(
+            "standalone_cache_off: required",
+            "standalone_cache_off: known_difference",
+        );
+    assert_error_contains(&yaml, "known_differences");
+}
+
+#[test]
+fn loads_governance_when_only_a_mode_has_a_known_difference() {
+    let yaml = governed_known_difference_manifest()
+        .replace(
+            "classification: known_difference",
+            "classification: deferred",
+        )
+        .replace(
+            "standalone_cache_off: required",
+            "standalone_cache_off: known_difference",
+        )
+        .replace("tests: [wire-differential, final-state]", "tests: []");
+    let manifest = parse_valid(&yaml);
+    let command = first_command(&manifest);
+
+    assert_eq!(command.classification(), Classification::Deferred);
+    assert_eq!(
+        command.modes().get(&Mode::StandaloneCacheOff),
+        Some(&Classification::KnownDifference)
+    );
+    assert_eq!(command.known_differences().len(), 1);
+}
+
+#[test]
+fn rejects_known_difference_metadata_without_a_matching_classification() {
+    let yaml = VALID_MANIFEST.replace(
+        "known_differences: []",
+        "known_differences:\n      - owner: cmd-string\n        issue: https://github.com/arana-db/kiwi/issues/999\n        reason: Redis behavior is not implemented yet\n        remove_when: wire differential and final-state evidence pass",
+    );
+    assert_error_contains(&yaml, "known_differences");
+}
+
+#[test]
+fn loads_governed_known_difference_metadata() {
+    let yaml = governed_known_difference_manifest();
+    let manifest = parse_valid(&yaml);
+    let differences = first_command(&manifest).known_differences();
+
+    assert_eq!(differences.len(), 1);
+    assert_eq!(differences[0].owner(), "cmd-string");
+    assert_eq!(
+        differences[0].issue(),
+        "https://github.com/arana-db/kiwi/issues/999"
+    );
+    assert_eq!(
+        differences[0].reason(),
+        "Redis behavior is not implemented yet"
+    );
+    assert_eq!(
+        differences[0].remove_when(),
+        "wire differential and final-state evidence pass"
+    );
+}
+
+#[test]
+fn rejects_blank_known_difference_governance_fields() {
+    for (field, original, replacement) in [
+        ("owner", "      - owner: cmd-string", "      - owner: '   '"),
+        (
+            "issue",
+            "        issue: https://github.com/arana-db/kiwi/issues/999",
+            "        issue: '   '",
+        ),
+        (
+            "reason",
+            "        reason: Redis behavior is not implemented yet",
+            "        reason: '   '",
+        ),
+        (
+            "remove_when",
+            "        remove_when: wire differential and final-state evidence pass",
+            "        remove_when: '   '",
+        ),
+    ] {
+        let yaml = governed_known_difference_manifest().replace(original, replacement);
+        assert_error_contains(&yaml, field);
+    }
 }
 
 #[test]
@@ -224,16 +394,73 @@ fn rejects_an_unsupported_protocol() {
 }
 
 #[test]
+fn loads_the_authoritative_command_contract_fields() {
+    let manifest = parse_valid(VALID_MANIFEST);
+    let command = first_command(&manifest);
+
+    assert_eq!(command.arguments(), ArgumentSemantics::Exact);
+    assert_eq!(command.reply_schema(), ReplySchema::Exact);
+    assert_eq!(command.errors(), ErrorSemantics::ExactPrefix);
+    assert_eq!(command.ttl_semantics(), TtlSemantics::Applicable);
+    assert_eq!(
+        command.tests(),
+        &[TestEvidence::WireDifferential, TestEvidence::FinalState]
+    );
+    assert!(command.known_differences().is_empty());
+}
+
+#[test]
+fn rejects_missing_authoritative_command_contract_fields() {
+    for (field, line) in [
+        ("arguments", "    arguments: exact\n"),
+        ("reply_schema", "    reply_schema: exact\n"),
+        ("errors", "    errors: exact-prefix\n"),
+        ("ttl_semantics", "    ttl_semantics: applicable\n"),
+        ("tests", "    tests: [wire-differential, final-state]\n"),
+        ("known_differences", "    known_differences: []\n"),
+    ] {
+        let yaml = VALID_MANIFEST.replace(line, "");
+        assert_error_contains(&yaml, field);
+    }
+}
+
+#[test]
+fn rejects_unsupported_authoritative_command_contract_values() {
+    for (field, supported, unsupported) in [
+        ("arguments", "arguments: exact", "arguments: normalized"),
+        (
+            "reply_schema",
+            "reply_schema: exact",
+            "reply_schema: approximate",
+        ),
+        ("errors", "errors: exact-prefix", "errors: ignored"),
+        (
+            "ttl_semantics",
+            "ttl_semantics: applicable",
+            "ttl_semantics: unspecified",
+        ),
+        (
+            "tests",
+            "tests: [wire-differential, final-state]",
+            "tests: [manual-only]",
+        ),
+    ] {
+        let yaml = VALID_MANIFEST.replace(supported, unsupported);
+        assert_error_contains(&yaml, field);
+    }
+}
+
+#[test]
 fn loads_a_valid_manifest_through_read_only_getters() {
     let manifest = parse_valid(VALID_MANIFEST);
     let command = first_command(&manifest);
 
     assert_eq!(manifest.schema(), "kiwi-redis-compat/v1");
-    assert_eq!(manifest.profile(), "redis_8_8_1_core");
+    assert_eq!(manifest.profile(), Profile::Redis881StandaloneCacheOff);
     assert_eq!(manifest.redis().tag(), REDIS_TAG);
     assert_eq!(manifest.redis().commit(), REDIS_COMMIT);
     assert_eq!(manifest.commands().len(), 1);
-    assert_eq!(command.classification(), Classification::KnownDifference);
+    assert_eq!(command.classification(), Classification::Required);
     assert_eq!(command.protocols(), &[Protocol::Resp2, Protocol::Resp3]);
     assert_eq!(command.owner(), "cmd-string");
 }
@@ -244,7 +471,7 @@ fn loads_the_repository_redis_8_8_1_manifest() {
     let manifest = parse_valid(yaml);
 
     assert_eq!(manifest.schema(), "kiwi-redis-compat/v1");
-    assert_eq!(manifest.profile(), "redis_8_8_1_core");
+    assert_eq!(manifest.profile(), Profile::Redis881StandaloneCacheOff);
     assert_eq!(manifest.redis().tag(), REDIS_TAG);
     assert_eq!(manifest.redis().commit(), REDIS_COMMIT);
     assert!(manifest.commands().is_empty());
@@ -274,4 +501,16 @@ fn assert_error_contains(yaml: &str, expected: &str) {
         message.contains(expected),
         "error {message:?} did not contain {expected:?}"
     );
+}
+
+fn governed_known_difference_manifest() -> String {
+    VALID_MANIFEST
+        .replace(
+            "classification: required",
+            "classification: known_difference",
+        )
+        .replace(
+            "known_differences: []",
+            "known_differences:\n      - owner: cmd-string\n        issue: https://github.com/arana-db/kiwi/issues/999\n        reason: Redis behavior is not implemented yet\n        remove_when: wire differential and final-state evidence pass",
+        )
 }

--- a/tools/compat/tests/manifest.rs
+++ b/tools/compat/tests/manifest.rs
@@ -1,0 +1,277 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use kiwi_compat::manifest::{
+    Classification, CompatibilityManifest, Mode, Protocol, REDIS_COMMIT, REDIS_TAG,
+};
+
+const VALID_MANIFEST: &str = r#"
+schema: kiwi-redis-compat/v1
+profile: redis_8_8_1_core
+redis:
+  tag: 8.8.1
+  commit: 77b6c308396c9700672390a210143a8496fb4b10
+commands:
+  - command: get
+    classification: known_difference
+    modes:
+      standalone_cache_off: required
+      raft_single_group_cache_off: deferred
+    protocols:
+      - resp2
+      - resp3
+    owner: cmd-string
+"#;
+
+#[test]
+fn rejects_a_manifest_with_an_incorrect_redis_commit() {
+    let yaml = VALID_MANIFEST.replace(REDIS_COMMIT, "0000000000000000000000000000000000000000");
+    assert_error_contains(&yaml, REDIS_COMMIT);
+    assert_error_contains(&yaml, REDIS_TAG);
+}
+
+#[test]
+fn rejects_a_manifest_with_an_incorrect_redis_tag() {
+    let yaml = VALID_MANIFEST.replace("tag: 8.8.1", "tag: 8.8.0");
+    assert_error_contains(&yaml, REDIS_TAG);
+    assert_error_contains(&yaml, REDIS_COMMIT);
+}
+
+#[test]
+fn rejects_a_manifest_with_an_incorrect_schema() {
+    let yaml = VALID_MANIFEST.replace("kiwi-redis-compat/v1", "kiwi-redis-compat/v2");
+    assert_error_contains(&yaml, "kiwi-redis-compat/v1");
+}
+
+#[test]
+fn rejects_an_unknown_top_level_field() {
+    let yaml = VALID_MANIFEST.replace(
+        "profile: redis_8_8_1_core",
+        "profile: redis_8_8_1_core\nunexpected: true",
+    );
+    assert_error_contains(&yaml, "unknown field");
+}
+
+#[test]
+fn rejects_an_unknown_nested_field() {
+    let yaml = VALID_MANIFEST.replace(
+        "    owner: cmd-string",
+        "    owner: cmd-string\n    extra: true",
+    );
+    assert_error_contains(&yaml, "unknown field");
+}
+
+#[test]
+fn rejects_an_unknown_redis_field() {
+    let yaml = VALID_MANIFEST.replace(
+        "  commit: 77b6c308396c9700672390a210143a8496fb4b10",
+        "  commit: 77b6c308396c9700672390a210143a8496fb4b10\n  source: upstream",
+    );
+    assert_error_contains(&yaml, "unknown field");
+}
+
+#[test]
+fn canonicalizes_command_names_with_ascii_uppercase() {
+    let manifest = parse_valid(VALID_MANIFEST);
+    assert_eq!(first_command(&manifest).command(), "GET");
+}
+
+#[test]
+fn accepts_a_printable_ascii_command_with_a_dot() {
+    let yaml = VALID_MANIFEST.replace("command: get", "command: module.command");
+    let manifest = parse_valid(&yaml);
+    assert_eq!(first_command(&manifest).command(), "MODULE.COMMAND");
+}
+
+#[test]
+fn rejects_an_empty_command_token() {
+    let yaml = VALID_MANIFEST.replace("command: get", "command: ''");
+    assert_error_contains(&yaml, "command");
+}
+
+#[test]
+fn rejects_command_tokens_with_leading_or_trailing_whitespace() {
+    for command in ["' GET'", "'GET '"] {
+        let yaml = VALID_MANIFEST.replace("command: get", &format!("command: {command}"));
+        assert_error_contains(&yaml, "command");
+    }
+}
+
+#[test]
+fn rejects_a_command_token_with_an_ascii_control_character() {
+    let yaml = VALID_MANIFEST.replace("command: get", "command: \"GET\\u0001\"");
+    assert_error_contains(&yaml, "command");
+}
+
+#[test]
+fn rejects_a_non_ascii_command_without_unicode_uppercasing_it() {
+    let yaml = VALID_MANIFEST.replace("command: get", "command: 'gét'");
+    assert_error_contains(&yaml, "gét");
+}
+
+#[test]
+fn rejects_duplicate_commands_after_ascii_canonicalization() {
+    let duplicate = r#"
+  - command: GET
+    classification: required
+    modes:
+      standalone_cache_off: required
+    protocols: [resp2]
+    owner: cmd-string
+"#;
+    let yaml = VALID_MANIFEST.replace(
+        "    owner: cmd-string\n",
+        &format!("    owner: cmd-string\n{duplicate}"),
+    );
+    assert_error_contains(&yaml, "duplicates");
+    assert_error_contains(&yaml, "GET");
+}
+
+#[test]
+fn rejects_empty_modes() {
+    let yaml = VALID_MANIFEST.replace(
+        "    modes:\n      standalone_cache_off: required\n      raft_single_group_cache_off: deferred",
+        "    modes: {}",
+    );
+    assert_error_contains(&yaml, "modes");
+}
+
+#[test]
+fn rejects_an_unknown_mode() {
+    let yaml = VALID_MANIFEST.replace("standalone_cache_off", "experimental_cache_off");
+    assert_error_contains(&yaml, "experimental_cache_off");
+}
+
+#[test]
+fn exposes_the_standalone_cache_off_mode_through_a_closed_getter() {
+    let manifest = parse_valid(VALID_MANIFEST);
+    assert_eq!(
+        first_command(&manifest)
+            .modes()
+            .get(&Mode::StandaloneCacheOff),
+        Some(&Classification::Required)
+    );
+}
+
+#[test]
+fn exposes_the_raft_single_group_cache_off_mode_through_a_closed_getter() {
+    let manifest = parse_valid(VALID_MANIFEST);
+    assert_eq!(
+        first_command(&manifest)
+            .modes()
+            .get(&Mode::RaftSingleGroupCacheOff),
+        Some(&Classification::Deferred)
+    );
+}
+
+#[test]
+fn rejects_a_blank_mode() {
+    let yaml = VALID_MANIFEST.replace("standalone_cache_off", "'   '");
+    assert_error_contains(&yaml, "   ");
+}
+
+#[test]
+fn rejects_empty_protocols() {
+    let yaml = VALID_MANIFEST.replace(
+        "    protocols:\n      - resp2\n      - resp3",
+        "    protocols: []",
+    );
+    assert_error_contains(&yaml, "protocols");
+}
+
+#[test]
+fn rejects_an_empty_owner_after_trimming() {
+    let yaml = VALID_MANIFEST.replace("owner: cmd-string", "owner: '   '");
+    assert_error_contains(&yaml, "owner");
+}
+
+#[test]
+fn rejects_an_unsupported_classification() {
+    let yaml = VALID_MANIFEST.replace(
+        "classification: known_difference",
+        "classification: partial",
+    );
+    assert_error_contains(&yaml, "classification");
+}
+
+#[test]
+fn rejects_an_unsupported_mode_classification() {
+    let yaml = VALID_MANIFEST.replace(
+        "standalone_cache_off: required",
+        "standalone_cache_off: partial",
+    );
+    assert_error_contains(&yaml, "partial");
+}
+
+#[test]
+fn rejects_an_unsupported_protocol() {
+    let yaml = VALID_MANIFEST.replace("      - resp3", "      - resp9");
+    assert_error_contains(&yaml, "resp9");
+}
+
+#[test]
+fn loads_a_valid_manifest_through_read_only_getters() {
+    let manifest = parse_valid(VALID_MANIFEST);
+    let command = first_command(&manifest);
+
+    assert_eq!(manifest.schema(), "kiwi-redis-compat/v1");
+    assert_eq!(manifest.profile(), "redis_8_8_1_core");
+    assert_eq!(manifest.redis().tag(), REDIS_TAG);
+    assert_eq!(manifest.redis().commit(), REDIS_COMMIT);
+    assert_eq!(manifest.commands().len(), 1);
+    assert_eq!(command.classification(), Classification::KnownDifference);
+    assert_eq!(command.protocols(), &[Protocol::Resp2, Protocol::Resp3]);
+    assert_eq!(command.owner(), "cmd-string");
+}
+
+#[test]
+fn loads_the_repository_redis_8_8_1_manifest() {
+    let yaml = include_str!("../../../tests/compat/redis-8.8.1/manifest.yaml");
+    let manifest = parse_valid(yaml);
+
+    assert_eq!(manifest.schema(), "kiwi-redis-compat/v1");
+    assert_eq!(manifest.profile(), "redis_8_8_1_core");
+    assert_eq!(manifest.redis().tag(), REDIS_TAG);
+    assert_eq!(manifest.redis().commit(), REDIS_COMMIT);
+    assert!(manifest.commands().is_empty());
+}
+
+fn parse_valid(yaml: &str) -> CompatibilityManifest {
+    match CompatibilityManifest::from_yaml(yaml) {
+        Ok(manifest) => manifest,
+        Err(error) => panic!("valid manifest must load: {error}"),
+    }
+}
+
+fn first_command(manifest: &CompatibilityManifest) -> &kiwi_compat::manifest::CommandContract {
+    match manifest.commands().first() {
+        Some(command) => command,
+        None => panic!("manifest must contain a command"),
+    }
+}
+
+fn assert_error_contains(yaml: &str, expected: &str) {
+    let error = match CompatibilityManifest::from_yaml(yaml) {
+        Ok(_) => panic!("manifest must be rejected"),
+        Err(error) => error,
+    };
+    let message = error.to_string();
+    assert!(
+        message.contains(expected),
+        "error {message:?} did not contain {expected:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- add the test-only `kiwi-compat` workspace crate
- define a closed Redis 8.8.1 compatibility manifest schema
- pin the exact Redis tag and commit in validated, read-only types
- reject unknown fields, invalid command tokens, duplicate canonical commands, and unsupported compatibility states

## Scope

This is a stacked implementation PR based on `codex/redis-8.8.1-doc-foundation` / PR #371. Its current commit contains M1-001 Task 1 only. Cache OFF remains required, and this PR does not implement or integrate the Embedded Redis Hot Tier.

## Validation

- Windows: manifest tests 25/25, strict Clippy, formatting check
- WSL/Linux: manifest tests 25/25, strict Clippy, formatting check
- production server normal/build dependency isolation passed
- exact schema and Redis identity checks passed
- commit path closure is 7/7 and the worktree is clean

## Dependency

This PR depends on PR #371 and should not be merged before its documentation and project-baseline changes are available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added YAML-based compatibility manifest support for validating Redis command contracts.
  * Added validation for schemas, Redis versions, command definitions, modes, protocols, test evidence, and governance metadata.
  * Added a Redis 8.8.1 compatibility manifest.

* **Tests**
  * Added comprehensive coverage for valid manifests, malformed data, duplicate entries, unsupported values, and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->