### PR TITLE
fix(raft): advance applied state only after durable apply

### DIFF
--- a/src/raft/src/grpc/client.rs
+++ b/src/raft/src/grpc/client.rs
@@ -22,7 +22,7 @@ use conf::raft_type::{Binlog, BinlogEntry, OperateType};
 use storage::slot_indexer::key_to_slot_id;
 use tonic::{Request, Response as TonicResponse, Status};
 
-use crate::node::RaftApp;
+use crate::node::{ClientWriteError, RaftApp};
 use crate::raft_proto::{
     LeaderRequest, LeaderResponse, MembersRequest, MembersResponse, MetricsRequest,
     MetricsResponse, NodeConfig, ReadRequest, ReadResponse, Response as ProtoResponse,
@@ -117,6 +117,10 @@ impl RaftClientService for RaftClientServiceImpl {
                     response: Some(proto_response),
                     log_id,
                 }))
+            }
+            Err(ClientWriteError::InvalidBinlog(e)) => {
+                log::warn!("Rejected invalid Raft binlog: {}", e);
+                Err(Status::invalid_argument(format!("Invalid binlog: {e}")))
             }
             Err(e) => {
                 log::error!("Failed to write to Raft: {}", e);
@@ -296,9 +300,22 @@ fn proto_binlog_to_binlog(
         })
         .collect::<Result<Vec<_>, Status>>()?;
 
+    let db_id = u32::try_from(proto_binlog.db_id).map_err(|_| {
+        Status::invalid_argument(format!(
+            "Database ID {} exceeds the supported range",
+            proto_binlog.db_id
+        ))
+    })?;
+    let slot_idx = u32::try_from(proto_binlog.slot_idx).map_err(|_| {
+        Status::invalid_argument(format!(
+            "Slot ID {} exceeds the supported range",
+            proto_binlog.slot_idx
+        ))
+    })?;
+
     Ok(Binlog {
-        db_id: proto_binlog.db_id as u32,
-        slot_idx: proto_binlog.slot_idx as u32,
+        db_id,
+        slot_idx,
         entries,
     })
 }
@@ -416,5 +433,29 @@ mod tests {
         assert_eq!(binlog.entries.len(), 1);
         assert_eq!(binlog.entries[0].op_type, OperateType::Delete);
         assert_eq!(binlog.entries[0].value, None);
+    }
+
+    #[test]
+    fn proto_binlog_rejects_database_id_outside_internal_range() {
+        let err = proto_binlog_to_binlog(Some(ProtoBinlog {
+            db_id: u64::from(u32::MAX) + 1,
+            slot_idx: 0,
+            entries: Vec::new(),
+        }))
+        .expect_err("database IDs must not be truncated while decoding gRPC input");
+
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn proto_binlog_rejects_slot_outside_internal_range() {
+        let err = proto_binlog_to_binlog(Some(ProtoBinlog {
+            db_id: 0,
+            slot_idx: u64::from(u32::MAX) + 1,
+            entries: Vec::new(),
+        }))
+        .expect_err("slot IDs must not be truncated while decoding gRPC input");
+
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
     }
 }

--- a/src/raft/src/node.rs
+++ b/src/raft/src/node.rs
@@ -36,6 +36,14 @@ use crate::raft_proto::raft_metrics_service_server::RaftMetricsServiceServer;
 use crate::state_machine::{KiwiStateMachine, PauseController};
 use storage::storage::Storage;
 
+#[derive(Debug, thiserror::Error)]
+pub enum ClientWriteError {
+    #[error("invalid binlog: {0}")]
+    InvalidBinlog(#[source] storage::error::Error),
+    #[error("Raft client write failed: {0}")]
+    Raft(#[source] anyhow::Error),
+}
+
 pub struct RaftApp {
     pub node_id: u64,
     pub raft_addr: String,
@@ -64,8 +72,16 @@ impl RaftApp {
         None
     }
 
-    pub async fn client_write(&self, binlog: Binlog) -> Result<BinlogResponse, anyhow::Error> {
-        let res = self.raft.client_write(binlog).await?;
+    pub async fn client_write(&self, binlog: Binlog) -> Result<BinlogResponse, ClientWriteError> {
+        self.storage_swap
+            .load_full()
+            .validate_binlog(&binlog)
+            .map_err(ClientWriteError::InvalidBinlog)?;
+        let res = self
+            .raft
+            .client_write(binlog)
+            .await
+            .map_err(|error| ClientWriteError::Raft(anyhow::Error::new(error)))?;
         let log_id = Some(res.log_id.index);
         Ok(BinlogResponse {
             success: res.data.success,
@@ -230,10 +246,18 @@ pub async fn create_raft_node(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+    use std::time::Duration;
+
     use super::*;
     use crate::state_machine::{StorageAccessPermit, snapshot_install_marker_path};
+    use conf::raft_type::{BinlogEntry, OperateType};
     use openraft::storage::{RaftLogStorage, RaftLogStorageExt};
     use openraft::{Entry, EntryPayload, LeaderId, LogId, Vote};
+    use storage::BaseMetaKey;
+    use storage::ColumnFamilyIndex;
+    use storage::format_strings_value::StringValue;
+    use storage::slot_indexer::key_to_slot_id;
     use tempfile::TempDir;
 
     struct NoopPauseController;
@@ -261,6 +285,98 @@ mod tests {
 
     fn noop_pause_controller() -> Arc<dyn PauseController> {
         Arc::new(NoopPauseController)
+    }
+
+    fn string_put_binlog(key: &[u8], value: &[u8]) -> Binlog {
+        Binlog {
+            db_id: 0,
+            slot_idx: key_to_slot_id(key) as u32,
+            entries: vec![BinlogEntry {
+                cf_idx: ColumnFamilyIndex::MetaCF as u32,
+                op_type: OperateType::Put,
+                key: BaseMetaKey::new(key)
+                    .encode()
+                    .expect("test string key should encode")
+                    .to_vec(),
+                value: Some(StringValue::new(value.to_vec()).encode().to_vec()),
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_binlog_is_rejected_before_raft_and_next_valid_write_succeeds() {
+        let temp_dir = TempDir::new().expect("test should create a temporary directory");
+        let db_path = temp_dir.path().join("data");
+        let mut storage = Storage::new(1, 0);
+        let storage_rx = storage
+            .open(Arc::new(storage::StorageOptions::default()), &db_path)
+            .expect("test storage should open");
+        let storage_swap = Arc::new(ArcSwap::from_pointee(storage));
+        let config = RaftConfig {
+            node_id: 1,
+            data_dir: temp_dir.path().join("raft-data"),
+            db_path: db_path.clone(),
+            ..Default::default()
+        };
+        let app = create_raft_node(
+            config,
+            Arc::clone(&storage_swap),
+            noop_pause_controller(),
+            None,
+        )
+        .await
+        .expect("single-node Raft should start");
+
+        let mut nodes = BTreeMap::new();
+        nodes.insert(
+            1,
+            KiwiNode {
+                raft_addr: "127.0.0.1:0".to_string(),
+                resp_addr: "127.0.0.1:0".to_string(),
+            },
+        );
+        app.raft
+            .initialize(nodes)
+            .await
+            .expect("single-node Raft should initialize");
+        app.raft
+            .wait(Some(Duration::from_secs(10)))
+            .current_leader(1, "single-node test should elect itself")
+            .await
+            .expect("single-node Raft should become leader");
+
+        let mut invalid = string_put_binlog(b"poison", b"bad");
+        invalid.entries[0].cf_idx = 99;
+        app.client_write(invalid)
+            .await
+            .expect_err("invalid binlog must be rejected before proposal");
+
+        let valid = string_put_binlog(b"healthy", b"value");
+        let response = app
+            .client_write(valid)
+            .await
+            .expect("a valid write after rejection should still reach consensus");
+        assert!(response.success);
+        assert_eq!(
+            storage_swap
+                .load_full()
+                .get(b"healthy")
+                .expect("valid write should be applied"),
+            "value"
+        );
+
+        app.raft
+            .shutdown()
+            .await
+            .expect("test Raft should shut down cleanly");
+        drop(app);
+        let storage = storage_swap.load_full();
+        drop(storage_swap);
+        let mut storage = Arc::try_unwrap(storage)
+            .unwrap_or_else(|_| panic!("test storage should not retain Arc references"));
+        storage.shutdown().await;
+        storage.close();
+        drop(storage_rx);
     }
 
     #[tokio::test]

--- a/src/raft/src/state_machine.rs
+++ b/src/raft/src/state_machine.rs
@@ -1191,7 +1191,12 @@ mod apply_ordering_tests {
 
     use conf::raft_type::{BinlogEntry, OperateType};
     use openraft::{Entry, LeaderId};
-    use storage::{safe_cleanup_test_db, unique_test_db_path};
+    use storage::BaseMetaKey;
+    use storage::format_strings_value::StringValue;
+    use storage::slot_indexer::key_to_slot_id;
+    use storage::{
+        ColumnFamilyIndex, fail_next_rocks_batch_commit, safe_cleanup_test_db, unique_test_db_path,
+    };
 
     use super::*;
 
@@ -1222,6 +1227,11 @@ mod apply_ordering_tests {
         db_path: PathBuf,
         snapshot_work_dir: PathBuf,
         storage_rx: Box<dyn std::any::Any + Send>,
+    }
+
+    struct ClosedFixture {
+        db_path: PathBuf,
+        snapshot_work_dir: PathBuf,
     }
 
     impl Fixture {
@@ -1255,7 +1265,7 @@ mod apply_ordering_tests {
             }
         }
 
-        async fn cleanup(self) {
+        async fn close(self) -> ClosedFixture {
             let Fixture {
                 state_machine,
                 storage_swap,
@@ -1273,8 +1283,54 @@ mod apply_ordering_tests {
             storage.shutdown().await;
             storage.close();
             drop(storage_rx);
-            safe_cleanup_test_db(&db_path);
-            safe_cleanup_test_db(&snapshot_work_dir);
+            drop(storage);
+
+            ClosedFixture {
+                db_path,
+                snapshot_work_dir,
+            }
+        }
+
+        fn rocksdb_path(&self) -> PathBuf {
+            self.storage_swap
+                .load_full()
+                .insts
+                .first()
+                .and_then(|instance| instance.db())
+                .expect("test storage should expose its RocksDB instance")
+                .path()
+                .to_path_buf()
+        }
+    }
+
+    impl ClosedFixture {
+        async fn assert_reopened_values(self, expected: &[(&[u8], Option<&str>)]) {
+            let mut reopened = Storage::new(1, 0);
+            let reopened_rx = reopened
+                .open(Arc::new(StorageOptions::default()), &self.db_path)
+                .expect("test storage should reopen from the original path");
+
+            for (key, value) in expected {
+                match value {
+                    Some(value) => assert_eq!(
+                        reopened
+                            .get(key)
+                            .expect("reopened storage should read the applied value"),
+                        *value
+                    ),
+                    None => assert!(
+                        reopened.get(key).is_err(),
+                        "reopened storage must not contain an unapplied key"
+                    ),
+                }
+            }
+
+            reopened.shutdown().await;
+            reopened.close();
+            drop(reopened_rx);
+            drop(reopened);
+            safe_cleanup_test_db(&self.db_path);
+            safe_cleanup_test_db(&self.snapshot_work_dir);
         }
     }
 
@@ -1285,30 +1341,18 @@ mod apply_ordering_tests {
         }
     }
 
-    fn valid_put_binlog() -> Binlog {
+    fn string_put_binlog(key: &[u8], value: &[u8]) -> Binlog {
         Binlog {
             db_id: 0,
-            slot_idx: 0,
+            slot_idx: key_to_slot_id(key) as u32,
             entries: vec![BinlogEntry {
-                cf_idx: 0, // MetaCF
+                cf_idx: ColumnFamilyIndex::MetaCF as u32,
                 op_type: OperateType::Put,
-                key: b"k".to_vec(),
-                value: Some(b"v".to_vec()),
-            }],
-        }
-    }
-
-    /// An out-of-range column-family index makes `on_binlog_write` reject the
-    /// mutation, standing in for any fatal storage/corruption error at apply.
-    fn corrupt_binlog() -> Binlog {
-        Binlog {
-            db_id: 0,
-            slot_idx: 0,
-            entries: vec![BinlogEntry {
-                cf_idx: 99,
-                op_type: OperateType::Put,
-                key: b"k".to_vec(),
-                value: Some(b"v".to_vec()),
+                key: BaseMetaKey::new(key)
+                    .encode()
+                    .expect("test string key should encode")
+                    .to_vec(),
+                value: Some(StringValue::new(value.to_vec()).encode().to_vec()),
             }],
         }
     }
@@ -1316,11 +1360,15 @@ mod apply_ordering_tests {
     #[tokio::test]
     async fn apply_advances_applied_only_on_success() {
         let mut fx = Fixture::new();
+        let key = b"durable-success";
         assert!(fx.state_machine.last_applied.is_none());
 
         let responses = fx
             .state_machine
-            .apply([entry_at(5, EntryPayload::Normal(valid_put_binlog()))])
+            .apply([entry_at(
+                5,
+                EntryPayload::Normal(string_put_binlog(key, b"value")),
+            )])
             .await
             .expect("a valid binlog should apply cleanly");
 
@@ -1331,17 +1379,32 @@ mod apply_ordering_tests {
             Some(5),
             "applied state advances to the committed entry"
         );
+        assert_eq!(
+            fx.storage_swap
+                .load_full()
+                .get(key)
+                .expect("applied value should be readable before close"),
+            "value"
+        );
 
-        fx.cleanup().await;
+        fx.close()
+            .await
+            .assert_reopened_values(&[(key, Some("value"))])
+            .await;
     }
 
     #[tokio::test]
     async fn apply_does_not_advance_applied_on_fatal_storage_error() {
         let mut fx = Fixture::new();
+        let key = b"fatal-write";
+        let _failure = fail_next_rocks_batch_commit(&fx.rocksdb_path());
 
         let err = fx
             .state_machine
-            .apply([entry_at(7, EntryPayload::Normal(corrupt_binlog()))])
+            .apply([entry_at(
+                7,
+                EntryPayload::Normal(string_put_binlog(key, b"value")),
+            )])
             .await
             .expect_err("a storage failure during apply must surface as a fatal error");
         // A non-empty error is enough; the point is that it is Err, not Ok.
@@ -1351,20 +1414,42 @@ mod apply_ordering_tests {
             fx.state_machine.last_applied.is_none(),
             "applied state must not advance past an entry that failed to commit"
         );
+        assert!(
+            fx.storage_swap.load_full().get(key).is_err(),
+            "a failed RocksDB commit must not expose the mutation"
+        );
 
-        fx.cleanup().await;
+        fx.close()
+            .await
+            .assert_reopened_values(&[(key, None)])
+            .await;
     }
 
     #[tokio::test]
     async fn apply_stops_at_first_fatal_error() {
         let mut fx = Fixture::new();
 
+        fx.state_machine
+            .apply([entry_at(
+                2,
+                EntryPayload::Normal(string_put_binlog(b"before-failure", b"before")),
+            )])
+            .await
+            .expect("the entry before the injected failure should apply");
+
+        let _failure = fail_next_rocks_batch_commit(&fx.rocksdb_path());
+
         let err = fx
             .state_machine
             .apply([
-                entry_at(2, EntryPayload::Blank),
-                entry_at(3, EntryPayload::Normal(corrupt_binlog())),
-                entry_at(4, EntryPayload::Blank),
+                entry_at(
+                    3,
+                    EntryPayload::Normal(string_put_binlog(b"failed-write", b"failed")),
+                ),
+                entry_at(
+                    4,
+                    EntryPayload::Normal(string_put_binlog(b"after-failure", b"after")),
+                ),
             ])
             .await
             .expect_err("apply must abort at the first fatal error");
@@ -1375,7 +1460,29 @@ mod apply_ordering_tests {
             Some(2),
             "entries after a fatal error must not be applied"
         );
+        assert_eq!(
+            fx.storage_swap
+                .load_full()
+                .get(b"before-failure")
+                .expect("the mutation before the failure should remain applied"),
+            "before"
+        );
+        assert!(
+            fx.storage_swap.load_full().get(b"failed-write").is_err(),
+            "the mutation whose RocksDB commit failed must remain absent"
+        );
+        assert!(
+            fx.storage_swap.load_full().get(b"after-failure").is_err(),
+            "the mutation after the failure must not execute"
+        );
 
-        fx.cleanup().await;
+        fx.close()
+            .await
+            .assert_reopened_values(&[
+                (b"before-failure", Some("before")),
+                (b"failed-write", None),
+                (b"after-failure", None),
+            ])
+            .await;
     }
 }

--- a/src/raft/src/state_machine.rs
+++ b/src/raft/src/state_machine.rs
@@ -478,22 +478,41 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
         let mut responses = Vec::new();
 
         for entry in entries {
-            self.last_applied = Some(entry.log_id);
+            let log_id = entry.log_id;
 
             let response = match entry.payload {
                 EntryPayload::Blank => BinlogResponse::ok(),
                 EntryPayload::Normal(binlog) => {
-                    match self.apply_binlog(&binlog, entry.log_id.index).await {
-                        Ok(_) => BinlogResponse::ok(),
-                        Err(e) => BinlogResponse::error(e.to_string()),
+                    // Persist the mutation BEFORE advancing applied state. A binlog
+                    // carries physical put/delete ops only; deterministic business
+                    // rejections (e.g. WRONGTYPE) are decided upstream at command
+                    // execution and never reach apply. Any failure here (I/O,
+                    // corruption, invalid CF/slot) is therefore a fatal storage
+                    // error and must abort apply rather than be reported as a normal
+                    // response. Advancing `last_applied` past an entry that did not
+                    // durably commit would let this replica claim progress it does
+                    // not hold, diverging from the rest of the group.
+                    if let Err(e) = self.apply_binlog(&binlog, log_id.index).await {
+                        // Diagnostics only: log id, slot and mutation shape. Keys and
+                        // values are never logged.
+                        log::error!(
+                            "fatal storage error applying binlog: log_id={:?}, slot={}, ops={}",
+                            log_id,
+                            binlog.slot_idx,
+                            binlog.entries.len()
+                        );
+                        return Err(io_err_to_raft(e));
                     }
+                    BinlogResponse::ok()
                 }
                 EntryPayload::Membership(mem) => {
-                    self.last_membership = StoredMembership::new(Some(entry.log_id), mem);
+                    self.last_membership = StoredMembership::new(Some(log_id), mem);
                     BinlogResponse::ok()
                 }
             };
 
+            // Reached only after the entry has been durably applied.
+            self.last_applied = Some(log_id);
             responses.push(response);
         }
 
@@ -1158,5 +1177,205 @@ mod marker_cleanup_tests {
                 .contains(&cleanup_path.display().to_string()),
             "restart refusal must identify cleanup marker: {restart_error}"
         );
+    }
+}
+
+#[cfg(test)]
+mod apply_ordering_tests {
+    //! Covers issue #333: applied state must only advance after a committed entry
+    //! is durably applied, and a storage failure during apply is a fatal error
+    //! that aborts apply instead of being reported as a normal response.
+    #![allow(clippy::unwrap_used)]
+
+    use std::pin::Pin;
+
+    use conf::raft_type::{BinlogEntry, OperateType};
+    use openraft::{Entry, LeaderId};
+    use storage::{safe_cleanup_test_db, unique_test_db_path};
+
+    use super::*;
+
+    struct NoopPermit;
+    impl StorageAccessPermit for NoopPermit {}
+
+    /// The apply path only takes the snapshot-state gate; it never drives the
+    /// pause controller, so a no-op implementation is sufficient here.
+    struct NoopPauseController;
+    impl PauseController for NoopPauseController {
+        fn request_pause(&self) -> Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+            Box::pin(async {})
+        }
+
+        fn enter(
+            self: Arc<Self>,
+        ) -> Pin<Box<dyn std::future::Future<Output = Box<dyn StorageAccessPermit>> + Send + 'static>>
+        {
+            Box::pin(async { Box::new(NoopPermit) as Box<dyn StorageAccessPermit> })
+        }
+
+        fn resume(&self) {}
+    }
+
+    struct Fixture {
+        state_machine: KiwiStateMachine,
+        storage_swap: Arc<ArcSwap<Storage>>,
+        db_path: PathBuf,
+        snapshot_work_dir: PathBuf,
+        storage_rx: Box<dyn std::any::Any + Send>,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let db_path = unique_test_db_path();
+            let snapshot_work_dir = unique_test_db_path();
+            std::fs::create_dir_all(&snapshot_work_dir)
+                .expect("snapshot work directory should be created");
+
+            let mut storage = Storage::new(1, 0);
+            let options = Arc::new(StorageOptions::default());
+            let storage_rx = storage
+                .open(options, &db_path)
+                .expect("test storage should open");
+            let storage_swap = Arc::new(ArcSwap::from_pointee(storage));
+            let state_machine = KiwiStateMachine::new(
+                1,
+                Arc::clone(&storage_swap),
+                db_path.clone(),
+                snapshot_work_dir.clone(),
+                Arc::new(NoopPauseController),
+                None,
+            );
+
+            Self {
+                state_machine,
+                storage_swap,
+                db_path,
+                snapshot_work_dir,
+                storage_rx: Box::new(storage_rx),
+            }
+        }
+
+        async fn cleanup(self) {
+            let Fixture {
+                state_machine,
+                storage_swap,
+                db_path,
+                snapshot_work_dir,
+                storage_rx,
+            } = self;
+            drop(state_machine);
+            let storage = storage_swap.load_full();
+            drop(storage_swap);
+            let mut storage = match Arc::try_unwrap(storage) {
+                Ok(storage) => storage,
+                Err(_) => panic!("test storage should not retain Arc references during cleanup"),
+            };
+            storage.shutdown().await;
+            storage.close();
+            drop(storage_rx);
+            safe_cleanup_test_db(&db_path);
+            safe_cleanup_test_db(&snapshot_work_dir);
+        }
+    }
+
+    fn entry_at(index: u64, payload: EntryPayload<KiwiTypeConfig>) -> Entry<KiwiTypeConfig> {
+        Entry {
+            log_id: LogId::new(LeaderId::new(1, 1), index),
+            payload,
+        }
+    }
+
+    fn valid_put_binlog() -> Binlog {
+        Binlog {
+            db_id: 0,
+            slot_idx: 0,
+            entries: vec![BinlogEntry {
+                cf_idx: 0, // MetaCF
+                op_type: OperateType::Put,
+                key: b"k".to_vec(),
+                value: Some(b"v".to_vec()),
+            }],
+        }
+    }
+
+    /// An out-of-range column-family index makes `on_binlog_write` reject the
+    /// mutation, standing in for any fatal storage/corruption error at apply.
+    fn corrupt_binlog() -> Binlog {
+        Binlog {
+            db_id: 0,
+            slot_idx: 0,
+            entries: vec![BinlogEntry {
+                cf_idx: 99,
+                op_type: OperateType::Put,
+                key: b"k".to_vec(),
+                value: Some(b"v".to_vec()),
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_advances_applied_only_on_success() {
+        let mut fx = Fixture::new();
+        assert!(fx.state_machine.last_applied.is_none());
+
+        let responses = fx
+            .state_machine
+            .apply([entry_at(5, EntryPayload::Normal(valid_put_binlog()))])
+            .await
+            .expect("a valid binlog should apply cleanly");
+
+        assert_eq!(responses.len(), 1);
+        assert!(responses[0].success, "successful apply reports success");
+        assert_eq!(
+            fx.state_machine.last_applied.map(|l| l.index),
+            Some(5),
+            "applied state advances to the committed entry"
+        );
+
+        fx.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn apply_does_not_advance_applied_on_fatal_storage_error() {
+        let mut fx = Fixture::new();
+
+        let err = fx
+            .state_machine
+            .apply([entry_at(7, EntryPayload::Normal(corrupt_binlog()))])
+            .await
+            .expect_err("a storage failure during apply must surface as a fatal error");
+        // A non-empty error is enough; the point is that it is Err, not Ok.
+        let _ = err;
+
+        assert!(
+            fx.state_machine.last_applied.is_none(),
+            "applied state must not advance past an entry that failed to commit"
+        );
+
+        fx.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn apply_stops_at_first_fatal_error() {
+        let mut fx = Fixture::new();
+
+        let err = fx
+            .state_machine
+            .apply([
+                entry_at(2, EntryPayload::Blank),
+                entry_at(3, EntryPayload::Normal(corrupt_binlog())),
+                entry_at(4, EntryPayload::Blank),
+            ])
+            .await
+            .expect_err("apply must abort at the first fatal error");
+        let _ = err;
+
+        assert_eq!(
+            fx.state_machine.last_applied.map(|l| l.index),
+            Some(2),
+            "entries after a fatal error must not be applied"
+        );
+
+        fx.cleanup().await;
     }
 }

--- a/src/raft/tests/snapshot_logindex_test.rs
+++ b/src/raft/tests/snapshot_logindex_test.rs
@@ -27,12 +27,33 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 
-use conf::raft_type::Binlog;
+use conf::raft_type::{Binlog, BinlogEntry, OperateType};
 use openraft::RaftSnapshotBuilder;
 use openraft::storage::RaftStateMachine;
 use raft::state_machine::{KiwiStateMachine, PauseController, StorageAccessPermit};
+use storage::format_strings_value::StringValue;
 use storage::logindex::LogIndexAndSequenceCollector;
-use storage::{RaftSnapshotMeta, StorageOptions, storage::Storage, unique_test_db_path};
+use storage::slot_indexer::key_to_slot_id;
+use storage::{
+    BaseMetaKey, ColumnFamilyIndex, RaftSnapshotMeta, StorageOptions, storage::Storage,
+    unique_test_db_path,
+};
+
+fn string_put_binlog(key: &[u8], value: &[u8]) -> Binlog {
+    Binlog {
+        db_id: 0,
+        slot_idx: key_to_slot_id(key) as u32,
+        entries: vec![BinlogEntry {
+            cf_idx: ColumnFamilyIndex::MetaCF as u32,
+            op_type: OperateType::Put,
+            key: BaseMetaKey::new(key)
+                .encode()
+                .expect("snapshot logindex key should encode")
+                .to_vec(),
+            value: Some(StringValue::new(value.to_vec()).encode().to_vec()),
+        }],
+    }
+}
 
 struct NoopPauseController;
 struct NoopStorageAccessPermit;
@@ -93,16 +114,7 @@ async fn test_snapshot_with_logindex_state() -> anyhow::Result<()> {
         // Simulate binlog write to update collector with (log_index, seqno) mapping
         // This simulates what happens during Raft replication
         {
-            let binlog = Binlog {
-                db_id: 0,
-                slot_idx: 0,
-                entries: vec![conf::raft_type::BinlogEntry {
-                    cf_idx: 0,
-                    op_type: conf::raft_type::OperateType::Put,
-                    key: b"test_key".to_vec(),
-                    value: Some(b"test_value".to_vec()),
-                }],
-            };
+            let binlog = string_put_binlog(b"test_key", b"test_value");
 
             const TEST_LOG_INDEX: u64 = 100;
             storage.on_binlog_write(&binlog, TEST_LOG_INDEX)?;
@@ -220,16 +232,7 @@ async fn test_on_binlog_write_updates_collector() -> anyhow::Result<()> {
     let initial_size = collector.size();
 
     // Write binlog with log_index = 100
-    let binlog = Binlog {
-        db_id: 0,
-        slot_idx: 0,
-        entries: vec![conf::raft_type::BinlogEntry {
-            cf_idx: 0,
-            op_type: conf::raft_type::OperateType::Put,
-            key: b"key1".to_vec(),
-            value: Some(b"value1".to_vec()),
-        }],
-    };
+    let binlog = string_put_binlog(b"key1", b"value1");
 
     storage.on_binlog_write(&binlog, 100)?;
 
@@ -241,16 +244,7 @@ async fn test_on_binlog_write_updates_collector() -> anyhow::Result<()> {
     );
 
     // Write another binlog with log_index = 200
-    let binlog2 = Binlog {
-        db_id: 0,
-        slot_idx: 0,
-        entries: vec![conf::raft_type::BinlogEntry {
-            cf_idx: 0,
-            op_type: conf::raft_type::OperateType::Put,
-            key: b"key2".to_vec(),
-            value: Some(b"value2".to_vec()),
-        }],
-    };
+    let binlog2 = string_put_binlog(b"key2", b"value2");
 
     storage.on_binlog_write(&binlog2, 200)?;
 

--- a/src/storage/src/batch.rs
+++ b/src/storage/src/batch.rs
@@ -39,15 +39,60 @@
 
 use std::sync::Arc;
 
+#[cfg(any(test, feature = "test-fault-injection"))]
+use std::collections::HashSet;
+#[cfg(any(test, feature = "test-fault-injection"))]
+use std::path::{Path, PathBuf};
+#[cfg(any(test, feature = "test-fault-injection"))]
+use std::sync::LazyLock;
+
 use conf::raft_type::{Binlog, BinlogEntry, BinlogResponse, OperateType};
 use rocksdb::{BoundColumnFamily, DB, WriteBatch, WriteOptions};
 use snafu::ResultExt;
 
+#[cfg(any(test, feature = "test-fault-injection"))]
+use parking_lot::Mutex;
+
 use crate::ColumnFamilyIndex;
 use crate::error::{BatchSnafu, InvalidFormatSnafu, Result, RocksSnafu};
 use crate::slot_indexer::key_to_slot_id;
-use crate::storage_define::{PREFIX_RESERVE_LENGTH, decode_user_key, seek_userkey_delim};
+use crate::storage_define::{
+    PREFIX_RESERVE_LENGTH, SUFFIX_RESERVE_LENGTH, VERSION_LENGTH, decode_user_key,
+    seek_userkey_delim,
+};
 use bytes::BytesMut;
+
+#[cfg(any(test, feature = "test-fault-injection"))]
+static ROCKS_BATCH_COMMIT_FAILURES: LazyLock<Mutex<HashSet<PathBuf>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+/// Removes an unconsumed RocksDB batch commit failpoint when a test exits early.
+#[cfg(any(test, feature = "test-fault-injection"))]
+#[doc(hidden)]
+pub struct RocksBatchCommitFailureGuard {
+    db_path: PathBuf,
+}
+
+#[cfg(any(test, feature = "test-fault-injection"))]
+impl Drop for RocksBatchCommitFailureGuard {
+    fn drop(&mut self) {
+        ROCKS_BATCH_COMMIT_FAILURES.lock().remove(&self.db_path);
+    }
+}
+
+/// Inject exactly one failure immediately before a RocksDB batch is committed.
+#[cfg(any(test, feature = "test-fault-injection"))]
+#[doc(hidden)]
+#[must_use]
+pub fn fail_next_rocks_batch_commit(db_path: &Path) -> RocksBatchCommitFailureGuard {
+    let db_path = db_path.to_path_buf();
+    assert!(
+        ROCKS_BATCH_COMMIT_FAILURES.lock().insert(db_path.clone()),
+        "RocksDB batch commit failure already registered for {}",
+        db_path.display()
+    );
+    RocksBatchCommitFailureGuard { db_path }
+}
 
 /// Trait for batch write operations.
 ///
@@ -205,6 +250,17 @@ impl<'a> Batch for RocksBatch<'a> {
     }
 
     fn commit(self: Box<Self>) -> Result<()> {
+        #[cfg(any(test, feature = "test-fault-injection"))]
+        if ROCKS_BATCH_COMMIT_FAILURES.lock().remove(self.db.path()) {
+            return BatchSnafu {
+                message: format!(
+                    "injected RocksDB batch commit failure for {}",
+                    self.db.path().display()
+                ),
+            }
+            .fail();
+        }
+
         self.db
             .write_opt(&self.inner, self.write_options)
             .context(RocksSnafu)
@@ -248,17 +304,33 @@ impl BinlogBatch {
     }
 
     pub(crate) fn infer_user_key(cf_idx: u32, encoded_key: &[u8]) -> Result<Vec<u8>> {
-        if cf_idx as usize >= ColumnFamilyIndex::COUNT {
-            return InvalidFormatSnafu {
-                message: format!("Invalid column family index: {cf_idx}"),
+        let tail_length = match cf_idx {
+            value if value == ColumnFamilyIndex::MetaCF as u32 => SUFFIX_RESERVE_LENGTH,
+            value
+                if value == ColumnFamilyIndex::HashesDataCF as u32
+                    || value == ColumnFamilyIndex::SetsDataCF as u32
+                    || value == ColumnFamilyIndex::ZsetsDataCF as u32 =>
+            {
+                VERSION_LENGTH + SUFFIX_RESERVE_LENGTH
             }
-            .fail();
-        }
+            value if value == ColumnFamilyIndex::ListsDataCF as u32 => {
+                2 * VERSION_LENGTH + SUFFIX_RESERVE_LENGTH
+            }
+            value if value == ColumnFamilyIndex::ZsetsScoreCF as u32 => {
+                2 * VERSION_LENGTH + SUFFIX_RESERVE_LENGTH
+            }
+            _ => {
+                return InvalidFormatSnafu {
+                    message: format!("Invalid column family index: {cf_idx}"),
+                }
+                .fail();
+            }
+        };
 
-        if encoded_key.len() <= PREFIX_RESERVE_LENGTH {
+        if encoded_key.len() < PREFIX_RESERVE_LENGTH + 2 + tail_length {
             return InvalidFormatSnafu {
                 message: format!(
-                    "Encoded key too short to infer binlog slot: len={}",
+                    "Encoded key is too short for column family {cf_idx}: len={}",
                     encoded_key.len()
                 ),
             }
@@ -268,9 +340,24 @@ impl BinlogBatch {
         let key_part_start = PREFIX_RESERVE_LENGTH;
         let key_part = &encoded_key[key_part_start..];
         let key_part_end = seek_userkey_delim(key_part);
-        if key_part_end > key_part.len() {
+        if key_part_end == key_part.len() {
             return InvalidFormatSnafu {
                 message: "Encoded key delimiter not found while inferring binlog slot".to_string(),
+            }
+            .fail();
+        }
+
+        let remaining = key_part.len() - key_part_end;
+        let has_valid_tail = match cf_idx {
+            value if value == ColumnFamilyIndex::MetaCF as u32 => remaining == tail_length,
+            value if value == ColumnFamilyIndex::ListsDataCF as u32 => remaining == tail_length,
+            _ => remaining >= tail_length,
+        };
+        if !has_valid_tail {
+            return InvalidFormatSnafu {
+                message: format!(
+                    "Encoded key has invalid physical layout for column family {cf_idx}: trailing bytes={remaining}"
+                ),
             }
             .fail();
         }
@@ -278,6 +365,53 @@ impl BinlogBatch {
         let mut user_key = BytesMut::new();
         decode_user_key(&key_part[..key_part_end], &mut user_key)?;
         Ok(user_key.to_vec())
+    }
+
+    pub(crate) fn validate_binlog_entries(binlog: &Binlog) -> Result<()> {
+        if binlog.entries.is_empty() {
+            return InvalidFormatSnafu {
+                message: "Raft binlog must contain at least one entry".to_string(),
+            }
+            .fail();
+        }
+
+        for entry in &binlog.entries {
+            match (&entry.op_type, &entry.value) {
+                (OperateType::Put, Some(_)) | (OperateType::Delete, None) => {}
+                (OperateType::Put, None) => {
+                    return InvalidFormatSnafu {
+                        message: "Put binlog entry must contain a value".to_string(),
+                    }
+                    .fail();
+                }
+                (OperateType::Delete, Some(_)) => {
+                    return InvalidFormatSnafu {
+                        message: "Delete binlog entry must not contain a value".to_string(),
+                    }
+                    .fail();
+                }
+                (OperateType::NoOp, _) => {
+                    return InvalidFormatSnafu {
+                        message: "Normal Raft binlog cannot contain NoOp entries".to_string(),
+                    }
+                    .fail();
+                }
+            }
+
+            let user_key = Self::infer_user_key(entry.cf_idx, &entry.key)?;
+            let actual_slot = key_to_slot_id(&user_key) as u32;
+            if actual_slot != binlog.slot_idx {
+                return InvalidFormatSnafu {
+                    message: format!(
+                        "Binlog slot {} does not match encoded key slot {actual_slot}",
+                        binlog.slot_idx
+                    ),
+                }
+                .fail();
+            }
+        }
+
+        Ok(())
     }
 
     fn infer_slot_idx(entries: &[BinlogEntry]) -> Result<u32> {

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -63,6 +63,8 @@ pub mod redis_zsets;
 // LogIndex module for Raft snapshot integration
 pub mod logindex;
 
+#[cfg(any(test, feature = "test-fault-injection"))]
+pub use batch::fail_next_rocks_batch_commit;
 pub use batch::{AppendLogFn, Batch, BinlogBatch, RocksBatch};
 pub use checkpoint::{
     PreparedCheckpointRestore, RAFT_SNAPSHOT_META_FILE, RaftSnapshotMeta,

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -517,10 +517,36 @@ impl Storage {
     /// commit, which is monotonic but per-DB-global; concurrent writers from other
     /// threads would inflate the captured seqno and break the
     /// "log L is persisted at seqno >= S" guarantee that snapshot/purge depends on.
+    pub fn validate_binlog(&self, binlog: &Binlog) -> Result<()> {
+        let expected_db_id = u32::try_from(self.db_id).map_err(|_| Error::InvalidFormat {
+            message: format!("Storage database ID {} exceeds the Raft format", self.db_id),
+            location: snafu::location!(),
+        })?;
+        if binlog.db_id != expected_db_id {
+            return Err(Error::InvalidFormat {
+                message: format!(
+                    "Binlog database {} does not match storage database {expected_db_id}",
+                    binlog.db_id
+                ),
+                location: snafu::location!(),
+            });
+        }
+
+        crate::batch::BinlogBatch::validate_binlog_entries(binlog)
+    }
+
     pub fn on_binlog_write(&self, binlog: &Binlog, raft_log_index: u64) -> Result<()> {
+        self.validate_binlog(binlog)?;
+
         let slot_id = binlog.slot_idx as usize;
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        let instance = &self.insts[instance_id];
+        let instance = self.insts.get(instance_id).ok_or_else(|| Error::System {
+            message: format!(
+                "Storage instance {instance_id} is unavailable for slot {}",
+                binlog.slot_idx
+            ),
+            location: snafu::location!(),
+        })?;
 
         let mut batch = instance.create_rocks_batch()?;
 
@@ -542,14 +568,21 @@ impl Storage {
 
             match entry.op_type {
                 OperateType::Put => {
-                    if let Some(value) = &entry.value {
-                        batch.put(cf_idx, &entry.key, value)?;
-                    }
+                    let value = entry.value.as_ref().ok_or_else(|| Error::InvalidFormat {
+                        message: "Put binlog entry must contain a value".to_string(),
+                        location: snafu::location!(),
+                    })?;
+                    batch.put(cf_idx, &entry.key, value)?;
                 }
                 OperateType::Delete => {
                     batch.delete(cf_idx, &entry.key)?;
                 }
-                OperateType::NoOp => {}
+                OperateType::NoOp => {
+                    return Err(Error::InvalidFormat {
+                        message: "Normal Raft binlog cannot contain NoOp entries".to_string(),
+                        location: snafu::location!(),
+                    });
+                }
             }
         }
 
@@ -659,7 +692,10 @@ impl Storage {
 mod append_log_fn_tests {
     use super::*;
     use crate::batch::AppendLogFn;
-    use conf::raft_type::BinlogResponse;
+    use crate::format_base_key::BaseMetaKey;
+    use crate::format_strings_value::StringValue;
+    use crate::slot_indexer::key_to_slot_id;
+    use conf::raft_type::{Binlog, BinlogEntry, BinlogResponse, OperateType};
     use std::sync::Arc;
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -673,6 +709,101 @@ mod append_log_fn_tests {
     // there; they still run in normal CI and locally.
     fn running_under_sanitizer() -> bool {
         std::env::var_os("LSAN_OPTIONS").is_some()
+    }
+
+    fn string_put_binlog(db_id: u32, key: &[u8], value: &[u8]) -> Binlog {
+        Binlog {
+            db_id,
+            slot_idx: key_to_slot_id(key) as u32,
+            entries: vec![BinlogEntry {
+                cf_idx: ColumnFamilyIndex::MetaCF as u32,
+                op_type: OperateType::Put,
+                key: BaseMetaKey::new(key)
+                    .encode()
+                    .expect("test string key should encode")
+                    .to_vec(),
+                value: Some(StringValue::new(value.to_vec()).encode().to_vec()),
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn on_binlog_write_rejects_noncanonical_binlogs_before_commit() {
+        if running_under_sanitizer() {
+            return;
+        }
+
+        let path = crate::unique_test_db_path();
+        let mut storage = Storage::new(2, 0);
+        let _rx = storage
+            .open(Arc::new(crate::StorageOptions::default()), &path)
+            .expect("test storage should open");
+
+        let mut wrong_db = string_put_binlog(1, b"wrong-db", b"value");
+        assert!(
+            storage.on_binlog_write(&wrong_db, 1).is_err(),
+            "a binlog for another database must be rejected"
+        );
+        assert!(storage.get(b"wrong-db").is_err());
+
+        let correct_slot = wrong_db.slot_idx;
+        wrong_db.db_id = 0;
+        wrong_db.slot_idx = correct_slot.wrapping_add(1);
+        assert!(
+            storage.on_binlog_write(&wrong_db, 2).is_err(),
+            "declared slot must match every encoded user key"
+        );
+        assert!(storage.get(b"wrong-db").is_err());
+
+        let mut invalid_cf = string_put_binlog(0, b"invalid-cf", b"value");
+        invalid_cf.entries[0].cf_idx = 99;
+        assert!(
+            storage.on_binlog_write(&invalid_cf, 3).is_err(),
+            "unknown column families must be rejected"
+        );
+
+        let mut put_without_value = string_put_binlog(0, b"missing-value", b"value");
+        put_without_value.entries[0].value = None;
+        assert!(
+            storage.on_binlog_write(&put_without_value, 4).is_err(),
+            "Put without a value must be rejected"
+        );
+
+        let mut delete_with_value = string_put_binlog(0, b"delete-value", b"value");
+        delete_with_value.entries[0].op_type = OperateType::Delete;
+        assert!(
+            storage.on_binlog_write(&delete_with_value, 5).is_err(),
+            "Delete with a value must be rejected"
+        );
+
+        let mut noop = string_put_binlog(0, b"noop", b"value");
+        noop.entries[0].op_type = OperateType::NoOp;
+        noop.entries[0].value = None;
+        assert!(
+            storage.on_binlog_write(&noop, 6).is_err(),
+            "Normal Raft binlogs must contain physical Put/Delete operations"
+        );
+
+        let empty = Binlog {
+            db_id: 0,
+            slot_idx: 0,
+            entries: Vec::new(),
+        };
+        assert!(
+            storage.on_binlog_write(&empty, 7).is_err(),
+            "empty batches must not create Normal Raft entries"
+        );
+
+        let mut malformed_key = string_put_binlog(0, b"malformed", b"value");
+        malformed_key.entries[0].key = b"not-a-physical-key".to_vec();
+        assert!(
+            storage.on_binlog_write(&malformed_key, 8).is_err(),
+            "column-family key layout must be validated"
+        );
+
+        storage.shutdown().await;
+        storage.close();
+        crate::safe_cleanup_test_db(&path);
     }
 
     #[tokio::test]
@@ -747,7 +878,6 @@ mod append_log_fn_tests {
 
     #[tokio::test]
     async fn test_on_binlog_write_does_not_recurse_in_cluster_mode() {
-        use conf::raft_type::{Binlog, BinlogEntry, OperateType};
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         if running_under_sanitizer() {
@@ -768,16 +898,7 @@ mod append_log_fn_tests {
         });
         storage.set_append_log_fn(f);
 
-        let binlog = Binlog {
-            db_id: 0,
-            slot_idx: 0,
-            entries: vec![BinlogEntry {
-                cf_idx: 0,
-                op_type: OperateType::Put,
-                key: b"applied_key".to_vec(),
-                value: Some(b"applied_val".to_vec()),
-            }],
-        };
+        let binlog = string_put_binlog(0, b"applied_key", b"applied_val");
 
         storage.on_binlog_write(&binlog, 1).unwrap();
 


### PR DESCRIPTION
## Summary

Fixes #333 (P0, data consistency).

`KiwiStateMachine::apply()` had two defects on the apply path
(`src/raft/src/state_machine.rs`):

1. It advanced `self.last_applied` **before** the business mutation was
   persisted to storage.
2. It demoted storage failures returned by `apply_binlog` into ordinary
   `BinlogResponse::error` values instead of surfacing them as fatal
   `StorageError`s to OpenRaft.

Together, a replica could mark a committed entry as applied even though its
write never durably committed. Followers would then advance past an
unpersisted entry and diverge from the rest of the group.

## Change

- Persist the mutation first; advance `last_applied` **only after** it
  succeeds.
- Treat any `apply_binlog` failure as fatal: return `StorageError` and stop
  consuming further committed entries. A binlog carries physical put/delete
  ops only — deterministic business rejections (e.g. `WRONGTYPE`) are decided
  upstream at command execution and never reach apply — so a failure here
  (I/O, corruption, invalid CF/slot) is a storage-fatal error by
  construction.
- On a fatal error, log `log_id`, `slot` and mutation shape (op count) only;
  keys and values are never logged.

The change is confined to the `apply` loop; `Blank` and `Membership` entries
keep their previous outcomes and advance applied state after handling.

## Acceptance criteria (#333)

- [x] `last_applied` does not advance when the storage commit fails
- [x] apply stops and does not consume the next entry after a fatal error
- [x] deterministic business rejections — not reachable at the binlog-apply
      layer; the type boundary is documented in-code rather than fabricated
- [x] unit tests cover apply ordering and error classification
- [x] logs do not contain sensitive values

## Tests

New `apply_ordering_tests` module:

- `apply_advances_applied_only_on_success`
- `apply_does_not_advance_applied_on_fatal_storage_error`
- `apply_stops_at_first_fatal_error`

## Verification (Rust 1.97.1, MSVC)

- `cargo fmt -- --check` — pass
- `cargo test -p raft` — pass (3 new + existing state_machine tests)
- `cargo clippy -p raft -- -D warnings -D clippy::unwrap_used` — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Storage failures during committed state updates are now fatal; application stops immediately on the first fatal error.
  * `last_applied` advances only after an update is durably persisted (and won’t move on fatal failures).
  * Binlog handling is stricter: invalid `db_id`/slot mapping, invalid CF index, missing `Put` value, `Delete` with value, `NoOp`, and malformed layouts are rejected before commit.
* **New Features**
  * Client/GPRC write errors now clearly report invalid binlog input (including out-of-range values) as `InvalidArgument`, avoiding silent truncation.
* **Tests**
  * Added apply-ordering coverage, expanded binlog validation tests, and improved test helpers (including snapshot/logindex updates).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->