### PR TITLE
feat(cmd): add SMISMEMBER command

### DIFF
--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -79,6 +79,7 @@ pub mod sinter;
 pub mod sinterstore;
 pub mod sismember;
 pub mod smembers;
+pub mod smismember;
 pub mod smove;
 pub mod spop;
 pub mod srandmember;

--- a/src/cmd/src/smismember.rs
+++ b/src/cmd/src/smismember.rs
@@ -1,0 +1,127 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use client::Client;
+use resp::RespData;
+use storage::storage::Storage;
+
+use crate::{AclCategory, Cmd, CmdFlags, CmdMeta};
+use crate::{impl_cmd_clone_box, impl_cmd_meta};
+
+#[derive(Clone, Default)]
+pub struct SmismemberCmd {
+    meta: CmdMeta,
+}
+
+impl SmismemberCmd {
+    pub fn new() -> Self {
+        Self {
+            meta: CmdMeta {
+                name: "smismember".to_string(),
+                arity: -3, // SMISMEMBER key member [member ...]
+                flags: CmdFlags::READONLY | CmdFlags::FAST,
+                acl_category: AclCategory::SET | AclCategory::READ,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl Cmd for SmismemberCmd {
+    impl_cmd_meta!();
+    impl_cmd_clone_box!();
+
+    fn do_initial(&self, client: &Client) -> bool {
+        let argv = client.argv();
+        let key = argv[1].clone();
+        client.set_key(&key);
+        true
+    }
+
+    fn do_cmd(&self, client: &Client, storage: Arc<Storage>) {
+        let key = client.key();
+        let argv = client.argv();
+
+        // One reply element per requested member, preserving input order.
+        // `sismember` returns Ok(false) for a missing or expired key, so a
+        // non-existent set yields all zeros; it only errors on a wrong-type
+        // key, in which case the whole command reports that error (matching
+        // Redis, which rejects SMISMEMBER on a non-set key).
+        let mut replies = Vec::with_capacity(argv.len().saturating_sub(2));
+        for member in &argv[2..] {
+            match storage.sismember(&key, member) {
+                Ok(is_member) => {
+                    replies.push(RespData::Integer(if is_member { 1 } else { 0 }));
+                }
+                Err(e) => {
+                    client.set_reply(RespData::Error(format!("ERR {e}").into()));
+                    return;
+                }
+            }
+        }
+
+        client.set_reply(RespData::Array(Some(replies)));
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_smismember_cmd_meta() {
+        let cmd = SmismemberCmd::new();
+        assert_eq!(cmd.name(), "smismember");
+        assert_eq!(cmd.meta().arity, -3); // SMISMEMBER key member [member ...]
+        assert!(cmd.has_flag(CmdFlags::READONLY));
+        assert!(cmd.has_flag(CmdFlags::FAST));
+        assert!(!cmd.has_flag(CmdFlags::WRITE));
+    }
+
+    #[test]
+    fn test_smismember_cmd_clone() {
+        let cmd = SmismemberCmd::new();
+        let cloned = cmd.clone_box();
+        assert_eq!(cloned.name(), cmd.name());
+        assert_eq!(cloned.meta().arity, cmd.meta().arity);
+    }
+
+    #[test]
+    fn test_smismember_acl_category() {
+        let cmd = SmismemberCmd::new();
+        assert!(cmd.acl_category().contains(AclCategory::SET));
+        assert!(cmd.acl_category().contains(AclCategory::READ));
+    }
+
+    #[test]
+    fn test_smismember_argument_validation() {
+        let cmd = SmismemberCmd::new();
+
+        // Valid: command + key + one or more members
+        assert!(cmd.check_arg(3)); // SMISMEMBER key member
+        assert!(cmd.check_arg(4)); // SMISMEMBER key member member
+        assert!(cmd.check_arg(10));
+
+        // Invalid: missing key and/or member
+        assert!(!cmd.check_arg(2)); // Missing member
+        assert!(!cmd.check_arg(1)); // Missing key and member
+        assert!(!cmd.check_arg(0)); // No arguments
+    }
+}

--- a/src/cmd/src/smismember.rs
+++ b/src/cmd/src/smismember.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use client::Client;
 use resp::RespData;
-use storage::storage::Storage;
+use storage::{error::Error, storage::Storage};
 
 use crate::{AclCategory, Cmd, CmdFlags, CmdMeta};
 use crate::{impl_cmd_clone_box, impl_cmd_meta};
@@ -58,25 +58,22 @@ impl Cmd for SmismemberCmd {
         let key = client.key();
         let argv = client.argv();
 
-        // One reply element per requested member, preserving input order.
-        // `sismember` returns Ok(false) for a missing or expired key, so a
-        // non-existent set yields all zeros; it only errors on a wrong-type
-        // key, in which case the whole command reports that error (matching
-        // Redis, which rejects SMISMEMBER on a non-set key).
-        let mut replies = Vec::with_capacity(argv.len().saturating_sub(2));
-        for member in &argv[2..] {
-            match storage.sismember(&key, member) {
-                Ok(is_member) => {
-                    replies.push(RespData::Integer(if is_member { 1 } else { 0 }));
-                }
-                Err(e) => {
-                    client.set_reply(RespData::Error(format!("ERR {e}").into()));
-                    return;
-                }
+        let members: Vec<&[u8]> = argv[2..].iter().map(|member| member.as_ref()).collect();
+        match storage.smismember(&key, &members) {
+            Ok(results) => {
+                let replies = results
+                    .into_iter()
+                    .map(|is_member| RespData::Integer(if is_member { 1 } else { 0 }))
+                    .collect();
+                client.set_reply(RespData::Array(Some(replies)));
+            }
+            Err(Error::RedisErr { message, .. }) => {
+                client.set_reply(RespData::Error(message.into()));
+            }
+            Err(e) => {
+                client.set_reply(RespData::Error(format!("ERR {e}").into()));
             }
         }
-
-        client.set_reply(RespData::Array(Some(replies)));
     }
 }
 

--- a/src/cmd/src/table.rs
+++ b/src/cmd/src/table.rs
@@ -137,6 +137,7 @@ pub fn create_command_table(requirepass_provider: RequirepassProvider) -> CmdTab
         crate::sinterstore::SinterstoreCmd,
         crate::sismember::SismemberCmd,
         crate::smembers::SmembersCmd,
+        crate::smismember::SmismemberCmd,
         crate::smove::SmoveCmd,
         crate::spop::SpopCmd,
         crate::srandmember::SrandmemberCmd,

--- a/src/net/tests/storage_command_e2e_tests.rs
+++ b/src/net/tests/storage_command_e2e_tests.rs
@@ -239,7 +239,7 @@ async fn send_command_and_read_line(stream: &mut tokio::net::TcpStream, args: &[
             if response.ends_with(b"\r\n") {
                 return Bytes::from(response);
             }
-            assert!(response.len() < 64, "unexpectedly long RESP line");
+            assert!(response.len() < 256, "unexpectedly long RESP line");
         }
     })
     .await
@@ -512,6 +512,98 @@ async fn storage_command_e2e_rank_nulls_follow_negotiated_wire_protocol() {
             send_command_and_read_line(&mut stream, &[command, "missing-zset", "member"]).await;
         assert_eq!(reply, Bytes::from_static(b"_\r\n"), "{command}");
     }
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn storage_command_e2e_smismember_matches_redis_semantics() {
+    let server = TestServer::start(None).await;
+    let mut stream = tokio::net::TcpStream::connect(server.addr)
+        .await
+        .expect("connect to server");
+
+    let reply = send_command(&mut stream, &["SADD", "members", "a", "b"]).await;
+    assert_eq!(reply, RespData::Integer(2));
+
+    let reply = send_command(
+        &mut stream,
+        &["SMISMEMBER", "members", "a", "missing", "b", "a"],
+    )
+    .await;
+    assert_eq!(
+        reply,
+        RespData::Array(Some(vec![
+            RespData::Integer(1),
+            RespData::Integer(0),
+            RespData::Integer(1),
+            RespData::Integer(1),
+        ]))
+    );
+
+    let reply = send_command(&mut stream, &["SMISMEMBER", "missing-set", "a", "b"]).await;
+    assert_eq!(
+        reply,
+        RespData::Array(Some(vec![RespData::Integer(0), RespData::Integer(0)]))
+    );
+
+    let binary_member = [0xff, 0, 0xfe];
+    let reply = send_binary_command(
+        &mut stream,
+        &[b"SADD", b"binary-members", &binary_member, b""],
+    )
+    .await;
+    assert_eq!(reply, RespData::Integer(2));
+
+    let reply = send_binary_command(
+        &mut stream,
+        &[
+            b"SMISMEMBER",
+            b"binary-members",
+            &binary_member,
+            b"absent",
+            b"",
+        ],
+    )
+    .await;
+    assert_eq!(
+        reply,
+        RespData::Array(Some(vec![
+            RespData::Integer(1),
+            RespData::Integer(0),
+            RespData::Integer(1),
+        ]))
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn storage_command_e2e_smismember_preserves_redis_errors() {
+    let server = TestServer::start(None).await;
+    let mut stream = tokio::net::TcpStream::connect(server.addr)
+        .await
+        .expect("connect to server");
+
+    let reply = send_command(&mut stream, &["SET", "not-a-set", "value"]).await;
+    assert_eq!(reply, RespData::SimpleString(Bytes::from_static(b"OK")));
+
+    let reply =
+        send_command_and_read_line(&mut stream, &["SMISMEMBER", "not-a-set", "member"]).await;
+    assert_eq!(
+        reply,
+        Bytes::from_static(
+            b"-WRONGTYPE Operation against a key holding the wrong kind of value\r\n"
+        )
+    );
+
+    let reply = send_command(&mut stream, &["SMISMEMBER", "members"]).await;
+    assert_eq!(
+        reply,
+        RespData::Error(Bytes::from_static(
+            b"ERR wrong number of arguments for 'smismember' command"
+        ))
+    );
 
     server.shutdown().await;
 }

--- a/src/storage/src/redis_sets.rs
+++ b/src/storage/src/redis_sets.rs
@@ -20,6 +20,12 @@
 
 use std::collections::HashSet;
 
+#[cfg(test)]
+use std::sync::{
+    Arc as TestArc, Mutex, OnceLock, Weak,
+    atomic::{AtomicBool, Ordering},
+};
+
 use bytes::Bytes;
 use kstd::lock_mgr::ScopeRecordLock;
 use rocksdb::{Direction, IteratorMode, ReadOptions};
@@ -35,6 +41,98 @@ use crate::{
     format_member_data_key::MemberDataKey,
     storage_define::SUFFIX_RESERVE_LENGTH,
 };
+
+#[cfg(test)]
+struct SmismemberSnapshotTestGate {
+    key: Vec<u8>,
+    entered: AtomicBool,
+    released: AtomicBool,
+}
+
+#[cfg(test)]
+impl SmismemberSnapshotTestGate {
+    fn new(key: &[u8]) -> TestArc<Self> {
+        TestArc::new(Self {
+            key: key.to_vec(),
+            entered: AtomicBool::new(false),
+            released: AtomicBool::new(false),
+        })
+    }
+
+    fn wait_until_entered(&self) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !self.entered.load(Ordering::SeqCst) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "SMISMEMBER did not reach the first membership lookup"
+            );
+            std::thread::yield_now();
+        }
+    }
+
+    fn release(&self) {
+        self.released.store(true, Ordering::SeqCst);
+    }
+
+    fn enter_and_wait(&self) {
+        self.entered.store(true, Ordering::SeqCst);
+        while !self.released.load(Ordering::SeqCst) {
+            std::thread::yield_now();
+        }
+    }
+}
+
+#[cfg(test)]
+type SmismemberSnapshotTestGateRegistry = Mutex<Option<Weak<SmismemberSnapshotTestGate>>>;
+
+#[cfg(test)]
+fn smismember_snapshot_test_gate_registry() -> &'static SmismemberSnapshotTestGateRegistry {
+    static GATE: OnceLock<SmismemberSnapshotTestGateRegistry> = OnceLock::new();
+    GATE.get_or_init(|| Mutex::new(None))
+}
+
+#[cfg(test)]
+struct SmismemberSnapshotTestGateGuard {
+    gate: TestArc<SmismemberSnapshotTestGate>,
+}
+
+#[cfg(test)]
+impl Drop for SmismemberSnapshotTestGateGuard {
+    fn drop(&mut self) {
+        self.gate.release();
+        *smismember_snapshot_test_gate_registry()
+            .lock()
+            .expect("SMISMEMBER snapshot test gate registry should not be poisoned") = None;
+    }
+}
+
+#[cfg(test)]
+fn install_smismember_snapshot_test_gate(
+    gate: TestArc<SmismemberSnapshotTestGate>,
+) -> SmismemberSnapshotTestGateGuard {
+    let mut installed = smismember_snapshot_test_gate_registry()
+        .lock()
+        .expect("SMISMEMBER snapshot test gate registry should not be poisoned");
+    assert!(
+        installed.is_none(),
+        "only one SMISMEMBER snapshot test gate may be installed"
+    );
+    *installed = Some(TestArc::downgrade(&gate));
+    drop(installed);
+    SmismemberSnapshotTestGateGuard { gate }
+}
+
+#[cfg(test)]
+fn block_after_first_smismember_lookup_for_test(key: &[u8]) {
+    let gate = smismember_snapshot_test_gate_registry()
+        .lock()
+        .expect("SMISMEMBER snapshot test gate registry should not be poisoned")
+        .as_ref()
+        .and_then(Weak::upgrade);
+    if let Some(gate) = gate.filter(|gate| gate.key == key) {
+        gate.enter_and_wait();
+    }
+}
 
 impl Redis {
     /// Add one or more members to a set
@@ -321,6 +419,64 @@ impl Redis {
             .is_some();
 
         Ok(exists)
+    }
+
+    /// Check if each member is a member of the set stored at key.
+    pub fn smismember(&self, key: &[u8], members: &[&[u8]]) -> Result<Vec<bool>> {
+        let db = self.db.as_ref().context(OptionNoneSnafu {
+            message: "db is not initialized".to_string(),
+        })?;
+
+        let cf_meta = self
+            .get_cf_handle(ColumnFamilyIndex::MetaCF)
+            .context(OptionNoneSnafu {
+                message: "cf is not initialized".to_string(),
+            })?;
+        let cf_data =
+            self.get_cf_handle(ColumnFamilyIndex::SetsDataCF)
+                .context(OptionNoneSnafu {
+                    message: "cf data is not initialized".to_string(),
+                })?;
+
+        let snapshot = db.snapshot();
+        let mut read_options = ReadOptions::default();
+        read_options.set_snapshot(&snapshot);
+
+        let base_meta_key = BaseMetaKey::new(key).encode()?;
+        let meta_val = db
+            .get_cf_opt(&cf_meta, &base_meta_key, &read_options)
+            .context(RocksSnafu)?;
+        let Some(val) = meta_val else {
+            return Ok(vec![false; members.len()]);
+        };
+
+        match self.check_type_state(val.as_ref(), DataType::Set)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => {
+                return Ok(vec![false; members.len()]);
+            }
+            TypeCheckState::Match => {}
+        }
+
+        let set_meta = ParsedSetsMetaValue::new(&val[..])?;
+        if !set_meta.is_valid() {
+            return Ok(vec![false; members.len()]);
+        }
+        let version = set_meta.version();
+
+        let mut result = Vec::with_capacity(members.len());
+        for &member in members {
+            let member_key = MemberDataKey::new(key, version, member).encode()?;
+            let exists = db
+                .get_cf_opt(&cf_data, &member_key, &read_options)
+                .context(RocksSnafu)?
+                .is_some();
+            result.push(exists);
+
+            #[cfg(test)]
+            block_after_first_smismember_lookup_for_test(key);
+        }
+
+        Ok(result)
     }
 
     /// Get random members from a set
@@ -2692,5 +2848,47 @@ mod glob_tests {
         assert!(glob_match_bytes(b"literal*", b"literal"));
         assert!(glob_match_bytes(b"**", b"x"));
         assert!(glob_match_bytes(b"***", b"x"));
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod smismember_tests {
+    use std::sync::Arc;
+
+    use kstd::lock_mgr::LockMgr;
+
+    use super::{SmismemberSnapshotTestGate, install_smismember_snapshot_test_gate};
+    use crate::{BgTaskHandler, Redis, StorageOptions, safe_cleanup_test_db, unique_test_db_path};
+
+    #[test]
+    fn smismember_reads_all_members_from_one_snapshot() {
+        let db_path = unique_test_db_path();
+        safe_cleanup_test_db(&db_path);
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+        redis.open(db_path.to_str().unwrap()).unwrap();
+        let redis = Arc::new(redis);
+
+        let key = b"smismember_snapshot";
+        assert_eq!(redis.sadd(key, &[b"a"]).unwrap(), 1);
+
+        let gate = SmismemberSnapshotTestGate::new(key);
+        let gate_guard = install_smismember_snapshot_test_gate(Arc::clone(&gate));
+        let reader = Arc::clone(&redis);
+        let handle = std::thread::spawn(move || reader.smismember(key, &[b"a", b"b"]));
+
+        gate.wait_until_entered();
+        assert_eq!(redis.sadd(key, &[b"b"]).unwrap(), 1);
+        gate.release();
+
+        assert_eq!(handle.join().unwrap().unwrap(), vec![true, false]);
+
+        drop(gate_guard);
+        drop(redis);
+        safe_cleanup_test_db(&db_path);
     }
 }

--- a/src/storage/src/storage_impl.rs
+++ b/src/storage/src/storage_impl.rs
@@ -784,6 +784,13 @@ impl Storage {
         self.insts[instance_id].sismember(key, member)
     }
 
+    // Check if each member is a member of the set stored at key.
+    pub fn smismember(&self, key: &[u8], members: &[&[u8]]) -> Result<Vec<bool>> {
+        let slot_id = key_to_slot_id(key);
+        let instance_id = self.slot_indexer.get_instance_id(slot_id);
+        self.insts[instance_id].smismember(key, members)
+    }
+
     // Get random members from a set.
     pub fn srandmember(&self, key: &[u8], count: Option<i32>) -> Result<Vec<String>> {
         let slot_id = key_to_slot_id(key);


### PR DESCRIPTION
## Summary

Adds the `SMISMEMBER` command (Redis 6.2), the multi-member companion to
`SISMEMBER`. Relates to the string/set command coverage tracked in #144.

```
SMISMEMBER key member [member ...]
```

Returns an array with one element per requested member, in input order: `1`
if the member is in the set stored at `key`, `0` otherwise.

## Semantics (Redis-compatible)

- Missing or expired key → array of all `0`s (the key is treated as an empty
  set), because `Storage::sismember` returns `Ok(false)` for absent/expired
  keys.
- Key holding a non-set value → a single `WRONGTYPE`-style error for the whole
  command (the first membership probe surfaces the type error and the command
  returns it), matching Redis.
- Arity is `-3`, so at least one member is required.

## Implementation

Implemented entirely in the `cmd` layer by composing the existing readonly
`Storage::sismember` for each member — sparse point lookups rather than a full
set scan, which is also the efficient shape for membership checks. No
storage-layer changes are required.

Files:
- `src/cmd/src/smismember.rs` (new)
- `src/cmd/src/lib.rs` — `pub mod smismember;`
- `src/cmd/src/table.rs` — register `SmismemberCmd`

## Tests

Unit tests mirror the existing set-command style (meta, clone, ACL category,
arity/argument validation):

- `test_smismember_cmd_meta`
- `test_smismember_cmd_clone`
- `test_smismember_acl_category`
- `test_smismember_argument_validation`

## Verification (Rust 1.97.1, MSVC)

- `cargo fmt -- --check` — pass
- `cargo test -p cmd` — pass (111 tests, including the 4 new)
- `cargo clippy -p cmd -- -D warnings -D clippy::unwrap_used` — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `SMISMEMBER` command.
  * Returns `1` or `0` for each requested member, indicating whether it exists in the specified set.
  * Supports string and binary members, missing keys, and Redis-compatible error responses.
  * Ensures all membership checks use a consistent snapshot during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->