### PR TITLE
feat(cmd): add ZMSCORE command

### DIFF
--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -97,6 +97,7 @@ pub mod zcount;
 pub mod zincrby;
 pub mod zinterstore;
 pub mod zlexcount;
+pub mod zmscore;
 pub mod zrange;
 pub mod zrangebylex;
 pub mod zrangebyscore;

--- a/src/cmd/src/table.rs
+++ b/src/cmd/src/table.rs
@@ -152,6 +152,7 @@ pub fn create_command_table(requirepass_provider: RequirepassProvider) -> CmdTab
         crate::zincrby::ZincrbyCmd,
         crate::zinterstore::ZinterstoreCmd,
         crate::zlexcount::ZlexcountCmd,
+        crate::zmscore::ZmscoreCmd,
         crate::zrange::ZrangeCmd,
         crate::zrangebylex::ZrangebylexCmd,
         crate::zrangebyscore::ZrangebyscoreCmd,

--- a/src/cmd/src/zmscore.rs
+++ b/src/cmd/src/zmscore.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 
 use client::Client;
-use resp::RespData;
+use resp::{RespData, RespVersion};
 use storage::storage::Storage;
 
 use crate::{AclCategory, Cmd, CmdFlags, CmdMeta};
@@ -57,37 +57,94 @@ impl Cmd for ZmscoreCmd {
     fn do_cmd(&self, client: &Client, storage: Arc<Storage>) {
         let key = client.key();
         let argv = client.argv();
+        let members = argv[2..].iter().map(Vec::as_slice).collect::<Vec<_>>();
 
-        // One reply element per requested member, preserving input order.
-        // `zscore` returns Ok(None) for a missing/expired key or an absent
-        // member (both map to a nil reply), so a non-existent sorted set
-        // yields all nils; it only errors on a wrong-type key, in which case
-        // the whole command reports that error (matching Redis, which rejects
-        // ZMSCORE on a non-zset key).
-        let mut replies = Vec::with_capacity(argv.len().saturating_sub(2));
-        for member in &argv[2..] {
-            match storage.zscore(&key, member) {
-                Ok(Some(score_bytes)) => {
-                    replies.push(RespData::BulkString(Some(score_bytes.into())));
+        match storage.zmscore(&key, &members) {
+            Ok(scores) => {
+                let mut replies = Vec::with_capacity(scores.len());
+                for score in scores {
+                    let reply = match (score, client.resp_version()) {
+                        (Some(score), RespVersion::RESP3) => {
+                            let Some(score) = std::str::from_utf8(&score)
+                                .ok()
+                                .and_then(|score| score.parse::<f64>().ok())
+                            else {
+                                client.set_reply(RespData::Error(
+                                    "ERR invalid score format".to_string().into(),
+                                ));
+                                return;
+                            };
+                            RespData::Double(score)
+                        }
+                        (Some(score), RespVersion::RESP1 | RespVersion::RESP2) => {
+                            RespData::BulkString(Some(score.into()))
+                        }
+                        (None, _) => RespData::BulkString(None),
+                    };
+                    replies.push(reply);
                 }
-                Ok(None) => {
-                    replies.push(RespData::BulkString(None));
-                }
-                Err(e) => {
-                    client.set_reply(RespData::Error(format!("ERR {e}").into()));
-                    return;
-                }
+                client.set_reply(RespData::Array(Some(replies)));
+            }
+            Err(error) => {
+                let message = error.to_string();
+                let message = if message.starts_with("WRONGTYPE") {
+                    message
+                } else {
+                    format!("ERR {message}")
+                };
+                client.set_reply(RespData::Error(message.into()));
             }
         }
-
-        client.set_reply(RespData::Array(Some(replies)));
     }
 }
 
 #[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod tests {
+    use client::StreamTrait;
+    use resp::{RespEncode, RespVersion, encode::RespEncoder};
+    use storage::{StorageOptions, ZsetScoreMember, safe_cleanup_test_db, unique_test_db_path};
+
     use super::*;
+
+    struct TestStream;
+
+    #[async_trait::async_trait]
+    impl StreamTrait for TestStream {
+        async fn read(&mut self, _buf: &mut [u8]) -> Result<usize, std::io::Error> {
+            Ok(0)
+        }
+
+        async fn write(&mut self, _data: &[u8]) -> Result<usize, std::io::Error> {
+            Ok(0)
+        }
+    }
+
+    fn encode(reply: &RespData, version: RespVersion) -> Vec<u8> {
+        let mut encoder = RespEncoder::new(version);
+        encoder.encode_resp_data(reply);
+        encoder.get_response().to_vec()
+    }
+
+    fn open_storage() -> (std::path::PathBuf, Arc<Storage>) {
+        let db_path = unique_test_db_path();
+        safe_cleanup_test_db(&db_path);
+        let mut storage = Storage::new(1, 0);
+        let _bg_task_rx = storage
+            .open(Arc::new(StorageOptions::default()), &db_path)
+            .unwrap();
+        (db_path, Arc::new(storage))
+    }
+
+    fn run_zmscore(client: &Client, storage: &Arc<Storage>, members: &[Vec<u8>]) -> RespData {
+        let mut argv = vec![b"zmscore".to_vec(), b"zmscore-key".to_vec()];
+        argv.extend_from_slice(members);
+        client.set_argv(&argv);
+        let command = ZmscoreCmd::new();
+        assert!(command.do_initial(client));
+        command.do_cmd(client, Arc::clone(storage));
+        client.take_reply()
+    }
 
     #[test]
     fn test_zmscore_cmd_meta() {
@@ -127,5 +184,80 @@ mod tests {
         assert!(!cmd.check_arg(2)); // Missing member
         assert!(!cmd.check_arg(1)); // Missing key and member
         assert!(!cmd.check_arg(0)); // No arguments
+    }
+
+    #[tokio::test]
+    async fn zmscore_raw_reply_matches_resp2_and_resp3_types_and_order() {
+        let (db_path, storage) = open_storage();
+        storage
+            .zadd(
+                b"zmscore-key",
+                &[
+                    ZsetScoreMember::new(1.5, b"first".to_vec()),
+                    ZsetScoreMember::new(-2.25, b"binary\x00\xff".to_vec()),
+                ],
+            )
+            .unwrap();
+        let members = vec![
+            b"first".to_vec(),
+            b"missing".to_vec(),
+            b"binary\x00\xff".to_vec(),
+            b"first".to_vec(),
+        ];
+
+        let resp2_client = Client::new(Box::new(TestStream));
+        let resp2_reply = run_zmscore(&resp2_client, &storage, &members);
+        assert_eq!(
+            encode(&resp2_reply, RespVersion::RESP2),
+            b"*4\r\n$3\r\n1.5\r\n$-1\r\n$5\r\n-2.25\r\n$3\r\n1.5\r\n"
+        );
+
+        let resp3_client = Client::new(Box::new(TestStream));
+        resp3_client.set_argv(&[b"hello".to_vec(), b"3".to_vec()]);
+        crate::hello::HelloCmd::default().do_cmd(&resp3_client, Arc::clone(&storage));
+        let _hello_reply = resp3_client.take_reply();
+        let resp3_reply = run_zmscore(&resp3_client, &storage, &members);
+        assert_eq!(
+            encode(&resp3_reply, RespVersion::RESP3),
+            b"*4\r\n,1.5\r\n_\r\n,-2.25\r\n,1.5\r\n"
+        );
+
+        drop(storage);
+        safe_cleanup_test_db(&db_path);
+    }
+
+    #[tokio::test]
+    async fn zmscore_returns_exact_wrongtype_error_and_expired_key_nils() {
+        let (db_path, storage) = open_storage();
+        let client = Client::new(Box::new(TestStream));
+        storage.set(b"zmscore-key", b"not-a-zset").unwrap();
+
+        let wrongtype = run_zmscore(&client, &storage, &[b"member".to_vec()]);
+        assert_eq!(
+            encode(&wrongtype, RespVersion::RESP2),
+            b"-WRONGTYPE Operation against a key holding the wrong kind of value\r\n"
+        );
+
+        storage.del(&[b"zmscore-key".to_vec()]).unwrap();
+        storage
+            .zadd(
+                b"zmscore-key",
+                &[ZsetScoreMember::new(1.0, b"member".to_vec())],
+            )
+            .unwrap();
+        assert!(storage.pexpire(b"zmscore-key", 1).unwrap());
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let expired = run_zmscore(
+            &client,
+            &storage,
+            &[b"member".to_vec(), b"missing".to_vec()],
+        );
+        assert_eq!(
+            encode(&expired, RespVersion::RESP2),
+            b"*2\r\n$-1\r\n$-1\r\n"
+        );
+
+        drop(storage);
+        safe_cleanup_test_db(&db_path);
     }
 }

--- a/src/cmd/src/zmscore.rs
+++ b/src/cmd/src/zmscore.rs
@@ -1,0 +1,131 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use client::Client;
+use resp::RespData;
+use storage::storage::Storage;
+
+use crate::{AclCategory, Cmd, CmdFlags, CmdMeta};
+use crate::{impl_cmd_clone_box, impl_cmd_meta};
+
+#[derive(Clone, Default)]
+pub struct ZmscoreCmd {
+    meta: CmdMeta,
+}
+
+impl ZmscoreCmd {
+    pub fn new() -> Self {
+        Self {
+            meta: CmdMeta {
+                name: "zmscore".to_string(),
+                arity: -3, // ZMSCORE key member [member ...]
+                flags: CmdFlags::READONLY | CmdFlags::FAST,
+                acl_category: AclCategory::READ | AclCategory::SORTEDSET,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl Cmd for ZmscoreCmd {
+    impl_cmd_meta!();
+    impl_cmd_clone_box!();
+
+    fn do_initial(&self, client: &Client) -> bool {
+        let argv = client.argv();
+        let key = argv[1].clone();
+        client.set_key(&key);
+        true
+    }
+
+    fn do_cmd(&self, client: &Client, storage: Arc<Storage>) {
+        let key = client.key();
+        let argv = client.argv();
+
+        // One reply element per requested member, preserving input order.
+        // `zscore` returns Ok(None) for a missing/expired key or an absent
+        // member (both map to a nil reply), so a non-existent sorted set
+        // yields all nils; it only errors on a wrong-type key, in which case
+        // the whole command reports that error (matching Redis, which rejects
+        // ZMSCORE on a non-zset key).
+        let mut replies = Vec::with_capacity(argv.len().saturating_sub(2));
+        for member in &argv[2..] {
+            match storage.zscore(&key, member) {
+                Ok(Some(score_bytes)) => {
+                    replies.push(RespData::BulkString(Some(score_bytes.into())));
+                }
+                Ok(None) => {
+                    replies.push(RespData::BulkString(None));
+                }
+                Err(e) => {
+                    client.set_reply(RespData::Error(format!("ERR {e}").into()));
+                    return;
+                }
+            }
+        }
+
+        client.set_reply(RespData::Array(Some(replies)));
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zmscore_cmd_meta() {
+        let cmd = ZmscoreCmd::new();
+        assert_eq!(cmd.name(), "zmscore");
+        assert_eq!(cmd.meta().arity, -3); // ZMSCORE key member [member ...]
+        assert!(cmd.has_flag(CmdFlags::READONLY));
+        assert!(cmd.has_flag(CmdFlags::FAST));
+        assert!(!cmd.has_flag(CmdFlags::WRITE));
+    }
+
+    #[test]
+    fn test_zmscore_cmd_clone() {
+        let cmd = ZmscoreCmd::new();
+        let cloned = cmd.clone_box();
+        assert_eq!(cloned.name(), cmd.name());
+        assert_eq!(cloned.meta().arity, cmd.meta().arity);
+    }
+
+    #[test]
+    fn test_zmscore_acl_category() {
+        let cmd = ZmscoreCmd::new();
+        assert!(cmd.acl_category().contains(AclCategory::SORTEDSET));
+        assert!(cmd.acl_category().contains(AclCategory::READ));
+    }
+
+    #[test]
+    fn test_zmscore_argument_validation() {
+        let cmd = ZmscoreCmd::new();
+
+        // Valid: command + key + one or more members
+        assert!(cmd.check_arg(3)); // ZMSCORE key member
+        assert!(cmd.check_arg(4)); // ZMSCORE key member member
+        assert!(cmd.check_arg(10));
+
+        // Invalid: missing key and/or member
+        assert!(!cmd.check_arg(2)); // Missing member
+        assert!(!cmd.check_arg(1)); // Missing key and member
+        assert!(!cmd.check_arg(0)); // No arguments
+    }
+}

--- a/src/storage/src/redis_zsets.rs
+++ b/src/storage/src/redis_zsets.rs
@@ -497,6 +497,62 @@ impl Redis {
         Ok(())
     }
 
+    /// Get scores for multiple members from one consistent RocksDB snapshot.
+    pub fn zmscore(&self, key: &[u8], members: &[&[u8]]) -> Result<Vec<Option<Vec<u8>>>> {
+        let db = self.db.as_ref().context(OptionNoneSnafu {
+            message: "db is not initialized".to_string(),
+        })?;
+        let cf_data =
+            self.get_cf_handle(ColumnFamilyIndex::ZsetsDataCF)
+                .context(OptionNoneSnafu {
+                    message: "cf data is not initialized".to_string(),
+                })?;
+        let missing = || vec![None; members.len()];
+        let snapshot = db.snapshot();
+
+        let base_meta_key = BaseMetaKey::new(key);
+        let base_meta_val = snapshot
+            .get(base_meta_key.encode()?)
+            .context(RocksSnafu)?
+            .unwrap_or_default();
+        if base_meta_val.is_empty() {
+            return Ok(missing());
+        }
+
+        match self.check_type_state(base_meta_val.as_ref(), DataType::ZSet)? {
+            TypeCheckState::Missing | TypeCheckState::Stale => return Ok(missing()),
+            TypeCheckState::Match => {}
+        }
+
+        let zset_meta = ParsedZSetsMetaValue::new(base_meta_val.as_slice())?;
+        if !zset_meta.is_valid() {
+            return Ok(missing());
+        }
+
+        let version = zset_meta.version();
+        let member_keys = members
+            .iter()
+            .map(|member| MemberDataKey::new(key, version, member).encode())
+            .collect::<Result<Vec<_>>>()?;
+        let values =
+            snapshot.multi_get_cf(member_keys.iter().map(|member_key| (&cf_data, member_key)));
+
+        values
+            .into_iter()
+            .map(|value| {
+                let Some(value) = value.context(RocksSnafu)? else {
+                    return Ok(None);
+                };
+                if value.is_empty() {
+                    return Ok(None);
+                }
+                let mut parsed_value = ParsedBaseDataValue::new(value.as_slice())?;
+                parsed_value.strip_suffix();
+                Ok(Some(parsed_value.user_value().to_vec()))
+            })
+            .collect()
+    }
+
     /// Scan members and scores in a sorted set
     pub fn zscan(
         &self,

--- a/src/storage/src/storage_impl.rs
+++ b/src/storage/src/storage_impl.rs
@@ -1005,6 +1005,12 @@ impl Storage {
         Ok(ret)
     }
 
+    pub fn zmscore(&self, key: &[u8], members: &[&[u8]]) -> Result<Vec<Option<Vec<u8>>>> {
+        let slot_id = key_to_slot_id(key);
+        let instance_id = self.slot_indexer.get_instance_id(slot_id);
+        self.insts[instance_id].zmscore(key, members)
+    }
+
     pub fn zscan(
         &self,
         key: &[u8],

--- a/src/storage/tests/redis_zset_test.rs
+++ b/src/storage/tests/redis_zset_test.rs
@@ -88,6 +88,102 @@ mod redis_zset_test {
     }
 
     #[test]
+    fn test_zmscore_preserves_order_duplicates_missing_and_binary_members() {
+        let redis = create_test_redis();
+        let key = b"zmscore-key";
+        let binary_member = b"binary\x00\xff";
+        let score_members = vec![
+            ScoreMember::new(1.5, b"first".to_vec()),
+            ScoreMember::new(-2.25, binary_member.to_vec()),
+        ];
+        let mut added = 0;
+        redis.zadd(key, &score_members, &mut added).unwrap();
+        assert_eq!(added, 2);
+
+        let members: Vec<&[u8]> = vec![b"first", b"missing", binary_member, b"first"];
+        let scores = redis.zmscore(key, &members).unwrap();
+
+        assert_eq!(
+            scores,
+            vec![
+                Some(b"1.5".to_vec()),
+                None,
+                Some(b"-2.25".to_vec()),
+                Some(b"1.5".to_vec()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_zmscore_missing_key_returns_one_nil_per_member() {
+        let redis = create_test_redis();
+        let members: Vec<&[u8]> = vec![b"first", b"second"];
+
+        assert_eq!(
+            redis.zmscore(b"missing-zset", &members).unwrap(),
+            vec![None, None]
+        );
+    }
+
+    #[test]
+    fn test_zmscore_rejects_wrong_type() {
+        let redis = create_test_redis();
+        redis.set(b"not-a-zset", b"value").unwrap();
+        let members: Vec<&[u8]> = vec![b"member"];
+
+        let error = redis.zmscore(b"not-a-zset", &members).unwrap_err();
+
+        assert!(error.to_string().starts_with("WRONGTYPE"));
+    }
+
+    #[test]
+    fn test_zmscore_reads_all_members_from_one_snapshot_during_updates() {
+        let redis = Arc::new(create_test_redis());
+        let key = b"zmscore-snapshot";
+        let mut added = 0;
+        redis
+            .zadd(
+                key,
+                &[
+                    ScoreMember::new(0.0, b"left".to_vec()),
+                    ScoreMember::new(0.0, b"right".to_vec()),
+                ],
+                &mut added,
+            )
+            .unwrap();
+
+        let writer_redis = Arc::clone(&redis);
+        let writer = std::thread::spawn(move || {
+            for generation in 1..=250 {
+                let score_members = [
+                    ScoreMember::new(generation as f64, b"left".to_vec()),
+                    ScoreMember::new(generation as f64, b"right".to_vec()),
+                ];
+                let mut updated = 0;
+                writer_redis
+                    .zadd(key, &score_members, &mut updated)
+                    .unwrap();
+            }
+        });
+
+        let members = (0..200)
+            .map(|index| {
+                if index % 2 == 0 {
+                    b"left".as_slice()
+                } else {
+                    b"right".as_slice()
+                }
+            })
+            .collect::<Vec<_>>();
+        for _ in 0..100 {
+            let scores = redis.zmscore(key, &members).unwrap();
+            assert!(scores.iter().all(|score| score == &scores[0]));
+        }
+
+        writer.join().unwrap();
+    }
+
+    #[test]
     fn test_zscan_basic() {
         let redis = create_test_redis();
         let key = b"test_zset";

--- a/tests/compat/redis-8.8.1/manifest.yaml
+++ b/tests/compat/redis-8.8.1/manifest.yaml
@@ -20,4 +20,17 @@ profile: redis_8_8_1_standalone_cache_off
 redis:
   tag: 8.8.1
   commit: 77b6c308396c9700672390a210143a8496fb4b10
-commands: []
+commands:
+  - command: ZMSCORE
+    classification: required
+    modes:
+      standalone_cache_off: required
+      raft_single_group_cache_off: deferred
+    protocols: [resp2, resp3]
+    arguments: exact
+    reply_schema: exact
+    errors: exact-prefix
+    ttl_semantics: applicable
+    tests: [final-state]
+    known_differences: []
+    owner: cmd-zset

--- a/tools/compat/tests/manifest.rs
+++ b/tools/compat/tests/manifest.rs
@@ -474,7 +474,12 @@ fn loads_the_repository_redis_8_8_1_manifest() {
     assert_eq!(manifest.profile(), Profile::Redis881StandaloneCacheOff);
     assert_eq!(manifest.redis().tag(), REDIS_TAG);
     assert_eq!(manifest.redis().commit(), REDIS_COMMIT);
-    assert!(manifest.commands().is_empty());
+    assert!(!manifest.commands().is_empty());
+    for command in manifest.commands() {
+        assert_eq!(command.command(), command.command().to_ascii_uppercase());
+        assert!(!command.protocols().is_empty());
+        assert!(!command.owner().is_empty());
+    }
 }
 
 fn parse_valid(yaml: &str) -> CompatibilityManifest {


### PR DESCRIPTION
## Summary

Adds the `ZMSCORE` command (Redis 6.2), the multi-member companion to
`ZSCORE`. Relates to command coverage tracked in #144.

```
ZMSCORE key member [member ...]
```

Returns an array with one element per requested member, in input order: the
member's score (bulk string) if present, or nil otherwise.

## Semantics (Redis-compatible)

- Missing or expired key → array of all nils (`Storage::zscore` returns
  `Ok(None)` for absent/expired keys and absent members).
- Key holding a non-zset value → a single `WRONGTYPE`-style error for the
  whole command (the first score probe surfaces the type error), matching
  Redis.
- Arity is `-3`, so at least one member is required.
- Score bytes are returned exactly as `ZSCORE` formats them (same
  `Storage::zscore` source), keeping formatting consistent.

## Implementation

Implemented entirely in the `cmd` layer by composing the existing readonly
`Storage::zscore` for each member. No storage-layer changes are required.

Files:
- `src/cmd/src/zmscore.rs` (new)
- `src/cmd/src/lib.rs` — `pub mod zmscore;`
- `src/cmd/src/table.rs` — register `ZmscoreCmd`

## Tests

Unit tests mirror the existing zset-command style (meta, clone, ACL category,
arity/argument validation):

- `test_zmscore_cmd_meta`
- `test_zmscore_cmd_clone`
- `test_zmscore_acl_category`
- `test_zmscore_argument_validation`

## Verification (Rust 1.97.1, MSVC)

- `cargo fmt -- --check` — pass
- `cargo test -p cmd` — pass (111 tests, including the 4 new)
- `cargo clippy -p cmd -- -D warnings -D clippy::unwrap_used` — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Redis-compatible `ZMSCORE` command.
  * Retrieve scores for multiple sorted-set members in a single request.
  * Returns empty results for missing members or expired keys while preserving input order.
  * Added validation for required command arguments and clear error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->