### PR TITLE
feat(runtime): add storage baseline harness foundations

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,4 +27,6 @@ jobs:
           sudo apt-get install -y protobuf-compiler
 
       - name: Compile benchmark targets
-        run: cargo bench --no-run
+        run: |
+          cargo build --release -p runtime-baseline --bin kiwi-runtime-baseline
+          cargo bench --no-run

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,6 +21,16 @@ jobs:
       - name: Setup toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - name: Verify runtime baseline source inputs are clean
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          dirty="$(git 'status' '--porcelain' '--untracked-files=all' '--' 'Cargo.toml' 'Cargo.lock' 'rust-toolchain.toml' '.cargo' 'src' 'tools/runtime-baseline/Cargo.toml' 'tools/runtime-baseline/build.rs' 'tools/runtime-baseline/build_support.rs' 'tools/runtime-baseline/src' 'tools/runtime-baseline/tests' ':(exclude,glob)**/.git' ':(exclude,glob)**/.git/**' ':(exclude,glob)**/target' ':(exclude,glob)**/target/**' ':(exclude,glob)**/results' ':(exclude,glob)**/results/**')"
+          if [[ -n "$dirty" ]]; then
+            printf '%s\n' "$dirty" >&2
+            exit 1
+          fi
+
       - name: Install protoc
         run: |
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,9 @@ jobs:
 
       - run: make lint
 
+      - name: Lint runtime baseline tool targets
+        run: cargo clippy -p runtime-baseline --all-targets -- -D warnings -D clippy::unwrap_used
+
   build-and-test:
     strategy:
       fail-fast: false
@@ -192,12 +195,18 @@ jobs:
       - name: Build
         run: make build
 
+      - name: Build runtime baseline tool
+        run: cargo build -p runtime-baseline --bin kiwi-runtime-baseline
+
       - name: Run Unit Test with retry
         uses: nick-fields/retry@v4
         with:
           timeout_minutes: 30
           max_attempts: 2
           command: bash -o pipefail -c "make test 2>&1 | tee cargo-test.log"
+
+      - name: Test runtime baseline tool
+        run: cargo test -p runtime-baseline --all-targets
 
       - name: Upload test results on failure
         if: failure()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,6 +1673,7 @@ dependencies = [
  "storage",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,6 +1499,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
 name = "libz-sys"
 version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2338,6 +2344,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -2425,6 +2432,12 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schemars"
@@ -3722,6 +3735,19 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,6 +2329,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "runtime-baseline"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "rust-librocksdb-sys"
 version = "0.47.1+11.1.2"
 source = "git+https://github.com/arana-db/rust-rocksdb?tag=v0.51.0-arana.1#971c792f3d6312204a5e162bd60d4d3c84a9e8a8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,25 @@ members = [
 	"src/executor",
 	"src/client",
 	"src/raft",
+	"tools/runtime-baseline",
+]
+
+# Keep ordinary root builds on the twelve production crates. The benchmark
+# harness opts in explicitly so its future runtime feature cannot unify into
+# the normal server build.
+default-members = [
+	"src/storage",
+	"src/kstd",
+	"src/common/macro",
+	"src/common/runtime",
+	"src/net",
+	"src/resp",
+	"src/server",
+	"src/conf",
+	"src/cmd",
+	"src/executor",
+	"src/client",
+	"src/raft",
 ]
 
 [workspace.package]

--- a/docs/superpowers/plans/2026-07-24-storage-runtime-baseline-harness.md
+++ b/docs/superpowers/plans/2026-07-24-storage-runtime-baseline-harness.md
@@ -1,0 +1,540 @@
+# Storage Runtime Baseline Harness 实现计划
+
+> **面向 AI 代理的工作者：** 必需子技能：使用 superpowers:subagent-driven-development（推荐）或 superpowers:executing-plans 逐任务实现此计划。步骤使用复选框（`- [ ]`）语法来跟踪进度。
+
+**目标：** 为 Issue #350 第一阶段交付一个可重复、fail-closed 的真实 `TCP -> RuntimeManager -> StorageServer -> RocksDB` 基线 harness，并在 CI 中真实执行 4 个 GET/SET smoke case，而不是只编译 benchmark target。
+
+**架构：** `runtime` crate 在 `runtime-baseline` feature 下只定义请求身份、生命周期事件和同步 observer 接口；具体原子指标、采样 collector、控制协议和真实服务编排由新的 `tools/runtime-baseline` crate 实现。`NetworkServer` 增加可取消且可等待的通用生命周期入口，harness 按“停止 accept/连接 -> 关闭 request sender -> 等待 StorageServer -> 停止 runtimes”顺序退出。Python 标准库控制器只负责编排、资源采样、memtier 调用和结果验证，主要负载固定使用可校验 provenance 的 `memtier_benchmark 2.5.1`。
+
+**技术栈：** Rust 2021、Tokio、Tokio CancellationToken/JoinSet、RocksDB、RESP、Clap、Serde/JSON、Python 3 标准库、Bash、memtier_benchmark 2.5.1、GitHub Actions、WSL/Linux。
+
+---
+
+## 实施边界
+
+- 本计划只实现 #350 第一阶段 harness、观测、4-case smoke 和 CI 门禁，不实现 #351 bounded executor。
+- 不改变当前 storage 调度模型、RocksDB 配置、命令语义、fsync、一致性或 batching 算法来改善结果。
+- 不启用现有 `StorageMetricsTracker`；其 async Mutex 和样本容器会污染热路径。
+- 不把 benchmark control 命令加入 Redis 命令表；控制协议只存在于 `kiwi-runtime-baseline` target。
+- 不将 GitHub hosted runner 的 QPS/P99 作为性能回归阈值；CI 只验证真实执行、非零结果、状态守恒和 fail-closed。
+- 普通 `cargo build` 和 `cargo build -p server` 不得启用 `runtime-baseline` feature；只有工具 target 和显式 `--all-features` 验证启用。
+- 第一阶段允许 `MEMTIER_BIN` 运行 smoke，但无可信 provenance 的结果必须标记 `non_publishable`；第二阶段正式 baseline 只接受 bootstrap 产物。
+- 所有新增 `.rs`、`.py`、`.sh` 和普通 `.yaml` 文件必须包含仓库认可的 Apache 2.0 license header；不能等到最终 license job 才补。
+
+## 实施前事实校正
+
+已批准设计中的两个时间约束需要在第一个实现提交中同步校正：
+
+1. `memtier_benchmark 2.5.1 --test-time` 使用整数秒，不能直接表达 0.5 秒。smoke 预热改为 1 秒；不得通过 0.5 秒强杀 memtier 模拟预热。
+2. 5 分钟只约束 controller 的 4-case smoke 执行 step。GitHub job 总超时设为 45 分钟，因为冷 runner 的 release RocksDB 编译可能超过 5 分钟。
+
+另一个构建边界需要在 workspace 层固定：新增工具 crate 后，虚拟 workspace 的默认 root build 会选择全部 members，并通过 Cargo feature unification 给同一次构建中的 `server` 启用 runtime benchmark feature。因此根 `Cargo.toml` 必须增加 `default-members`，显式保留当前 12 个生产 crate并排除 `tools/runtime-baseline`。
+
+## 文件职责
+
+### 根目录和 CI
+
+- 修改 `Cargo.toml`：新增 workspace member、workspace dependency，并用 `default-members` 隔离工具 target。
+- 修改 `Cargo.lock`：记录工具 crate 和新增依赖解析结果。
+- 修改 `.github/workflows/benchmark.yml`：保留 `Compile Benchmarks`，新增独立 `Runtime Baseline Smoke` check、artifact 传递和 always-upload 证据。
+- 修改 `docs/superpowers/specs/2026-07-24-storage-runtime-baseline-design.md`：同步 1 秒预热、45 分钟 job/5 分钟 smoke step、observer 所有权和 workspace feature 隔离事实。
+- 创建 `docs/performance/storage-runtime-baseline.md`：本地/WSL 复现、结果解释、publishability 和故障排查。
+
+### Runtime observer 和生命周期
+
+- 修改 `src/common/runtime/Cargo.toml`：新增 `runtime-baseline` feature。
+- 创建 `src/common/runtime/baseline.rs`：logical/physical 身份、attempt 状态机、observer 事件和 RAII token。
+- 修改 `src/common/runtime/lib.rs`：feature-gated module/re-export。
+- 修改 `src/common/runtime/manager.rs`：observer 注入、同一 observer 传递、显式关闭 manager 自持 `StorageClient`。
+- 修改 `src/common/runtime/message.rs`：logical request、physical retry attempt、reserve-before-send、timeout/response/retry 观测。
+- 修改 `src/common/runtime/storage_server.rs`：组合 config/pause/observer、batch/gate/running/terminal 状态、benchmark-only blocker 和 operation delay hook。
+- 修改 `src/common/runtime/tests.rs`：跨 MessageChannel、StorageClient、StorageServer 的状态守恒和 shutdown 回归。
+
+### NetworkServer 生命周期
+
+- 修改 `src/net/Cargo.toml`：声明 `tokio-util` workspace dependency。
+- 修改 `src/net/src/network_server.rs`：新增 `run_until_cancelled`，停止 accept 和已有连接并等待 JoinSet。
+- 修改 `src/net/src/pool.rs`：提供显式清空空闲资源的生命周期 API，确保 pool 不再持有 `StorageClient` clone。
+- 修改 `src/net/tests/storage_command_e2e_tests.rs`：真实 listener/connection cancellation 和退出回归；保留现有真实 stack 测试语义。
+
+### Rust benchmark target
+
+- 创建 `tools/runtime-baseline/Cargo.toml`：package `runtime-baseline` 和 binary `kiwi-runtime-baseline`。
+- 创建 `tools/runtime-baseline/build.rs`：把构建 checkout 的 40 位 Git SHA 嵌入 binary；禁止运行时参数自报版本。
+- 创建 `tools/runtime-baseline/src/lib.rs`：公开模块与 `BaselineHarness` API。
+- 创建 `tools/runtime-baseline/src/main.rs`：CLI、启动、等待 shutdown 和退出码。
+- 创建 `tools/runtime-baseline/src/cli.rs`：严格参数及 loopback/绝对路径校验。
+- 创建 `tools/runtime-baseline/src/startup.rs`：startup JSON 临时文件、flush/sync、原子 rename。
+- 创建 `tools/runtime-baseline/src/schema.rs`：版本化 startup/control/metrics DTO。
+- 创建 `tools/runtime-baseline/src/metrics.rs`：`BaselineObserver` 实现、atomic current/max/counters、bounded sample channel 和 snapshot 守恒。
+- 创建 `tools/runtime-baseline/src/control.rs`：loopback NDJSON 控制服务和 64 KiB 单行上限。
+- 创建 `tools/runtime-baseline/src/harness.rs`：真实 Storage、RuntimeManager、StorageServer、NetworkServer 的启动和有界 shutdown。
+- 创建 `tools/runtime-baseline/tests/cli_test.rs`、`startup_test.rs`、`control_test.rs`、`harness_smoke_test.rs`、`lifecycle_test.rs`。
+
+### Python controller 和 memtier
+
+- 创建 `tools/runtime-baseline/run_baseline.py`：`run`/`verify` CLI 和退出码映射。
+- 创建 `tools/runtime-baseline/runtime_baseline/` 下的 `controller.py`、`manifest.py`、`memtier.py`、`process.py`、`resp.py`、`control.py`、`sampling.py`、`results.py`、`schema.py`、`verify.py`。
+- 创建 `tools/runtime-baseline/cases/cases.yaml`：带 Apache header 注释的 JSON-compatible YAML；4 个 smoke case 必须显式列出。
+- 创建 `tools/runtime-baseline/schema/outcome.schema.json`：JSON Schema 2020-12 发布契约。
+- 创建 `tools/runtime-baseline/bootstrap_memtier.sh`：固定 commit 构建、版本/SHA 校验和 provenance。
+- 创建 `tools/runtime-baseline/tests/test_manifest.py`、`test_memtier.py`、`test_process.py`、`test_schema.py`、`test_controller_fail_closed.py` 及必要 JSON fixtures。
+
+## 关键接口冻结
+
+### Runtime observer 合同
+
+`runtime` crate 只拥有 observer 协议和随请求传递的 token；具体 `BaselineMetrics` 位于工具 crate，避免 `runtime -> tools/runtime-baseline` 依赖环。
+
+```rust
+#[cfg(feature = "runtime-baseline")]
+pub trait BaselineObserver: Send + Sync + 'static {
+    fn on_event(&self, event: BaselineEvent);
+    fn before_execute(&self, trace: &BaselineTrace);
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub enum AttemptState {
+    Offered,
+    ChannelQueued,
+    BatchQueued,
+    WaitingGate,
+    Running,
+    ExecutionFinished,
+    ShutdownRejectedAfterAccept,
+    Abandoned,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct BaselineTrace {
+    pub logical_id: LogicalRequestId,
+    pub attempt_id: RequestId,
+    pub attempt_index: u32,
+}
+```
+
+`BaselineAttempt` 内部保存 `BaselineTrace`、当前 `AtomicU8` 状态、上次状态转换的 `Instant` 和 `Arc<dyn BaselineObserver>`。最后一个 token 被 drop 且状态仍非 terminal 时，必须转换为 `Abandoned`；非法、重复或 terminal 后转换必须返回错误并增加 observer invariant violation，而不是静默重复计数。
+
+### Request 状态守恒
+
+每个 snapshot 必须满足“累计 accepted = 当前 active + 累计 terminal”的混合守恒式：
+
+```text
+accepted_attempts_total
+  = channel_queued_current
+  + batch_queued_current
+  + waiting_gate_current
+  + running_current
+  + execution_finished_total
+  + shutdown_rejected_after_accept_total
+  + abandoned_total
+```
+
+`client_timeout`、`response_delivered`、`response_dropped`、`retry_attempt` 是正交累计事件。client timeout 后，服务端仍可进入 `execution_finished + response_dropped`。
+
+shutdown 开始后、尚未进入 request channel 的新 logical request 计入独立的 `rejected_after_shutdown` client counter，不得伪装成 accepted attempt；已经取得 channel permit 的 attempt 才能进入 `shutdown_rejected_after_accept` terminal。
+
+shutdown 完成时只要求 `channel_queued_current`、`batch_queued_current`、`waiting_gate_current` 和 `running_current` 四个 active current 为 0；terminal totals 必须保留，不能为了“清零”丢失执行历史。snapshot 不能在多 counter transition 的中间状态返回。实现使用无锁 writer generation：transition 进入时增加 active writers，更新旧/新状态 counter 和 generation，退出时减少 active writers；snapshot 只接受“前后 active writers 都为 0 且 generation 未变化”的读取，否则有界重试并返回 snapshot busy 错误。
+
+### Channel enqueue 竞态约束
+
+feature-enabled path 不能在 `sender.send(request).await` 返回后才标记 `ChannelQueued`，否则 receiver 可能先 dequeue。使用 timeout 包围 `sender.reserve()`，取得 permit 后先进行 `Offered -> ChannelQueued`，再用同步 `permit.send(request)` 发布请求。reserve/closed/timeout 失败不能计入 `accepted_attempts`。
+
+### Network lifecycle
+
+```rust
+pub async fn run_until_cancelled(
+    &self,
+    shutdown: CancellationToken,
+) -> Result<(), Box<dyn Error>>;
+```
+
+现有 `ServerTrait::run()` 调用该方法并传入永不取消的 token，保持生产行为。新方法以一个三路 `tokio::select!` 同时处理 listener accept、cancellation 和 `JoinSet::join_next()`：运行期间持续 reap 已完成连接，不能等 shutdown 才清空而导致连接 churn 下 JoinSet 无界增长。普通连接 EOF/协议错误继续记录日志且不终止生产 server；只有 task panic/JoinError 或 server 级错误才使 server 返回 error。
+
+当前 `start_pool_cleanup()` 是 detached 无限任务，`ConnectionPool<NetworkResources>` 的 idle entries 又持有 `StorageClient` clone。实现必须让 pool cleanup 受同一个 cancellation token 控制并被等待；connection tasks 全部结束后显式清空 pool 中的空闲 `NetworkResources`，确认 pool stats 为 active=0、available=0，再允许 `run_until_cancelled` 返回。
+
+### Harness shutdown 顺序
+
+```text
+1. control handler 原子标记 shutdown_started，拒绝新 control mutation
+2. cancel NetworkServer，停止 accept，并等待已有 connection tasks 退出
+3. 确认 NetworkServer cleanup task 已退出、JoinSet 已清空、connection pool 已清空，并 drop NetworkServer 持有的 StorageClient
+4. RuntimeManager::close_storage_requests() drop manager 自持 StorageClient，再 drop harness 中最后一个 StorageClient clone，使 request receiver 关闭
+5. 等待 StorageServer：已接受 attempt 完成或明确归类 abandoned/rejected
+6. 写最终 metrics，验证 `channel_queued_current`、`batch_queued_current`、`waiting_gate_current`、`running_current` 四项为 0，并验证累计状态守恒
+7. RuntimeManager::stop() 关闭 storage/network runtimes
+8. flush/sync outcome 和 log，target 正常退出
+```
+
+任何阶段超过 deadline 都返回非零；不得把 TERM/KILL 后的结果标为 pass。
+
+### Control 协议
+
+每一行是一个 JSON request/response，单行最多 64 KiB：
+
+```json
+{"request_id":"r-1","command":"metrics"}
+{"request_id":"r-2","command":"pause"}
+{"request_id":"r-3","command":"resume"}
+{"request_id":"r-4","command":"block_runtime_workers","duration_ms":50,"concurrency":4}
+{"request_id":"r-5","command":"arm_operation_delay","duration_ms":50}
+{"request_id":"r-6","command":"release_operation_delay"}
+{"request_id":"r-7","command":"shutdown","mode":"drain"}
+```
+
+响应固定为 `{request_id, ok, result}` 或 `{request_id, ok:false, error:{code,message}}`。未知字段、未知命令、重复 shutdown、非 loopback peer、超限行、invalid JSON 和 timeout 都必须显式失败。
+
+## 任务 1：校正设计约束并创建可独立编译的工具 crate 骨架
+
+**文件：**
+
+- 修改：`docs/superpowers/specs/2026-07-24-storage-runtime-baseline-design.md`
+- 修改：`Cargo.toml`
+- 修改：`Cargo.lock`
+- 创建：`tools/runtime-baseline/Cargo.toml`
+- 创建：`tools/runtime-baseline/src/lib.rs`
+- 创建：`tools/runtime-baseline/src/main.rs`
+- 创建：`tools/runtime-baseline/build.rs`
+- 创建：`tools/runtime-baseline/src/cli.rs`
+- 创建：`tools/runtime-baseline/src/startup.rs`
+- 创建：`tools/runtime-baseline/src/schema.rs`
+- 创建：`tools/runtime-baseline/tests/cli_test.rs`
+- 创建：`tools/runtime-baseline/tests/startup_test.rs`
+
+- [ ] 在设计规格中将 smoke warmup 从 0.5 秒修订为 1 秒，并写明依据是 memtier 2.5.1 的整数 `--test-time`。
+- [ ] 在设计规格中将“整个 job 5 分钟”修订为“controller smoke step 5 分钟、job 45 分钟”。
+- [ ] 在设计规格中明确 runtime crate 只定义 observer contract，工具 crate 拥有具体 `BaselineMetrics`；写明 Cargo feature unification 隔离方案。
+- [ ] 在 `Cargo.toml` 增加 `tools/runtime-baseline` member，并增加 `default-members`，内容与当前 12 个生产 members 完全相同。
+- [ ] 任务 1 的工具 manifest 只声明 CLI/startup 骨架所需的 `clap`、`serde`、`serde_json`、`anyhow`、`tempfile` 等依赖；此时不得请求尚未创建的 runtime `runtime-baseline` feature，保证本提交独立可解析和编译。
+- [ ] 添加失败测试：相对 `--data-dir`、非 loopback listen、已含 RocksDB `CURRENT` 的 data dir、相对 startup/metrics path 均被 CLI 拒绝。
+- [ ] 运行 `cargo test -p runtime-baseline --test cli_test`，确认测试因 CLI 尚未实现而红灯。
+- [ ] 最小实现 `ServerArgs`：`--listen`、`--control-listen`、`--data-dir`、`--startup-event`、`--metrics-output`、`--expected-git-sha`、runtime thread/capacity/timeout/batching/instrumentation 参数。
+- [ ] 在 `build.rs` 中优先读取 CI 显式提供的 `KIWI_BASELINE_BUILD_GIT_SHA`，否则从当前 checkout 执行 `git rev-parse HEAD`；两者都必须是 40 位 hex，结果通过 `cargo:rustc-env=KIWI_BASELINE_COMPILED_GIT_SHA=...` 编入 binary。构建时同时执行受边界限制的 `git status --porcelain`，嵌入 `KIWI_BASELINE_SOURCE_DIRTY=true|false`。设置 `rerun-if-env-changed`，并覆盖 worktree `.git` 指针/HEAD 的 rerun 依赖。
+- [ ] dirty build 允许执行 smoke，但 startup/outcome 的 `publishability` 必须为 `non_publishable` 且包含 `dirty_source_tree`；CI Compile job 必须在 build 前断言 checkout clean。
+- [ ] 添加 build identity 测试：startup 报告 `env!("KIWI_BASELINE_COMPILED_GIT_SHA")`；`--expected-git-sha` 不同则 binary 在 listener/startup 之前失败，不能回显 caller 输入。
+- [ ] 添加 startup JSON 测试：临时文件与目标同目录；目标出现时 JSON 完整；PID、两个地址、canonical data dir、compiled Git SHA 和 schema version 正确；临时文件不残留。
+- [ ] 运行 `cargo test -p runtime-baseline --test startup_test`，确认先红后绿。
+- [ ] 保持 `main.rs` 只解析参数并返回“harness not initialized”非零；不得伪装成可运行 smoke。
+- [ ] 运行 `cargo build -p server`，并用 `cargo tree -p server -e features | rg "runtime-baseline"` 确认普通 server 构建未启用 feature。
+- [ ] 运行 `cargo build`，确认默认 root build 不构建 `runtime-baseline` package。
+- [ ] 运行 `cargo test -p runtime-baseline --test cli_test --test startup_test` 和 `git diff --check`。
+- [ ] 提交：`build(runtime): add baseline tool workspace`。
+
+## 任务 2：让 StorageServer 同时接收自定义 config 和 pause controller
+
+**文件：**
+
+- 修改：`src/common/runtime/storage_server.rs`
+- 修改：`src/common/runtime/tests.rs`
+
+- [ ] 添加单元测试：传入 `batching_enabled=true`、自定义 batch size/timeout 和一个 `StorageServerPauseController`，构造出的 server 必须复用 controller 的同一个 access gate，而不是新建 gate。
+- [ ] 添加行为测试：先 `request_pause()`，再发送请求；请求不得开始执行；`resume()` 后请求完成。
+- [ ] 运行 `cargo test -p runtime storage_server::tests::test_config_and_pause_controller_share_gate -- --exact`，确认当前无组合 API 而红灯。
+- [ ] 新增公开构造器：
+
+```rust
+pub fn with_config_and_pause_controller(
+    global_storage: Arc<GlobalStorage>,
+    receiver: mpsc::Receiver<StorageRequest>,
+    config: StorageServerConfig,
+    pause_controller: StorageServerPauseController,
+) -> Self
+```
+
+- [ ] 让 `new`、`with_pause_controller`、`with_config` 和新构造器统一调用一个 private inner constructor；不得改变默认 config 和现有 gate 语义。
+- [ ] 运行新增测试、现有 storage server tests 和 `cargo test -p runtime`。
+- [ ] 提交：`refactor(runtime): compose storage server controls`。
+
+## 任务 3：为 NetworkServer 增加可取消、可等待的生命周期
+
+**文件：**
+
+- 修改：`src/net/Cargo.toml`
+- 修改：`src/net/src/network_server.rs`
+- 修改：`src/net/src/pool.rs`
+- 修改：`src/net/tests/storage_command_e2e_tests.rs`
+
+- [ ] 添加测试：在 `127.0.0.1:0` bind 后运行 server，连接并完成 `PING`，cancel token 后外层 JoinHandle 必须在 1 秒内成功返回。
+- [ ] 添加测试：cancel 后新 TCP connect 必须失败；cancel 前建立的 keep-alive connection 再发送命令必须 EOF/connection reset，不能继续接受新命令。
+- [ ] 添加高频短连接测试：反复建立/断开连接后，已完成 task 被持续 reap，JoinSet 活跃数不随历史连接数无界增长。
+- [ ] 添加 pool/cleanup 测试：cancel 后 cleanup task 已 join，pool stats 为 active=0、available=0；drop manager/harness 最后 client 后 storage receiver 能收到 EOF。
+- [ ] 运行目标测试，确认当前 `run()` 无限 accept、detached connection tasks 导致超时红灯。
+- [ ] 在 `src/net/Cargo.toml` 增加 `tokio-util.workspace = true`。
+- [ ] 实现 `NetworkServer::run_until_cancelled(CancellationToken)`，accept、cancellation 和 `JoinSet::join_next()` 使用三路 `tokio::select!`，运行期间持续 reap 完成 task。
+- [ ] 用 `JoinSet` 保存 connection tasks；每个 task 使用 child token，在 shutdown 后停止从连接读取新命令并退出。普通连接错误在 task 内日志记录后正常结束，不升级为 server 失败。
+- [ ] 把 pool cleanup task 纳入可取消、可等待生命周期；为 `ConnectionPool` 增加清空 idle entries 的 API。
+- [ ] cancellation 后停止 accept、取消 child token、持续等待所有 JoinSet task和 cleanup task；JoinError/panic 必须传播为 server error；最后清空 pool 并验证 active/available 均为 0。
+- [ ] 现有 `ServerTrait::run()` 调用 `run_until_cancelled(CancellationToken::new())`，保持普通生产 server 的无限运行语义。
+- [ ] 运行新增测试、`cargo test -p net --test storage_command_e2e_tests` 和 `cargo test -p net`。
+- [ ] 提交：`feat(net): add cancellable server lifecycle`。
+
+## 任务 4：增加显式 request sender 关闭点
+
+**文件：**
+
+- 修改：`src/common/runtime/manager.rs`
+- 修改：`src/common/runtime/tests.rs`
+
+- [ ] 添加测试：`RuntimeManager` 初始化 storage components 后，receiver 仍因 manager 自持 `StorageClient` 保持 open；调用新 API 后，在其他 client clones 全部 drop 的前提下 receiver 返回 `None`。
+- [ ] 添加幂等测试：第二次关闭返回 `false`，不会 panic。
+- [ ] 运行目标测试，确认当前没有关闭 manager 自持 sender 的 API 而红灯。
+- [ ] 实现：
+
+```rust
+pub fn close_storage_requests(&mut self) -> bool {
+    self.storage_client.take().is_some()
+}
+```
+
+- [ ] 不在 `RuntimeManager::stop()` 中隐式调用该方法；生产 stop 顺序保持不变，harness 负责显式生命周期顺序。
+- [ ] 运行 `cargo test -p runtime`。
+- [ ] 提交：`feat(runtime): close storage requests explicitly`。
+
+## 任务 5：实现 feature-gated observer contract、请求身份和状态 token
+
+**文件：**
+
+- 修改：`src/common/runtime/Cargo.toml`
+- 创建：`src/common/runtime/baseline.rs`
+- 修改：`src/common/runtime/lib.rs`
+- 修改：`src/common/runtime/message.rs`
+
+- [ ] 在 runtime manifest 新增 `[features] default = []` 和 `runtime-baseline = []`。
+- [ ] 先在 `baseline.rs` 写状态机测试：合法 transition、非法跳转、重复 terminal、最后 token drop -> abandoned、clone 未全部 drop 时不提前 abandoned。
+- [ ] 写 identity 测试：一个 logical request 的 retry attempts 共享 logical id，但 physical `RequestId` 和 `attempt_index` 不同。
+- [ ] 写 terminal 正交测试：client timeout 之后仍允许 execution finished，再记录 response dropped。
+- [ ] 运行 `cargo test -p runtime --features runtime-baseline baseline::tests -- --nocapture`，确认 module/type 不存在而红灯。
+- [ ] 最小实现 `LogicalRequestId`、`BaselineTrace`、`AttemptState`、`ExecutionOutcome`、`BaselineEvent`、`BaselineObserver` 和 `BaselineAttempt`。
+- [ ] 给 `StorageRequest` 增加 feature-gated `baseline_attempt: Option<BaselineAttempt>`；修复 `message.rs`、`storage_server.rs`、`tests.rs` 中全部结构体字面量在 `--all-features` 下的初始化。
+- [ ] 搜索并修复所有对 `StorageCommand` 的 exhaustive match，使后续 feature-only blocker variant 在 `--all-features` 下不会造成遗漏或把内部命令当普通 Execute/Batch。
+- [ ] 事件必须包含 transition 前后状态、单调 elapsed、logical/attempt identity；不得包含系统时间作为延迟计算来源。
+- [ ] 运行 feature tests、`cargo test -p runtime` 和 `cargo check -p server`，确认 feature off 生产调用方无需 observer。
+- [ ] 提交：`feat(runtime): add baseline request observer`。
+
+## 任务 6：接通 MessageChannel、StorageClient、retry、timeout 和 response 事件
+
+**文件：**
+
+- 修改：`src/common/runtime/manager.rs`
+- 修改：`src/common/runtime/message.rs`
+- 修改：`src/common/runtime/tests.rs`
+
+- [ ] 添加 channel 测试：reserve 成功后 receiver 看到 request 时状态已经是 `ChannelQueued`；不得出现 receiver 先 dequeue、observer 后 enqueue。
+- [ ] 添加 closed/full timeout 测试：reserve 失败计 `send_failed`，但 `accepted_attempts == 0`。
+- [ ] 添加 retry 测试：logical requests 为 1，physical attempts 为 N，attempt index 从 0 单调递增，retry counter 为 N-1。
+- [ ] 覆盖 normal、degraded、recovery 和 queued retry helper，确保所有 helper 复用同一个 logical context，而不是重新计 logical request。
+- [ ] 添加 timeout 测试：client 先超时，server 后完成，最终同时出现 `client_timeout=1`、`execution_finished=1` 和 `response_dropped=1`。
+- [ ] 添加 shutdown race 测试：shutdown flag 之后、reserve 之前的 request 计 `rejected_after_shutdown` 且不增加 accepted；已 reserve 的 request 最终进入执行 terminal、`shutdown_rejected_after_accept` 或 `abandoned`。
+- [ ] 运行目标 tests，确认当前代码没有 observer/identity 而红灯。
+- [ ] 给 `RuntimeManager` 增加 feature-only `with_baseline_observer(config, Arc<dyn BaselineObserver>)`，并统一复用 private `new_inner`；`new` 继续传 `None`。
+- [ ] 让 `MessageChannel` 和 `StorageClient` 从 manager 得到同一个 observer；不要让 manager 创建第二个 observer。
+- [ ] feature-enabled send 使用 timeout-wrapped `sender.reserve()`；取得 permit 后 transition 到 `ChannelQueued`，再同步 `permit.send(request)`。
+- [ ] 在 `send_request_with_priority` 开始 logical request；每次进入 `try_send_request` 创建 physical attempt；degraded/recovery/queued retry 显式传递 logical context。
+- [ ] 在 response received、client timeout、send closed/backpressure timeout 和 retry 决策点发送对应事件。
+- [ ] 不使用现有 `StorageRequest.timestamp` 计算 channel wait；它包含 send/backpressure 等待。
+- [ ] 运行 `cargo test -p runtime --features runtime-baseline`、`cargo test -p runtime` 和 `cargo check -p server`。
+- [ ] 提交：`feat(runtime): trace storage request attempts`。
+
+## 任务 7：接通 batching、access gate、running、terminal 和 benchmark delay/blocker
+
+**文件：**
+
+- 修改：`src/common/runtime/storage_server.rs`
+- 修改：`src/common/runtime/tests.rs`
+
+- [ ] 添加 batching-off 测试：receive 后为 `WaitingGate`，gate permit 后为 `Running`，成功后为 `ExecutionFinished`。
+- [ ] 添加 batching-on 测试：receive 后为 `BatchQueued`；分别制造 size trigger、timeout trigger 和 high-priority trigger，三类 counter 必须分开。
+- [ ] 添加 paused batch 测试：batch 中每个 request 都从 `BatchQueued -> WaitingGate`；不得把 access gate 的一个 batch permit 当成一个 running request。
+- [ ] 添加 command error、internal failure、oneshot receiver drop、task panic/cancel 测试；所有路径 running current 最终为 0，panic/cancel 归 `Abandoned`。
+- [ ] 添加 receiver close 测试：BatchProcessor 中尚未 flush 的 accepted requests 不能静默消失，必须执行或归 `Abandoned` 并保持守恒。
+- [ ] 添加 operation delay 测试：armed 后的普通 storage execution 在 storage runtime thread 同步延迟；release 后新请求不再延迟。
+- [ ] 添加 blocker 测试：`concurrency=N` 时必须收到 N 个 started 且在 probe 开始前 0 个 completed；无法形成重叠窗口必须失败。
+- [ ] 运行目标 tests，确认当前状态和 benchmark command 不存在而红灯。
+- [ ] 在组合构造 API 上增加 feature-only observer builder/参数，使同一 observer 到达 BatchProcessor 和 execution path。
+- [ ] 在 batching off/on 的 receive、batch add/flush、gate wait、running、execute terminal 和 oneshot send 处进行状态转换。
+- [ ] 用 RAII guard 回收 running current；显式 finish 后 guard 不得重复 abandoned。
+- [ ] 增加 feature-only internal `StorageCommand` blocker variant 或等价内部执行入口；不得注册为 Redis 命令。
+- [ ] `before_execute` 只在 feature on 且 observer 存在时调用；feature off 不得保留 sleep/branch。
+- [ ] 运行 `cargo test -p runtime --features runtime-baseline`、`cargo test -p runtime` 和 `cargo clippy -p runtime --all-features -- -D warnings -D clippy::unwrap_used`。
+- [ ] 提交：`feat(runtime): observe storage execution lifecycle`。
+
+## 任务 8：实现原子指标、NDJSON control 和真实 Rust harness
+
+**文件：**
+
+- 修改：`tools/runtime-baseline/Cargo.toml`
+- 修改：`tools/runtime-baseline/src/lib.rs`
+- 修改：`tools/runtime-baseline/src/main.rs`
+- 创建：`tools/runtime-baseline/src/metrics.rs`
+- 创建：`tools/runtime-baseline/src/control.rs`
+- 创建：`tools/runtime-baseline/src/harness.rs`
+- 修改：`tools/runtime-baseline/src/schema.rs`
+- 创建：`tools/runtime-baseline/tests/control_test.rs`
+- 创建：`tools/runtime-baseline/tests/harness_smoke_test.rs`
+- 创建：`tools/runtime-baseline/tests/lifecycle_test.rs`
+
+- [ ] 先写 `BaselineMetrics` 单测：四个 active 状态的 current/max、三个 terminal totals 和其它 cumulative、sample channel 满时只增加 `dropped_metric_samples`、snapshot generation 守恒、有界重试失败返回结构化错误。
+- [ ] 写守恒红灯测试：`accepted_attempts_total == active_current_sum + terminal_total_sum`；执行过请求并 shutdown 后，四个 active current 为 0，但 execution/abandoned/rejected terminal totals 保留且公式继续成立。
+- [ ] 写 control protocol tests：metrics、pause/resume、arm/release delay、block workers、drain shutdown；未知命令/字段、malformed JSON、重复 request id、64 KiB 超限、非 loopback peer 均失败。
+- [ ] 写真实 harness smoke test：临时 RocksDB、RuntimeManager、StorageServer 和 NetworkServer 启动后真实 RESP `PING`、`SET`、`GET` 成功；分别覆盖 batching off/on。
+- [ ] 写 lifecycle test：pause 等 active owners drain 后才返回；shutdown 后 listener 关闭、cleanup/connection tasks和 pool 全清、sender 关闭、storage task 退出、四个 active current 全为 0、terminal totals 保留且 accepted 状态分解守恒。
+- [ ] 运行 `cargo test -p runtime-baseline`，确认实现缺失而红灯。
+- [ ] 此时才在工具 manifest 增加 `runtime = { workspace = true, features = ["runtime-baseline"] }` 以及 `net`、`storage`、`cmd`、`executor`、`resp`、`tokio`、`tokio-util`、`log`、`env_logger` 等真实 stack 依赖。
+- [ ] 运行 `cargo tree -p runtime-baseline`，确认依赖方向只有 `runtime-baseline -> runtime/net/...`，`runtime` 和 `net` 不反向依赖工具 crate，且不存在循环。
+- [ ] 实现具体 `BaselineMetrics: BaselineObserver`；热路径只使用 atomics、bounded nonblocking sample send 和单调时间。
+- [ ] 实现 `BaselineHarness::start`：校验 data dir、打开真实 `Storage`、创建 observer、RuntimeManager、StorageServerPauseController、自定义 StorageServer config、NetworkServer 和 control listener。
+- [ ] startup JSON 只在 Redis/control 两个 listener 都 bind 后原子发布；harness 自身不把“startup file 已写”当作 RESP ready 证明。
+- [ ] 实现 control response request-id 回显和结构化错误；`pause` 必须等待 active drain；blocker 必须返回 started/completed event 进度。
+- [ ] 实现 harness shutdown 顺序和各阶段 deadline；任一 JoinHandle panic、timeout、metrics 不守恒，或四个 active current 任一非零，均使 binary 非零退出。
+- [ ] shutdown 最后关闭 sample sender、等待 collector JoinHandle flush 完成，再生成最终 snapshot；collector 丢样可以计数，但 collector 未退出/未 flush 不能 pass。
+- [ ] `main.rs` 删除任务 1 的占位失败，进入真实 `start -> wait control shutdown -> drain -> exit`。
+- [ ] 运行 `cargo test -p runtime-baseline`、`cargo test -p net`、`cargo test -p runtime --features runtime-baseline`。
+- [ ] 提交：`test(runtime): add baseline harness control plane`。
+
+## 任务 9：实现标准库 Python manifest、schema、process 和 fail-closed controller
+
+**文件：**
+
+- 创建：`tools/runtime-baseline/run_baseline.py`
+- 创建：`tools/runtime-baseline/runtime_baseline/__init__.py`
+- 创建：`tools/runtime-baseline/runtime_baseline/controller.py`
+- 创建：`tools/runtime-baseline/runtime_baseline/manifest.py`
+- 创建：`tools/runtime-baseline/runtime_baseline/memtier.py`
+- 创建：`tools/runtime-baseline/runtime_baseline/process.py`
+- 创建：`tools/runtime-baseline/runtime_baseline/resp.py`
+- 创建：`tools/runtime-baseline/runtime_baseline/control.py`
+- 创建：`tools/runtime-baseline/runtime_baseline/sampling.py`
+- 创建：`tools/runtime-baseline/runtime_baseline/results.py`
+- 创建：`tools/runtime-baseline/runtime_baseline/schema.py`
+- 创建：`tools/runtime-baseline/runtime_baseline/verify.py`
+- 创建：`tools/runtime-baseline/cases/cases.yaml`
+- 创建：`tools/runtime-baseline/schema/outcome.schema.json`
+- 创建：`tools/runtime-baseline/tests/test_manifest.py`
+- 创建：`tools/runtime-baseline/tests/test_process.py`
+- 创建：`tools/runtime-baseline/tests/test_schema.py`
+- 创建：`tools/runtime-baseline/tests/test_controller_fail_closed.py`
+
+- [ ] 所有新增 `.py` 和 `.yaml` 加 Apache 2.0 header；JSON/Markdown 按现有 `.licenserc.yaml` 规则处理。
+- [ ] 在 `cases.yaml` 显式列出且只列出 4 个 smoke case：GET c1/p1 batch off、GET c8/p8 batch on、SET c1/p1 batch off、SET c8/p8 batch on。
+- [ ] manifest 采用“开头只允许空行/`#` 注释，剩余正文必须可被 `json.loads` 解析”的 JSON-compatible YAML；禁止 anchor、alias、隐式类型和组合展开。
+- [ ] 写 manifest 红灯测试：case id 重复、未知字段、缺/多/替换 smoke case、0 connection/pipeline/value/duration、keyspace 不是精确 100,000、batch-on 非 100 requests/10 ms 均拒绝。
+- [ ] 写 process 红灯测试：binary 缺失/不可执行、child 立即退出、startup timeout/invalid/mismatch、非 loopback、PID/data dir/Git SHA 不一致、cleanup root 外/`..`/symlink escape 拒绝。
+- [ ] 写 schema 红灯测试：缺字段、错类型、额外字段、pass+failure reason、fail+空 reason、absolute/traversal artifact path、NaN/Infinity、case 集不守恒。
+- [ ] 写 controller fail-closed 红灯测试：`/bin/false`、PING 失败、server load 中 crash、memtier exit 0 但 zero requests、control malformed/timeout、shutdown timeout、cleanup 后四个 active current 任一非零、4 case 任一失败、只产 3 个或多产第 5 个 outcome。
+- [ ] 添加路径真实性红灯测试：GET prefill 的 prefix/range 少写或错写一个 key、1,000-key probe 出现 nil/错长度/错内容必须失败；batch-on 配置被 controller/harness 忽略、batch metrics 全零必须失败；batch-off 出现任何 batch queue/flush 也必须失败。
+- [ ] 运行 `python3 -m unittest discover -s tools/runtime-baseline/tests -p 'test_*.py'`，确认实现缺失而红灯。
+- [ ] 实现每 case 独立进程/独立 data dir；Popen 使用 argv list 和 `start_new_session=True`，禁止 `shell=True`。
+- [ ] case 的 15 秒 deadline 覆盖 startup、PING、prefill/probe、1 秒 warmup、2 秒 measurement、metrics、drain shutdown 和 cleanup 全流程；内部子步骤 timeout 不得把总 deadline 延长。
+- [ ] readiness 同时验证 child 存活、startup JSON、PID、compiled Git SHA 等于 controller expected SHA、canonical data dir、loopback 地址和真实 RESP `PING +PONG`；不得比较两个都来自同一 CLI 参数的值。
+- [ ] 实现 `/proc/<pid>` CPU/RSS/thread/io 采样；目标平台无 `/proc` 时明确失败或标记 unsupported，CI Linux 不得跳过。
+- [ ] 实现 INT -> TERM -> KILL 分级回收和 `wait()`；强杀或 cleanup 失败必须使 case fail。
+- [ ] outcome failure code 至少覆盖设计列出的 binary、startup、PING、memtier、server crash、control、metrics invariant、shutdown、cleanup、schema、missing/unexpected case。
+- [ ] `outcome.schema.json` 是发布契约；由于 Python 标准库没有通用 JSON Schema 2020-12 validator，`schema.py` 明确实现“仅针对本仓库 outcome/run-outcome schema”的严格字段、类型、枚举、additional-properties、数值有限性、路径和跨字段语义校验，不得声称实现通用 JSON Schema 引擎。
+- [ ] 用一组 valid fixture 和逐字段 invalid fixtures 同时驱动 `outcome.schema.json` 与 `schema.py` 的一致性测试；不能只做 `json.loads` 或零散 required-field 检查。
+- [ ] 独立 `verify` 子命令比较 manifest expected ids、executed ids 和 outcome ids 完全相等，`skipped == 0`。
+- [ ] 运行 Python 全部 tests，预期全绿。
+- [ ] 提交：`test(runtime): add fail-closed baseline controller`。
+
+## 任务 10：固定 memtier provenance 并跑真实 4-case smoke
+
+**文件：**
+
+- 创建：`tools/runtime-baseline/bootstrap_memtier.sh`
+- 创建：`tools/runtime-baseline/tests/test_memtier.py`
+- 创建：`tools/runtime-baseline/tests/fixtures/memtier-success.json`
+- 创建：`tools/runtime-baseline/tests/fixtures/memtier-zero.json`
+- 修改：`tools/runtime-baseline/runtime_baseline/memtier.py`
+- 修改：`tools/runtime-baseline/runtime_baseline/controller.py`
+
+- [ ] 为 bootstrap 写 shell-level/fixture tests：缺工具、错误 commit、错误 version、digest mismatch 和 cache binary 被替换均失败。
+- [ ] bootstrap 固定 repository `https://github.com/redis/memtier_benchmark.git`、commit `5f634d171b83efca9640c5a87606c47b34d3d330`、expected version `2.5.1`。
+- [ ] 使用 `git init -> fetch --depth 1 <commit> -> checkout --detach FETCH_HEAD`；构建前后都验证 `git rev-parse HEAD`。
+- [ ] 检查 `git`、autoreconf/automake、pkg-config、make、C++ compiler、sha256sum；缺失时打印准确 apt 命令并失败，不在脚本内隐式 sudo 安装。
+- [ ] 用 `autoreconf -ivf && ./configure && make` 在 bootstrap 自己的 build root 构建，并写 `memtier-provenance.json`：repository、commit、完整 version output、binary SHA-256、build method。
+- [ ] cache 命中时重新执行 executable、commit、version、digest 校验；不一致时仅清理 bootstrap 自己拥有的 prefix 后重建。
+- [ ] 写 memtier parser tests：missing/non-executable、version mismatch、provenance/digest mismatch、nonzero、timeout、invalid/empty JSON、缺 `ALL STATS/Totals`、Count/Ops 为 0、NaN/Infinity 都失败。
+- [ ] memtier argv 固定 protocol、server/port、threads=1、clients、pipeline、data size=64、key range/prefix、ratio、test-time、run-count、percentiles、JSON output；禁止 `--randomize`。
+- [ ] GET case 使用确定性的单 client 顺序写入完整 100,000-key keyspace，验证 memtier/loader 写入成功数恰为 100,000；prefix、minimum、maximum 和 value generator 必须与正式 GET measurement 完全相同。
+- [ ] GET prefill 后使用固定 seed 选择 1,000 个不重复 key，通过原始 RESP GET 确认每个响应非 nil、value 长度为 64 B 且内容与 generator 一致；允许在一个 socket 上流水发送以满足 15 秒总 deadline，但必须逐响应校验并保证 request/response 数量恰为 1,000。任一 miss/错内容都失败。不能把 memtier 的“命令响应成功”当成 cache hit 证明。
+- [ ] SET case 先执行真实 SET probe，并限制写入同一固定 100,000-key 范围，不持续创建新 key。
+- [ ] 在 WSL/Linux 构建 target：`cargo build --release -p runtime-baseline --bin kiwi-runtime-baseline`。
+- [ ] 在 WSL/Linux bootstrap memtier，并运行：
+
+```bash
+timeout --signal=TERM --kill-after=30s 5m \
+  python3 tools/runtime-baseline/run_baseline.py run \
+    --suite smoke \
+    --cases tools/runtime-baseline/cases/cases.yaml \
+    --server-binary target/release/kiwi-runtime-baseline \
+    --memtier-binary "$MEMTIER_PREFIX/bin/memtier_benchmark" \
+    --memtier-provenance "$MEMTIER_PREFIX/memtier-provenance.json" \
+    --results-root "$TMPDIR/runtime-baseline-results" \
+    --expected-git-sha "$(git rev-parse HEAD)"
+```
+
+- [ ] 独立运行 verify，确认 expected/executed/outcome 精确为 4、passed=4、failed=0、skipped=0、每 case successful requests/QPS 和 execution terminal 非零。
+- [ ] verifier 对 batch-off case 强制 `batch_queued_max=0`、`batch_count=0`、所有 flush counters=0；对 batch-on case强制 `batch_queued_max>0`、`batch_count>0`，且 size/timeout/high-priority flush counter 至少一个大于 0。任一不满足都标记路径未覆盖并使 smoke 失败。
+- [ ] 检查结果不含 RocksDB data dir、core dump、本机凭据或仓库外绝对用户路径。
+- [ ] 提交：`build(runtime): pin memtier smoke dependency`。
+
+## 任务 11：把 Benchmark workflow 拆成 compile 与真实 smoke
+
+**文件：**
+
+- 修改：`.github/workflows/benchmark.yml`
+
+- [ ] 保留 job/check 名称 `Compile Benchmarks`，继续执行 `cargo bench --no-run`。
+- [ ] Compile job 先断言 `git status --porcelain` 为空，再安装 protoc/memtier build dependencies、bootstrap memtier，并设置 `KIWI_BASELINE_BUILD_GIT_SHA=${{ github.sha }}` 构建 exact-head `kiwi-runtime-baseline` release binary；生成包含 compiled Git SHA、source_dirty=false、harness SHA-256 和两个 binary `ldd` 输出的 artifact manifest，并把 harness binary、memtier binary、provenance/manifest 上传为短期 artifact。
+- [ ] 新增独立 job/check `Runtime Baseline Smoke`，依赖 Compile job，`timeout-minutes: 45`；checkout 同一个 `${{ github.sha }}` 以取得 controller/tests/cases，然后只下载 Compile job 的 exact-run binary artifact，不重新使用 runner 上未知 binary。
+- [ ] Smoke job 显式安装两个 binary 所需的 runtime packages。download-artifact 后执行 `chmod +x`，重新校验 harness artifact digest、compiled SHA/source_dirty、memtier provenance digest/commit/version；分别运行 `ldd` 并拒绝任何 `not found`，同时保存实际 `ldd` 与 Compile manifest 对账。GitHub artifact 不保留 Unix executable bit，不能直接假定可执行。
+- [ ] Smoke job 先运行 Python unit tests，再用 GNU `timeout ... 5m` 执行 controller，随后独立 verify 4 个结果。
+- [ ] verify 除 case 集合外还检查 GET 的 `prefilled_keys=100000`、`verified_hits=1000`、`misses=0`，以及每个 case 的 batching path metrics 与 manifest 配置一致。
+- [ ] 所有使用 `tee` 的 shell step 开头使用 `set -Eeuo pipefail`，防止非零退出被覆盖。
+- [ ] 在 job 开头创建 results root；artifact upload 使用 `if: always()` 和 `if-no-files-found: error`，成功/失败都保存 run-outcome、controller/kiwi/memtier logs、metrics、samples 和 outcomes。
+- [ ] 不上传 case RocksDB data dir；上传前用 controller verifier 检查 artifact 相对路径和允许列表。
+- [ ] 用 actionlint（若仓库/环境可用）或 YAML parser 检查 workflow；工具缺失时记录环境问题，至少执行 shell 命令 dry-run/语法检查。
+- [ ] 运行 `git diff --check` 和 `skywalking-eyes`/仓库 license check，确认新增 Shell/Python/YAML header 合规。
+- [ ] 提交：`ci(runtime): run baseline smoke`。
+
+## 任务 12：文档、全量验证、独立审查和 GitHub 门禁核验
+
+**文件：**
+
+- 创建：`docs/performance/storage-runtime-baseline.md`
+- 修改：`tools/runtime-baseline/README.md`（若任务 9 已创建则补齐，否则本任务创建）
+- 必要时修改：前述实现文件中的审查问题
+
+- [ ] 文档记录 WSL/Linux prerequisites、bootstrap、build、run、verify、结果目录、publishable/non-publishable、4-case smoke 非性能门限、常见 failure code 和安全 cleanup 边界。
+- [ ] 明确第二阶段仍需固定机器、完整 `cases.yaml`、重复 5 次、CV 稳定性和 #351 阈值冻结；第一阶段不关闭 #350。
+- [ ] 运行格式检查：`cargo fmt --all -- --check`。
+- [ ] 运行 feature 测试：`cargo test -p runtime --features runtime-baseline`。
+- [ ] 运行受影响 crates：`cargo test -p runtime`、`cargo test -p net`、`cargo test -p runtime-baseline`。
+- [ ] 运行严格 lint：`cargo clippy --workspace --all-features -- -D warnings -D clippy::unwrap_used`。
+- [ ] 在 WSL/Linux 运行 `cargo test --workspace`。
+- [ ] 在 WSL/Linux 运行 `bash tests/run_python_integration.sh`，确认现有 55 个 Python 集成测试仍真实执行且没有 skip。
+- [ ] 在 WSL/Linux 重新运行真实 4-case smoke 和独立 verify；保存命令、exact SHA、memtier version、binary SHA 和结果摘要。
+- [ ] 运行 production isolation 检查：`cargo tree -p server -e features` 不含 `runtime-baseline`；普通 `cargo build -p server` 生成的 `kiwi` 不监听 control port、不包含 benchmark CLI。
+- [ ] 运行 build identity 负路径：用 SHA A 构建 binary，controller 传 expected SHA B，必须在 startup/readiness 阶段失败；不能仅检查 runtime 传入值的自洽。
+- [ ] 运行 `git diff --check`、license check，并确认 worktree 没有临时 RocksDB/data/results/build prefix 被跟踪。
+- [ ] 启动一个只读子代理做规格符合性审查：逐项对照本计划和设计规格，阻断任何遗漏的 P0/P1。
+- [ ] 修复后启动另一个只读子代理做代码质量/并发/生命周期审查，重点检查 reserve 竞态、token drop、JoinSet shutdown、batch residual、path cleanup 和 feature leakage。
+- [ ] 最终重新运行受修复影响的最小测试及完整门禁，不使用旧测试结果宣称完成。
+- [ ] 提交：`docs(runtime): document baseline harness`；若审查修复涉及代码，按关注点使用独立 conventional commits，不把全部修复压入文档 commit。
+- [ ] push/创建 PR 前重新获取 GitHub main、确认 branch base 和 diff；push 与 PR 创建仍等待用户单独授权。
+- [ ] PR 创建后实时查询 ruleset/branch protection，确认 `Runtime Baseline Smoke` 是否被配置为 required；无管理权限或尚未 required 时，在 PR 和收尾对账中列为仓库配置待办，不得声称门禁已生效。
+
+## 最终验收证据
+
+完成第一阶段时必须同时具备：
+
+- `cargo build -p server` 的 feature tree 不含 `runtime-baseline`。
+- `cargo test -p runtime --features runtime-baseline` 覆盖 logical/physical identity、channel/batch/gate/running/terminal、timeout/drop、panic/cancel，以及 `accepted_total = active_current + terminal_total` shutdown 守恒。
+- `cargo test -p runtime-baseline` 覆盖 CLI、startup atomic write、control protocol、真实 RocksDB stack 和 lifecycle。
+- Python unit tests证明 binary/server/memtier/control/schema/cleanup 任一失败均返回非零，且不存在 skip 分支。
+- WSL/Linux 的 4 个显式 smoke case 全部真实执行，GET/SET、batch off/on 都有非零 successful requests/QPS。
+- 两个 GET case 均完成 100,000-key 精确预填和固定 seed 1,000-key 非 nil/长度/内容验证；batch-off/on 的 observer 指标证明实际执行路径与 manifest 一致。
+- run-level verifier 证明 expected/executed/outcome case 集合完全一致，passed=4、failed=0、skipped=0。
+- CI `Compile Benchmarks` 和 `Runtime Baseline Smoke` 是两个名称清晰的 check；后者保存可审计 artifact。
+- production `kiwi` 不包含 benchmark control endpoint 或 benchmark CLI。
+- 当前 GitHub Python integration 继续真实通过；#350 不重新引入 server-missing 全 skip 假绿。
+- 没有把 hosted runner 性能数值作为 #351 阈值，也没有提前改变 storage 调度模型。

--- a/docs/superpowers/plans/2026-07-24-storage-runtime-baseline-harness.md
+++ b/docs/superpowers/plans/2026-07-24-storage-runtime-baseline-harness.md
@@ -2,7 +2,7 @@
 
 > **面向 AI 代理的工作者：** 必需子技能：使用 superpowers:subagent-driven-development（推荐）或 superpowers:executing-plans 逐任务实现此计划。步骤使用复选框（`- [ ]`）语法来跟踪进度。
 
-**目标：** 为 Issue #350 第一阶段交付一个可重复、fail-closed 的真实 `TCP -> RuntimeManager -> StorageServer -> RocksDB` 基线 harness，并在 CI 中真实执行 4 个 GET/SET smoke case，而不是只编译 benchmark target。
+**目标：** 为 Issue #350 原第一阶段交付一个可重复、fail-closed 的真实 `TCP -> RuntimeManager -> StorageServer -> RocksDB` 基线 harness，并在 CI 中真实执行 4 个 GET/SET smoke case，而不是只编译 benchmark target；原第一阶段拆成 Foundation PR（Tasks 1-5）和 Wiring and Smoke PR（Tasks 6-12）两个有序 PR。
 
 **架构：** `runtime` crate 在 `runtime-baseline` feature 下只定义请求身份、生命周期事件和同步 observer 接口；具体原子指标、采样 collector、控制协议和真实服务编排由新的 `tools/runtime-baseline` crate 实现。`NetworkServer` 增加可取消且可等待的通用生命周期入口，harness 按“停止 accept/连接 -> 关闭 request sender -> 等待 StorageServer -> 停止 runtimes”顺序退出。Python 标准库控制器只负责编排、资源采样、memtier 调用和结果验证，主要负载固定使用可校验 provenance 的 `memtier_benchmark 2.5.1`。
 
@@ -10,15 +10,27 @@
 
 ---
 
+## 交付拓扑与 PR 门禁
+
+```text
+Foundation PR（Tasks 1-5，当前 PR #378）
+  -> Wiring and Smoke PR（Tasks 6-12，完成原第一阶段）
+  -> Baseline Results PR（原第二阶段）
+```
+
+- **Foundation PR（当前 PR #378）：** 只交付工具 crate 骨架、组合与生命周期入口、request sender 显式关闭点、feature-gated observer contract、请求身份和状态 token。Ready 前必须完成 Tasks 1-5 的构建、测试、feature 隔离和生产路径无影响验证。binary 仍必须以 `harness not initialized` 非零退出；这表示真实接线尚未开始，不是可运行 smoke。该 PR 不关闭 #350。
+- **Wiring and Smoke PR：** 交付 Tasks 6-12，把 observer 接入真实请求生命周期，实现 benchmark-only server、控制器、4-case smoke、结果校验和 CI fail-closed 门禁，完成原第一阶段。Ready 前必须具备本文“Wiring and Smoke PR Ready/验收证据”列出的全部证据。该 PR 不发布正式性能结论，也不关闭 #350。
+- **Baseline Results PR：** 执行原第二阶段，在固定 WSL/Linux 或固定 self-hosted 环境运行完整版本化矩阵，提交可追溯结果，冻结 #351 阈值并给出 executor 选择建议。只有该 PR 验收后才关闭 #350。
+
 ## 实施边界
 
-- 本计划只实现 #350 第一阶段 harness、观测、4-case smoke 和 CI 门禁，不实现 #351 bounded executor。
+- 本计划的 Tasks 1-12 只实现 #350 原第一阶段的 harness、观测、4-case smoke 和 CI 门禁，不实现 Baseline Results PR，也不实现 #351 bounded executor。
 - 不改变当前 storage 调度模型、RocksDB 配置、命令语义、fsync、一致性或 batching 算法来改善结果。
 - 不启用现有 `StorageMetricsTracker`；其 async Mutex 和样本容器会污染热路径。
 - 不把 benchmark control 命令加入 Redis 命令表；控制协议只存在于 `kiwi-runtime-baseline` target。
 - 不将 GitHub hosted runner 的 QPS/P99 作为性能回归阈值；CI 只验证真实执行、非零结果、状态守恒和 fail-closed。
 - 普通 `cargo build` 和 `cargo build -p server` 不得启用 `runtime-baseline` feature；只有工具 target 和显式 `--all-features` 验证启用。
-- 第一阶段允许 `MEMTIER_BIN` 运行 smoke，但无可信 provenance 的结果必须标记 `non_publishable`；第二阶段正式 baseline 只接受 bootstrap 产物。
+- Wiring and Smoke PR 允许 `MEMTIER_BIN` 运行 smoke，但无可信 provenance 的结果必须标记 `non_publishable`；Baseline Results PR 的正式 baseline 只接受 bootstrap 产物。
 - 所有新增 `.rs`、`.py`、`.sh` 和普通 `.yaml` 文件必须包含仓库认可的 Apache 2.0 license header；不能等到最终 license job 才补。
 
 ## 实施前事实校正
@@ -184,6 +196,8 @@ pub async fn run_until_cancelled(
 
 响应固定为 `{request_id, ok, result}` 或 `{request_id, ok:false, error:{code,message}}`。未知字段、未知命令、重复 shutdown、非 loopback peer、超限行、invalid JSON 和 timeout 都必须显式失败。
 
+> **Foundation PR 边界：** Tasks 1-5 属于当前 PR #378。完成 Task 5 后仍不得接入真实 harness 或声称 smoke 可运行。
+
 ## 任务 1：校正设计约束并创建可独立编译的工具 crate 骨架
 
 **文件：**
@@ -214,7 +228,7 @@ pub async fn run_until_cancelled(
 - [ ] 添加 build identity 测试：startup 报告 `env!("KIWI_BASELINE_COMPILED_GIT_SHA")`；`--expected-git-sha` 不同则 binary 在 listener/startup 之前失败，不能回显 caller 输入。
 - [ ] 添加 startup JSON 测试：临时文件与目标同目录；目标出现时 JSON 完整；PID、两个地址、canonical data dir、compiled Git SHA 和 schema version 正确；临时文件不残留。
 - [ ] 运行 `cargo test -p runtime-baseline --test startup_test`，确认先红后绿。
-- [ ] 保持 `main.rs` 只解析参数并返回“harness not initialized”非零；不得伪装成可运行 smoke。
+- [ ] 保持 `main.rs` 只解析参数并返回“harness not initialized”非零；该行为必须保持到 Foundation PR #378 合并，且不得伪装成可运行 smoke。只有后续 Wiring and Smoke PR 的任务 8 才删除占位失败。
 - [ ] 运行 `cargo build -p server`，并用 `cargo tree -p server -e features | rg "runtime-baseline"` 确认普通 server 构建未启用 feature。
 - [ ] 运行 `cargo build`，确认默认 root build 不构建 `runtime-baseline` package。
 - [ ] 运行 `cargo test -p runtime-baseline --test cli_test --test startup_test` 和 `git diff --check`。
@@ -311,6 +325,8 @@ pub fn close_storage_requests(&mut self) -> bool {
 - [ ] 运行 feature tests、`cargo test -p runtime` 和 `cargo check -p server`，确认 feature off 生产调用方无需 observer。
 - [ ] 提交：`feat(runtime): add baseline request observer`。
 
+> **Wiring and Smoke PR 起点：** Tasks 6-12 必须在 Foundation PR 之后实施；这一 PR 完成原第一阶段的真实接线、smoke 和 CI 门禁。
+
 ## 任务 6：接通 MessageChannel、StorageClient、retry、timeout 和 response 事件
 
 **文件：**
@@ -387,7 +403,7 @@ pub fn close_storage_requests(&mut self) -> bool {
 - [ ] 实现 control response request-id 回显和结构化错误；`pause` 必须等待 active drain；blocker 必须返回 started/completed event 进度。
 - [ ] 实现 harness shutdown 顺序和各阶段 deadline；任一 JoinHandle panic、timeout、metrics 不守恒，或四个 active current 任一非零，均使 binary 非零退出。
 - [ ] shutdown 最后关闭 sample sender、等待 collector JoinHandle flush 完成，再生成最终 snapshot；collector 丢样可以计数，但 collector 未退出/未 flush 不能 pass。
-- [ ] `main.rs` 删除任务 1 的占位失败，进入真实 `start -> wait control shutdown -> drain -> exit`。
+- [ ] 在 Wiring and Smoke PR 中删除任务 1 的占位失败，使 `main.rs` 进入真实 `start -> wait control shutdown -> drain -> exit`。
 - [ ] 运行 `cargo test -p runtime-baseline`、`cargo test -p net`、`cargo test -p runtime --features runtime-baseline`。
 - [ ] 提交：`test(runtime): add baseline harness control plane`。
 
@@ -505,7 +521,7 @@ timeout --signal=TERM --kill-after=30s 5m \
 - 必要时修改：前述实现文件中的审查问题
 
 - [ ] 文档记录 WSL/Linux prerequisites、bootstrap、build、run、verify、结果目录、publishable/non-publishable、4-case smoke 非性能门限、常见 failure code 和安全 cleanup 边界。
-- [ ] 明确第二阶段仍需固定机器、完整 `cases.yaml`、重复 5 次、CV 稳定性和 #351 阈值冻结；第一阶段不关闭 #350。
+- [ ] 明确 Baseline Results PR 仍需固定机器、完整 `cases.yaml`、重复 5 次、CV 稳定性和 #351 阈值冻结；Foundation PR 与 Wiring and Smoke PR 都不关闭 #350。
 - [ ] 运行格式检查：`cargo fmt --all -- --check`。
 - [ ] 运行 feature 测试：`cargo test -p runtime --features runtime-baseline`。
 - [ ] 运行受影响 crates：`cargo test -p runtime`、`cargo test -p net`、`cargo test -p runtime-baseline`。
@@ -523,9 +539,9 @@ timeout --signal=TERM --kill-after=30s 5m \
 - [ ] push/创建 PR 前重新获取 GitHub main、确认 branch base 和 diff；push 与 PR 创建仍等待用户单独授权。
 - [ ] PR 创建后实时查询 ruleset/branch protection，确认 `Runtime Baseline Smoke` 是否被配置为 required；无管理权限或尚未 required 时，在 PR 和收尾对账中列为仓库配置待办，不得声称门禁已生效。
 
-## 最终验收证据
+## Wiring and Smoke PR Ready/验收证据（完成原第一阶段）
 
-完成第一阶段时必须同时具备：
+Wiring and Smoke PR 达到 Ready、完成原第一阶段时必须同时具备：
 
 - `cargo build -p server` 的 feature tree 不含 `runtime-baseline`。
 - `cargo test -p runtime --features runtime-baseline` 覆盖 logical/physical identity、channel/batch/gate/running/terminal、timeout/drop、panic/cancel，以及 `accepted_total = active_current + terminal_total` shutdown 守恒。
@@ -538,3 +554,13 @@ timeout --signal=TERM --kill-after=30s 5m \
 - production `kiwi` 不包含 benchmark control endpoint 或 benchmark CLI。
 - 当前 GitHub Python integration 继续真实通过；#350 不重新引入 server-missing 全 skip 假绿。
 - 没有把 hosted runner 性能数值作为 #351 阈值，也没有提前改变 storage 调度模型。
+
+## Baseline Results PR Ready/验收证据（原第二阶段）
+
+Baseline Results PR 达到 Ready、关闭 #350 前必须同时具备：
+
+- 在固定 WSL/Linux 或固定 self-hosted 环境按版本化 `cases.yaml` 执行完整矩阵。
+- 每个正式 case 独立重复 5 次，并满足设计规格定义的 CV 稳定性要求；不使用 hosted runner 数值冻结阈值。
+- 提交环境清单、exact SHA、binary/provenance digest、原始 JSON/CSV、日志和可复核摘要。
+- 覆盖 batching、runtime threads、pipeline、value size、queue saturation、慢 storage、storage-gate pause 和 shutdown drain 行为。
+- 基于稳定结果冻结 #351 的量化验收阈值，并给出 executor 模型选择建议，但不在该 PR 中实施 #351。

--- a/docs/superpowers/plans/2026-07-24-storage-runtime-baseline-harness.md
+++ b/docs/superpowers/plans/2026-07-24-storage-runtime-baseline-harness.md
@@ -161,7 +161,7 @@ pub async fn run_until_cancelled(
 ) -> Result<(), Box<dyn Error>>;
 ```
 
-现有 `ServerTrait::run()` 调用该方法并传入永不取消的 token，保持生产行为。新方法以一个三路 `tokio::select!` 同时处理 listener accept、cancellation 和 `JoinSet::join_next()`：运行期间持续 reap 已完成连接，不能等 shutdown 才清空而导致连接 churn 下 JoinSet 无界增长。普通连接 EOF/协议错误继续记录日志且不终止生产 server；只有 task panic/JoinError 或 server 级错误才使 server 返回 error。
+现有 `ServerTrait::run()` 调用该方法并传入永不取消的 token，保持生产行为。新方法以一个三路 `tokio::select!` 同时处理 listener accept、cancellation 和 `JoinSet::join_next()`：运行期间持续 reap 已完成连接，不能等 shutdown 才清空而导致连接 churn 下 JoinSet 无界增长。普通连接 EOF/协议错误继续记录日志且不终止生产 server；单连接 task panic/JoinError 记录 warning 和 lifecycle failure counter 后继续 accept，只有 listener、cleanup、pool 守恒等 server 级错误才使 server 返回 error。
 
 当前 `start_pool_cleanup()` 是 detached 无限任务，`ConnectionPool<NetworkResources>` 的 idle entries 又持有 `StorageClient` clone。实现必须让 pool cleanup 受同一个 cancellation token 控制并被等待；connection tasks 全部结束后显式清空 pool 中的空闲 `NetworkResources`，确认 pool stats 为 active=0、available=0，再允许 `run_until_cancelled` 返回。
 
@@ -223,8 +223,8 @@ pub async fn run_until_cancelled(
 - [ ] 添加失败测试：相对 `--data-dir`、非 loopback listen、已含 RocksDB `CURRENT` 的 data dir、相对 startup/metrics path 均被 CLI 拒绝。
 - [ ] 运行 `cargo test -p runtime-baseline --test cli_test`，确认测试因 CLI 尚未实现而红灯。
 - [ ] 最小实现 `ServerArgs`：`--listen`、`--control-listen`、`--data-dir`、`--startup-event`、`--metrics-output`、`--expected-git-sha`、runtime thread/capacity/timeout/batching/instrumentation 参数。
-- [ ] 在 `build.rs` 中优先读取 CI 显式提供的 `KIWI_BASELINE_BUILD_GIT_SHA`，否则从当前 checkout 执行 `git rev-parse HEAD`；两者都必须是 40 位 hex，结果通过 `cargo:rustc-env=KIWI_BASELINE_COMPILED_GIT_SHA=...` 编入 binary。构建时同时执行受边界限制的 `git status --porcelain`，嵌入 `KIWI_BASELINE_SOURCE_DIRTY=true|false`。设置 `rerun-if-env-changed`，并覆盖 worktree `.git` 指针/HEAD 的 rerun 依赖。
-- [ ] dirty build 允许执行 smoke，但 startup/outcome 的 `publishability` 必须为 `non_publishable` 且包含 `dirty_source_tree`；CI Compile job 必须在 build 前断言 checkout clean。
+- [ ] 在 `build.rs` 中优先读取 CI 显式提供的 `KIWI_BASELINE_BUILD_GIT_SHA`，否则从当前 checkout 执行 `git rev-parse HEAD`；两者都必须是 40 位 hex，结果通过 `cargo:rustc-env=KIWI_BASELINE_COMPILED_GIT_SHA=...` 编入 binary。构建时必须通过 `build_support::source_status_arguments()` 执行 canonical `git status --porcelain --untracked-files=all -- <inputs/exclusions>`：根 `Cargo.toml`、`Cargo.lock`、`rust-toolchain.toml`、`.cargo/`、`src/`，工具 `Cargo.toml`、`build.rs`、`build_support.rs`、`src/`、`tests/`，并排除任意层级 `.git`、`target`、`results`。嵌入 `KIWI_BASELINE_SOURCE_DIRTY=true|false`，设置 `rerun-if-env-changed`，并覆盖 worktree `.git` 指针/HEAD 的 rerun 依赖。
+- [ ] dirty build 允许执行 smoke，但 startup/outcome 的 `publishability` 必须为 `non_publishable` 且包含 `dirty_source_tree`；CI Compile job 必须在 build 前使用同一 `source_status_arguments()` 精确断言 canonical source scope clean，不得扩大成全仓库 status。
 - [ ] 添加 build identity 测试：startup 报告 `env!("KIWI_BASELINE_COMPILED_GIT_SHA")`；`--expected-git-sha` 不同则 binary 在 listener/startup 之前失败，不能回显 caller 输入。
 - [ ] 添加 startup JSON 测试：临时文件与目标同目录；目标出现时 JSON 完整；PID、两个地址、canonical data dir、compiled Git SHA 和 schema version 正确；临时文件不残留。
 - [ ] 运行 `cargo test -p runtime-baseline --test startup_test`，确认先红后绿。
@@ -277,7 +277,7 @@ pub fn with_config_and_pause_controller(
 - [ ] 实现 `NetworkServer::run_until_cancelled(CancellationToken)`，accept、cancellation 和 `JoinSet::join_next()` 使用三路 `tokio::select!`，运行期间持续 reap 完成 task。
 - [ ] 用 `JoinSet` 保存 connection tasks；每个 task 使用 child token，在 shutdown 后停止从连接读取新命令并退出。普通连接错误在 task 内日志记录后正常结束，不升级为 server 失败。
 - [ ] 把 pool cleanup task 纳入可取消、可等待生命周期；为 `ConnectionPool` 增加清空 idle entries 的 API。
-- [ ] cancellation 后停止 accept、取消 child token、持续等待所有 JoinSet task和 cleanup task；JoinError/panic 必须传播为 server error；最后清空 pool 并验证 active/available 均为 0。
+- [ ] cancellation 后停止 accept、取消 child token、持续等待所有 JoinSet task和 cleanup task；单连接 JoinError/panic 必须计入 failure counter 并记录 warning，但不改变 server shutdown 返回值；最后清空 pool 并验证 active/available 均为 0。cleanup JoinError 和 pool 守恒失败仍作为 server error 传播。
 - [ ] 现有 `ServerTrait::run()` 调用 `run_until_cancelled(CancellationToken::new())`，保持普通生产 server 的无限运行语义。
 - [ ] 运行新增测试、`cargo test -p net --test storage_command_e2e_tests` 和 `cargo test -p net`。
 - [ ] 提交：`feat(net): add cancellable server lifecycle`。
@@ -477,6 +477,9 @@ pub fn close_storage_requests(&mut self) -> bool {
 - [ ] 在 WSL/Linux bootstrap memtier，并运行：
 
 ```bash
+MEMTIER_PREFIX="${MEMTIER_PREFIX:?set MEMTIER_PREFIX to the memtier install prefix}"
+TMPDIR="${TMPDIR:-${RUNNER_TEMP:-/tmp}}"
+RESULTS_ROOT="$TMPDIR/runtime-baseline-results"
 timeout --signal=TERM --kill-after=30s 5m \
   python3 tools/runtime-baseline/run_baseline.py run \
     --suite smoke \
@@ -484,11 +487,21 @@ timeout --signal=TERM --kill-after=30s 5m \
     --server-binary target/release/kiwi-runtime-baseline \
     --memtier-binary "$MEMTIER_PREFIX/bin/memtier_benchmark" \
     --memtier-provenance "$MEMTIER_PREFIX/memtier-provenance.json" \
-    --results-root "$TMPDIR/runtime-baseline-results" \
+    --results-root "$RESULTS_ROOT" \
     --expected-git-sha "$(git rev-parse HEAD)"
 ```
 
-- [ ] 独立运行 verify，确认 expected/executed/outcome 精确为 4、passed=4、failed=0、skipped=0、每 case successful requests/QPS 和 execution terminal 非零。
+```bash
+TMPDIR="${TMPDIR:-${RUNNER_TEMP:-/tmp}}"
+RESULTS_ROOT="$TMPDIR/runtime-baseline-results"
+python3 tools/runtime-baseline/run_baseline.py verify \
+  --suite smoke \
+  --cases tools/runtime-baseline/cases/cases.yaml \
+  --results-root "$RESULTS_ROOT" \
+  --expected-git-sha "$(git rev-parse HEAD)"
+```
+
+- [ ] 使用上述独立 `verify` 命令，确认 expected/executed/outcome 精确为 4、passed=4、failed=0、skipped=0、每 case successful requests/QPS 和 execution terminal 非零。
 - [ ] verifier 对 batch-off case 强制 `batch_queued_max=0`、`batch_count=0`、所有 flush counters=0；对 batch-on case强制 `batch_queued_max>0`、`batch_count>0`，且 size/timeout/high-priority flush counter 至少一个大于 0。任一不满足都标记路径未覆盖并使 smoke 失败。
 - [ ] 检查结果不含 RocksDB data dir、core dump、本机凭据或仓库外绝对用户路径。
 - [ ] 提交：`build(runtime): pin memtier smoke dependency`。
@@ -500,7 +513,7 @@ timeout --signal=TERM --kill-after=30s 5m \
 - 修改：`.github/workflows/benchmark.yml`
 
 - [ ] 保留 job/check 名称 `Compile Benchmarks`，继续执行 `cargo bench --no-run`。
-- [ ] Compile job 先断言 `git status --porcelain` 为空，再安装 protoc/memtier build dependencies、bootstrap memtier，并设置 `KIWI_BASELINE_BUILD_GIT_SHA=${{ github.sha }}` 构建 exact-head `kiwi-runtime-baseline` release binary；生成包含 compiled Git SHA、source_dirty=false、harness SHA-256 和两个 binary `ldd` 输出的 artifact manifest，并把 harness binary、memtier binary、provenance/manifest 上传为短期 artifact。
+- [ ] Compile job 先使用 `build_support::source_status_arguments()` 对应的 canonical `git status --porcelain --untracked-files=all -- <inputs/exclusions>` 精确断言 source scope 为空，再安装 protoc/memtier build dependencies、bootstrap memtier，并设置 `KIWI_BASELINE_BUILD_GIT_SHA=${{ github.sha }}` 构建 exact-head `kiwi-runtime-baseline` release binary；生成包含 compiled Git SHA、source_dirty=false、harness SHA-256 和两个 binary `ldd` 输出的 artifact manifest，并把 harness binary、memtier binary、provenance/manifest 上传为短期 artifact。
 - [ ] 新增独立 job/check `Runtime Baseline Smoke`，依赖 Compile job，`timeout-minutes: 45`；checkout 同一个 `${{ github.sha }}` 以取得 controller/tests/cases，然后只下载 Compile job 的 exact-run binary artifact，不重新使用 runner 上未知 binary。
 - [ ] Smoke job 显式安装两个 binary 所需的 runtime packages。download-artifact 后执行 `chmod +x`，重新校验 harness artifact digest、compiled SHA/source_dirty、memtier provenance digest/commit/version；分别运行 `ldd` 并拒绝任何 `not found`，同时保存实际 `ldd` 与 Compile manifest 对账。GitHub artifact 不保留 Unix executable bit，不能直接假定可执行。
 - [ ] Smoke job 先运行 Python unit tests，再用 GNU `timeout ... 5m` 执行 controller，随后独立 verify 4 个结果。

--- a/docs/superpowers/specs/2026-07-24-storage-runtime-baseline-design.md
+++ b/docs/superpowers/specs/2026-07-24-storage-runtime-baseline-design.md
@@ -1,0 +1,553 @@
+# Storage Runtime 性能与背压基线设计
+
+## 背景
+
+Issue #350 是 Epic #347 的第三阶段。#348 已删除生产路径中的内存 Raft LogStore，#349 已通过 PR #365 删除 `Engine` 伪抽象并明确 RocksDB 所有权。下一步必须先测量当前 storage 执行链路，再进入 #351 的 bounded RocksDB executor 重构。
+
+当前生产请求链路为：
+
+```text
+RESP TCP
+  -> network runtime
+  -> bounded mpsc request channel
+  -> StorageServer
+  -> batching on: 收集请求后逐请求 tokio::spawn
+     batching off: 每请求 tokio::spawn
+  -> 同步 RocksDB command
+  -> oneshot response
+```
+
+bounded mpsc 只能限制仍在 channel 中的请求。StorageServer 取出请求后会继续创建 Tokio task，`StorageServerConfig.worker_count` 没有进入调度路径，因此 queued 加 running 的总量没有真实上界。当前 batching 也没有形成 RocksDB WriteBatch 或 MultiGet，只是在执行前等待并重新分组请求。
+
+仓库现有性能代码不能作为 #350 的验收基线：根目录 `benches/dual_runtime_performance_benchmark.rs` 没有注册为 Cargo target，包含 simulated workload、placeholder 指标和过期 API；已注册的 `network_benchmark` 只测 mock 网络组件，不经过 StorageServer 或 RocksDB；Benchmark workflow 只运行 `cargo bench --no-run`，只证明 benchmark target 可以编译。
+
+## CI 真实性基线
+
+PR #365 已修复 GitHub Python integration 的 server-missing/全 skip 假绿，不能再以旧
+workflow 作为当前设计前提。该结论只适用于 Python integration，不代表现有 Benchmark
+workflow 已运行真实负载。当前 `.github/workflows/ci.yml` 调用
+`tests/run_python_integration.sh`，该脚本：
+
+- 拒绝复用已占用的 `127.0.0.1:6379`；
+- 启动本次构建的 `target/debug/kiwi`；
+- 使用独立 data、log 和配置目录；
+- 通过真实 RESP `PING` 等待 ready；
+- 设置 `KIWI_TEST_REQUIRE_SERVER=1`，使连接失败从 `pytest.skip` 变为 `pytest.fail`；
+- 测试后检查 Kiwi 进程仍存活；
+- 通过 EXIT trap 回收进程并保留原始退出码。
+
+`main@89bd840919a4650ea718ea39f27cde869f49da74` 的 integration run `30079482937` 实际 collected 55、passed 55、skipped 0。#350 harness 必须复用同样的 fail-closed 原则，不得退回“外部服务不存在时全部 skip 仍返回 0”的模式。
+
+直接运行 `make -C tests test-python` 时仍保留本地宽松语义：没有服务可以 skip。这不是当前 GitHub CI 路径，也不作为 #350 的阻断修改。#350 新增的 benchmark smoke 和完整基线入口必须始终自行启动目标进程并在 ready、执行或 cleanup 失败时返回非零状态。
+
+## 目标
+
+- 建立可重复执行的真实 `TCP -> runtime -> StorageServer -> RocksDB` 基线工具。
+- 测量吞吐、P50/P95/P99、错误率、背压、资源占用、storage-gate pause/drain 和 shutdown。
+- 比较 batching 开关、runtime thread 数、channel capacity、pipeline 和 value size。
+- 验证或证伪双 runtime 在慢 storage 场景下保持网络可响应性的收益。
+- 保存机器可读原始结果、环境清单和人类可读摘要。
+- 用测量结果冻结 #351 的性能、错误率、容量和生命周期验收阈值。
+- 为固定同步 worker pool 与 `spawn_blocking + Semaphore` 的后续选择提供数据依据。
+
+## 非目标
+
+- 不在 #350 中实现 bounded executor、Semaphore 或固定 worker pool。
+- 不改变当前请求调度、命令语义、持久化、fsync、RocksDB 参数或一致性语义来改善数字。
+- 不在测量前修改 MGET 的 `STORAGE_EXCLUSIVE`，避免污染当前基线。
+- 不在本任务中删除 batching、priority、scaling、fault injection 或 metrics 脚手架；这些属于 #352。
+- 不把 unit microbenchmark、mock 网络测试或 `cargo bench --no-run` 当作端到端结果。
+- 不把 GitHub hosted runner 的波动性能数字设为稳定的 Merge 阈值。
+- 不混入 ZSCAN 二进制 pattern、旧 `.restore_temp_*` 自动清理或其他 Redis/恢复功能修改。
+
+## 方案选择
+
+采用方案 C：固定版本 `memtier_benchmark` 生成主负载，仓库内薄控制器负责启动、编排、采样和结果归档，Kiwi 只增加 benchmark 所需的最小只读观测能力。
+
+主负载工具固定为 `memtier_benchmark 2.5.1`，对应 upstream commit
+`5f634d171b83efca9640c5a87606c47b34d3d330`。仓库提供 bootstrap 脚本从该 commit
+构建工具，并校验 checkout SHA。bootstrap 在 Linux 安装或检查 `autoconf`、`automake`、
+`libevent-dev`、`pkg-config`、`libssl-dev` 和 `zlib1g-dev` 等 upstream 构建依赖；缓存只
+用于加速，不能跳过 SHA 与版本校验。
+
+正式可发布 baseline 默认只接受 bootstrap 构建的 binary。控制器保存 upstream commit、
+完整 `memtier_benchmark --version` 输出和 binary SHA-256。允许通过 `MEMTIER_BIN` 使用
+预装二进制，但无法提供受信 provenance 的 binary 只能运行 CI smoke，结果标记为
+`non_publishable`。`redis-benchmark` 只用于少量 GET、SET 和 pipeline 交叉验证，不作为
+唯一结果来源。
+
+不采用仅使用 `redis-benchmark` 的方案，因为它无法完整表达混合负载、storage-gate
+pause、慢 storage 和 pending shutdown 场景。不采用完全自研高性能客户端，因为开发
+成本高，且客户端实现本身会成为新的性能变量。
+
+## 交付分段
+
+#350 通过两个小 PR 完成，避免把工具、观测接线和大量结果混在一个 PR 中。
+
+### 第一阶段：基线 harness 与 smoke
+
+建议标题：
+
+```text
+test(runtime): add reproducible storage baseline harness
+```
+
+交付内容：
+
+- 可参数化启动真实 Kiwi runtime stack 的 benchmark-only server/harness。
+- 薄控制器启动 harness、等待 RESP PING、运行 memtier、采样资源、停止进程并写出 JSON。
+- 只读 runtime 观测快照及其测试。
+- 一个短时间 smoke matrix，验证工具链、结果 schema 和 fail-closed 行为。
+- CI 继续编译所有 benchmark target，并额外运行不用于性能判定的短 smoke。
+- smoke 失败时上传 controller log、Kiwi log、环境清单和部分 JSON。
+
+第一阶段不发布“优化后更快”等性能结论，也不关闭 #350。
+
+### 第二阶段：完整基线与阈值冻结
+
+建议标题：
+
+```text
+perf(runtime): publish storage execution baseline
+```
+
+交付内容：
+
+- 在固定 WSL/Linux 或固定 self-hosted 环境执行完整矩阵。
+- 提交环境说明、运行清单、原始 JSON/CSV 和摘要。
+- 分析 batching、runtime threads、pipeline、value size、queue saturation 和慢 storage。
+- 记录 storage-gate pause 与 shutdown 的请求归属和 drain 行为。
+- 在 #350 文档中冻结 #351 的量化验收阈值。
+- 给出 #351 executor 模型的选择建议，但不在该 PR 中实施。
+
+## Harness 架构
+
+### Benchmark-only server
+
+新增 workspace 工具 crate `tools/runtime-baseline`，其中提供可直接执行的
+`kiwi-runtime-baseline` binary，而不是使用 `[[bench]]` 或通过 `cargo bench` 间接启动。
+构建命令固定为：
+
+```bash
+cargo build --release -p runtime-baseline --bin kiwi-runtime-baseline
+```
+
+Python 控制器只接收该明确 binary 的绝对路径，PID、signal 和退出码都属于这个直接
+子进程。已有 `cargo bench --no-run` 继续只负责正式 Cargo bench target，不能代表 server
+harness 已运行。
+
+该工具 crate 不依赖生产配置文件暴露尚未稳定的 runtime 参数，而是复用现有 E2E
+`TestServer` 的真实组件组合：
+
+- `RuntimeManager`；
+- bounded request channel；
+- `StorageServer::with_config`；
+- `NetworkServer`；
+- 真实临时 RocksDB；
+- `StorageServerPauseController`。
+
+当前 StorageServer 的 `with_config`、`with_pause_controller` 和 `with_metrics` 不能同时组合
+自定义 config、共享 access gate 和 observer；RuntimeManager 又在内部创建 MessageChannel
+和 StorageClient。第一阶段允许增加最小的组合构造入口，把同一个可选
+`Arc<BaselineMetrics>` 注入完整请求链：
+
+- RuntimeManager/MessageChannel：logical request 开始、physical attempt 创建、send accepted、
+  send failed 和 channel queued；
+- StorageClient：retry、client timeout 和 response received；
+- StorageServer/BatchProcessor：dequeue、batch queued、waiting gate、running、execution terminal
+  和 oneshot send result；
+- lifecycle handle：shutdown rejection 和 abandoned 归类。
+
+logical request id 与每次 retry 的 physical attempt id 分离；attempt id 从 enqueue 到 execution
+terminal 保持不变。现有生产构造路径统一传入 `None`，benchmark observer、原子更新和控制
+协议通过 `runtime-baseline` feature 编译，普通生产 `kiwi` 不包含这些 hooks。组合 API 不改变
+worker/batching 调度。
+
+target 接受明确参数：
+
+- listen host/port；
+- data directory；
+- network runtime threads；
+- storage runtime threads；
+- request channel capacity；
+- request timeout；
+- batching enabled；
+- batch size；
+- batch timeout；
+- metrics output path；
+- control listen address；
+- startup event output path。
+
+默认绑定 loopback，并拒绝复用已占用端口。所有数据目录必须由控制器创建并显式传入。benchmark target 不读取用户生产数据目录，也不修改生产配置默认值。
+
+### 启动与控制通道
+
+benchmark target 的 Redis listener 和控制 listener 都绑定 loopback，并允许端口为 0，
+由操作系统分配可用端口。两个 listener 就绪后，target 以原子 rename 写出一个 startup
+JSON 文件：
+
+```text
+{
+  "pid": 1234,
+  "redis_addr": "127.0.0.1:41001",
+  "control_addr": "127.0.0.1:41002",
+  "data_dir": "...",
+  "git_sha": "..."
+}
+```
+
+控制器读取该文件后仍必须通过 Redis listener 执行真实 `PING`，不能只相信 startup
+事件。startup JSON 中的 PID、data dir 和 Git SHA 必须与控制器启动参数一致。
+
+控制器需要触发 storage access gate pause/resume、受控慢 storage、读取 metrics snapshot 和执行
+shutdown。控制通道使用 newline-delimited JSON request/response，至少支持：
+
+```text
+{"command":"metrics"}
+{"command":"pause"}
+{"command":"resume"}
+{"command":"block_runtime_workers","duration_ms":50,"concurrency":4}
+{"command":"arm_operation_delay","duration_ms":50}
+{"command":"release_operation_delay"}
+{"command":"shutdown","mode":"drain"}
+```
+
+每个 response 都包含 request id、`ok` 和结构化结果或错误。`pause` 只有在 access gate
+active owners 已 drain 后才返回；channel queued、batch queued 和 running metrics 同时被
+记录。该场景和结果统一命名为 `storage-gate-pause`，不声称执行了完整 Raft snapshot
+build/install；完整 snapshot 行为继续由现有 raft integration tests 负责。
+
+慢 storage 分为两个独立机制：
+
+- `block_runtime_workers` 向当前 request channel 注入指定 `concurrency` 的 benchmark-only
+  内部 command，在 storage runtime 线程中执行 `std::thread::sleep`。每个阻塞 command
+  产生 started/completed event，用于确认负载和网络 probe 确实落在阻塞窗口内。
+- `arm_operation_delay` 在 benchmark feature 下为后续每个 storage execution 增加同步
+  等价延迟，用于稳定制造 queue saturation、timeout 和背压。控制器等待 armed event 后
+  才开始正式采样，并通过 `release_operation_delay` 解除。
+
+两种机制都不进入 Redis 命令表，也不编译进普通生产 `kiwi` 二进制。
+
+控制器只有在目标数量的 blocker 全部进入 started 且尚未 completed 后才能启动 network
+probe。若达到目标并发前已有 blocker completed，该 case 失败；控制器可以按 manifest 中
+规定的更长 duration 重新执行，但不能把未形成重叠阻塞窗口的样本记为成功。
+
+`shutdown` 触发 benchmark target 中与当前 NetworkServer、StorageServer 和 RuntimeManager
+一致的 stop 路径，不预设当前实现一定 drain 或一定取消。第一阶段增加最小的 lifecycle
+handle：停止 accept、停止从现有连接接受新命令、保留 accept/connection/StorageServer
+JoinHandle、关闭 request sender，然后观察当前 queued/batch/waiting/running 请求如何结束，
+最后关闭 runtime。该 handle 复用真正的 NetworkServer，不另写简化 TCP server。
+
+shutdown 开始后新 offered requests 归为 `rejected_after_shutdown`。shutdown 前已 accepted 的
+storage attempts 必须最终归类为 execution finished、shutdown rejected after accept 或
+abandoned；timeout 和 response dropped 作为客户端观察/交付结果单独统计，不能与 execution
+终态混为一类。
+
+控制协议只属于 benchmark target，不进入 Redis 命令表、不暴露在生产 `kiwi` 二进制中。
+控制请求失败、超时或返回格式错误必须使对应 case 失败。
+
+### Python 控制器
+
+Python 只负责编排，不生成主要负载。控制器使用标准库完成：
+
+- 临时目录与配置生成；
+- 子进程启动和有界 readiness polling；
+- memtier 命令构造与超时；
+- `/proc/<pid>` CPU、RSS、线程数和进程 I/O 采样；
+- control channel 请求；
+- stdout/stderr、server log 和结果文件归档；
+- SIGINT、SIGTERM、SIGKILL 分级回收；
+- 最终 JSON schema 校验。
+
+任何阶段失败都返回非零状态。控制器必须检查：目标 PID 仍为本次启动进程、RESP PING 成功、memtier 实际完成、至少有一个成功请求、结果不是全零、server 在非 crash case 中保持存活、cleanup 完成。
+
+## 只读观测模型
+
+不直接启用现有 `StorageMetricsTracker` 的每请求异步 Mutex 路径。其共享锁和样本
+`Vec::remove(0)` 会改变被测热路径，不能作为当前 runtime 基线的既定实现。
+
+工具 crate 使用独立的 `BaselineMetrics`。热路径只执行原子 current/max/counter 更新和
+单调时间戳采样；需要分位数的阶段延迟通过有界 non-blocking sample channel 交给单独
+collector，channel 满时只增加 `dropped_metric_samples`，不得阻塞请求。默认生产 `kiwi`
+不创建该 observer、不暴露 endpoint，也不编译 benchmark 控制通道。
+
+正式 anchor case 同时运行 instrumentation off/on 配对测试：
+
+- 使用普通生产 `kiwi` binary 的默认配置运行 control case，量化 benchmark target 与生产
+  启动路径的总开销；
+- #351 的 QPS/P99 阈值以 instrumentation off 结果为主；
+- instrumentation on 用于解释 queue、running、batch 和 lifecycle 行为；
+- 开启观测后吞吐中位数下降超过 2%，或 P99 上升超过 5% 时，该 case 的 instrumented
+  QPS/P99 不得用于冻结性能阈值，并在摘要中披露观测开销。
+
+若 benchmark target 的 instrumentation-off control 相对普通生产 `kiwi` 吞吐下降超过 2%
+或 P99 上升超过 5%，不得用 target 的绝对 QPS/P99 代表当前生产基线；应以普通 `kiwi`
+结果冻结性能阈值，target 只提供内部诊断数据。
+
+观测快照至少包含：
+
+- channel current/max queued；
+- BatchProcessor current/max queued；
+- dispatch waiting for access gate current/max；
+- batch count、实际 batch size 分布；
+- timeout flush 与 size-trigger flush 次数；
+- storage task current/max running；
+- client logical requests 与 physical storage attempts 分离；
+- accepted attempts、execution success、command error、internal failure；
+- response delivered、response dropped、client timeout、retry attempt；
+- queue wait、batch wait、execution time；
+- storage-gate pause 请求时间、active drain 时间、resume 后 backlog drain 时间；
+- shutdown 开始/结束时间、完成/拒绝/遗留请求数。
+
+current/max 计数使用原子计数和 RAII guard，确保 task panic、early return 和 response drop
+都能回收 current 值。延迟以单调时钟记录。storage-gate active、channel queued、batch
+queued、waiting gate 和 running 必须分别报告，不能合并成一个含义不清的 `pending`。
+
+每个 physical attempt 按以下互斥生命周期对账：
+
+```text
+accepted_attempts
+  = channel_queued
+  + batch_queued
+  + waiting_gate
+  + running
+  + execution_finished
+  + shutdown_rejected_after_accept
+  + abandoned
+```
+
+这是某一时刻的状态分解；累计 counters 另行保存。client timeout 可与后续
+`execution_finished + response_dropped` 同时发生，因此不能把 timeout 当作 execution 终态。
+
+## 数据集与重复隔离
+
+所有 GET 和混合负载使用固定的 100,000-key keyspace，key pattern 为
+`baseline:<seed>:<zero-padded-id>`。每个 value size 创建独立预填充模板数据库：
+
+- 预填充全部 100,000 个 key，并校验 memtier 成功数；
+- 随机抽样 1,000 个 key 执行 GET，必须全部命中且 value 长度正确；
+- GET case 为 100% hit；
+- 80/20 mixed case 的 SET 只覆盖同一固定 keyspace，不持续创建新 key；
+- SET-only case 同样覆盖固定 keyspace，使每轮 WAL、flush 和 compaction 输入可比较；
+- 正式基线禁用 memtier `--randomize`，记录是否启用 `--distinct-client-seed`，并把 key
+  pattern/range 写入 case manifest。
+
+每个正式重复从同一个预填充 RocksDB checkpoint 复制到新的 case data dir，启动新的
+target 进程，不跨重复复用可变数据库。环境清单保存 template manifest：文件名、大小、
+CURRENT、MANIFEST 和 OPTIONS 文件 SHA-256。主矩阵统一测 warm workload：启动后完成规定
+预热再计时；#350 不发布无法稳定复现的 OS cold-page-cache 结论。
+
+## 测量矩阵
+
+第一阶段 smoke 固定为 4 个显式 case，不做组合展开：
+
+- GET，connections 1，pipeline 1，batching off；
+- GET，connections 8，pipeline 8，batching on；
+- SET，connections 1，pipeline 1，batching off；
+- SET，connections 8，pipeline 8，batching on。
+
+smoke value 固定 64 B，每 case 预热 0.5 秒、测量 2 秒、总超时 15 秒；整个 smoke job
+总超时 5 分钟。它只验证真实执行和 fail-closed，不用于性能比较。
+
+第二阶段使用版本化 `cases.yaml` 作为唯一可执行 case 清单。下表是可选维度，不做全
+笛卡尔积。manifest 分为以下组，合计不得超过 60 个 case variant：
+
+1. 基础吞吐：在 1 KiB value 下扫描 3 种 operation、3 种 connections、3 种 pipeline，
+   共 27 个 case。
+2. Value size：固定 anchor `GET 100% / connections 16 / pipeline 16`，扫描 64 B、1 KiB、
+   4 KiB，共 3 个 case。
+3. 单因素 runtime 扫描：固定 anchor，分别扫描 storage threads、batching 和 channel
+   capacity，不与其他变化维度组合。
+4. Offered-load 扫描：先以 anchor 校准饱和吞吐，再执行 50%、80%、100%、120% 四个
+   case。memtier 的 rate limit 按每 connection 生效，控制器必须根据 threads × clients
+   换算并记录实际 aggregate target 与舍入值。
+5. Lifecycle：慢 storage、storage-gate-pause 和 shutdown 各自独立执行，不与基础吞吐
+   矩阵交叉。
+
+`cases.yaml` 为审查和复现依据；新增 case 必须显式提交 Diff，不能由脚本隐式生成组合。
+
+可选维度定义如下：
+
+| 维度 | 档位 |
+|---|---|
+| 操作 | GET、SET、GET/SET 80/20 |
+| 连接数 | 1、16、64 |
+| Pipeline | 1、16、64 |
+| Value | 64 B、1 KiB、4 KiB |
+| Storage threads | 1、2、4、固定机器物理核心数内的代表值 |
+| Batching | off；on，100 requests / 10 ms |
+| Channel capacity | 16、256、1000 |
+| Offered load | 约饱和吞吐的 50%、80%、100%、120% |
+| 慢 storage | 10 ms、50 ms、200 ms 等价延迟 |
+| Storage gate pause | 无在途、running、channel queued、batch queued |
+| Shutdown | pending 0、queued、running |
+
+基础吞吐、value size、runtime 和 offered-load case 预热 30 秒、测量 60 秒、重复 5 次。
+lifecycle case 重复 3 次并记录每次完整事件序列。报告保留全部原始轮次，以中位数为主，
+同时输出 min、max 和变异系数。变异系数超过 5% 的 case 标记为环境不稳定，不用于冻结
+#351 阈值，必须在降低环境噪声后重跑。成功标准是提交的 `cases.yaml` 中所有 case 完成，
+不是让所有维度互相组合。
+
+## 结果格式
+
+每次运行产生独立目录：
+
+```text
+results/<git-sha>/<timestamp>/<case-id>/
+  environment.json
+  config.json
+  memtier.json
+  runtime-metrics.json
+  process-samples.jsonl
+  controller.log
+  kiwi.log
+  outcome.json
+```
+
+`outcome.json` 至少包含：
+
+- exact Git SHA 与 Cargo.lock hash；
+- case 参数；
+- start/end/duration；
+- QPS、successful QPS；
+- P50/P95/P99/max；
+- success/error/timeout/connect failure；
+- runtime metrics 最终值和峰值；
+- CPU、RSS、threads、read/write bytes；
+- storage-gate pause/shutdown 时间；
+- pass/fail 及机器可解析原因。
+
+仓库只提交经过脱敏、体积受控的原始结果和摘要。不得提交临时 RocksDB 数据目录、完整 core dump 或本机绝对用户路径。
+
+## 环境冻结
+
+正式基线必须记录：
+
+- OS、kernel、WSL/native、文件系统和 mount options；
+- CPU 型号、物理/逻辑核心、governor、turbo、affinity；
+- 内存、磁盘类型和可用空间；
+- Rust/rustc、profile、Cargo.lock hash；
+- memtier 精确版本、upstream commit、binary SHA-256 和构建方式；
+- Kiwi exact SHA 和全部 harness 参数；
+- 数据集 key 数、value size、总大小、template manifest 和 warmup 状态；
+- 客户端与服务端是否同机；
+- 预热、持续时间、重复次数、key pattern/range 和 distinct-client-seed 设置；
+- 测试期间其他已知负载。
+
+## CI 设计
+
+普通 PR CI 不把 hosted runner 的 QPS 或 P99 作为硬阈值。Benchmark workflow 拆成名称明确
+的 `Compile Benchmarks` 和 `Runtime Baseline Smoke`；smoke 作为独立、可见并应配置为
+required 的 check。CI 只验证：
+
+- `cargo build --release -p runtime-baseline --bin kiwi-runtime-baseline` 可以编译；
+- memtier 版本检查生效；
+- smoke matrix 实际启动本次构建的 target；
+- RESP PING 和至少一个 GET/SET 成功；
+- 结果 JSON 符合 schema，非全零且没有 skipped case；
+- 无服务、错误 binary、ready timeout、memtier 非零退出、server crash 和 cleanup failure 均使 job 失败；
+- 失败时日志和部分结果作为 artifact 上传。
+
+完整矩阵通过 `workflow_dispatch` 在固定环境运行，或由维护者在文档规定的固定 WSL/Linux
+主机执行。Benchmark workflow 的名称和摘要必须区分“compile/smoke”与“正式 baseline”，
+避免把 target 编译成功表述为性能验证成功。
+
+workflow 只能创建独立 check，是否 required 由 GitHub ruleset/branch protection 控制。
+第一阶段收尾必须实时核验 ruleset；若执行账号无权修改，应把“将 Runtime Baseline Smoke
+设为 required”记录为明确的仓库配置待办，不能仅凭 job 存在声称 required 门禁已生效。
+
+## 错误处理
+
+- 目标端口被占用：立即失败，不连接未知 Redis/Kiwi。
+- binary 缺失或不可执行：立即失败。
+- 进程提前退出：保存日志并失败。
+- PING 未在总超时内成功：终止进程、保存日志并失败。
+- memtier 版本不匹配或执行失败：该 case 失败，不生成可发布基线。
+- 全部请求失败、结果为空或全零：失败。
+- control channel 失败：对应 lifecycle case 失败。
+- metrics 计数不守恒或 current 在 cleanup 后非零：失败。
+- shutdown 超时：按 INT、TERM、KILL 回收并将 case 标记失败。
+- cleanup 删除路径必须位于控制器创建的临时根目录；路径验证失败时停止删除并失败。
+
+## 测试设计
+
+### Fail-closed 测试
+
+- binary 不存在时 controller 返回非零。
+- 使用 `/bin/false` 或立即退出的 test child 时 readiness 返回非零。
+- 端口被占用时不启动 target。
+- PING 失败不能转为 skip。
+- memtier 不存在、版本不匹配、超时或返回非零时 case 失败。
+- server 在负载期间退出时 case 失败。
+- outcome 中成功请求为零时 case 失败。
+
+### Metrics 测试
+
+- enqueue/dequeue 更新 channel current/max。
+- batch timeout 与 size trigger 分别计数。
+- receiver 取出后等待 access gate 的请求进入 waiting_gate，并在进入 running 后归零。
+- running guard 在成功、错误和 task panic 后归零。
+- response receiver drop 不泄漏 current，并增加 dropped counter。
+- storage-gate pause 分别报告 active、channel queued、batch queued、waiting gate 和 running。
+- retry 时 logical request 与 physical attempts 分开计数。
+- client timeout 后 execution completion 与 response dropped 可以同时出现且对账正确。
+- 请求仍在 channel 中时触发 storage-gate pause/shutdown，验证它已计入 accepted attempt，
+  attempt id 在 MessageChannel、StorageClient 和 StorageServer 之间保持一致，最终进入明确
+  terminal 分类。
+- shutdown 后 current 状态归零，accepted attempt 状态分解守恒。
+
+### 真实 smoke
+
+- 启动真实临时 RocksDB、runtime、StorageServer 和 NetworkServer。
+- 使用 memtier 2.5.1 执行短 GET/SET case。
+- 验证 client result、runtime metrics 和 process samples 均有非零数据。
+- 验证 batching off/on 都经过真实链路。
+- 验证 controller 能优雅停止 target 并释放临时目录。
+
+## 验证命令
+
+第一阶段实现后至少执行：
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-features --workspace -- -D warnings -D clippy::unwrap_used
+cargo test --package runtime
+cargo test --package net
+cargo test --package runtime-baseline
+cargo test --workspace
+bash tests/run_python_integration.sh
+python3 tools/runtime-baseline/run_baseline.py \
+  --smoke \
+  --server-binary target/release/kiwi-runtime-baseline
+git diff --check
+```
+
+完整矩阵只在固定 Linux 环境执行，不能用 Windows 结果替代。普通 Windows/macOS CI 仍负责代码可编译、Clippy 和现有行为测试。
+
+## #351 阈值冻结规则
+
+第二阶段不预先拍脑袋指定 executor 参数，但必须从稳定 baseline 产生以下阈值：
+
+- 正常负载吞吐允许回退比例；
+- P99 与 max latency 允许变化；
+- 正常负载错误率；
+- 120% offered load 下允许的错误类型和上限；
+- queued 加 running 的最大允许值；
+- storage-gate pause/drain 和 shutdown 最大时间；
+- 慢 storage 时新连接和 PING 的最大延迟；
+- CPU、RSS 和线程数允许变化。
+
+阈值只使用变异系数不超过 5% 的 case。#351 的同机对比使用相同数据、配置、工具版本、
+key pattern/range、`--distinct-client-seed` 设置和重复次数；同时报告绝对值与相对变化。
+
+## 成功标准
+
+- 其他开发者可以按文档在固定 Linux 环境复现相同矩阵。
+- benchmark 测量真实 TCP、真实 runtime、真实 StorageServer 和真实 RocksDB。
+- smoke CI 不能在 server 未启动、全部请求失败或全部 case skipped 时保持绿色。
+- 原始结果包含客户端、runtime、资源和生命周期指标。
+- batching 开关、runtime threads、queue saturation、慢 storage、storage-gate pause 和
+  shutdown 均有结果。
+- 完整基线有稳定性判断，不用单次数字冻结阈值。
+- #351 的量化验收阈值和 executor 模型选择依据已经记录。
+- #350 没有提前改变调度模型或通过降低持久化/一致性要求换取性能数字。

--- a/docs/superpowers/specs/2026-07-24-storage-runtime-baseline-design.md
+++ b/docs/superpowers/specs/2026-07-24-storage-runtime-baseline-design.md
@@ -190,9 +190,11 @@ terminal 保持不变。现有生产构造路径统一传入 `None`，benchmark 
 协议通过 `runtime-baseline` feature 编译，普通生产 `kiwi` 不包含这些 hooks。根 workspace 的
 `default-members` 精确保留 12 个生产 crate 并排除工具 crate，使普通 root build 不与工具 target
 处于同一 Cargo invocation，隔离 feature unification。组合 API 不改变 worker/batching 调度。
-构建身份中的 `source_dirty` 是受限的可编译输入状态：根 `src/`、`.cargo/`、根
-`Cargo.toml`/`Cargo.lock`/`rust-toolchain.toml`，以及工具 crate 的 manifest、build script、
-`src/` 和 `tests/`。build script 以同一集合执行有 pathspec 的 `git status --porcelain` 并注册
+构建身份中的 `source_dirty` 是受限的可编译输入状态：根 `Cargo.toml`、`Cargo.lock`、
+`rust-toolchain.toml`、`.cargo/`、`src/`，以及工具 crate 的 `Cargo.toml`、`build.rs`、
+`build_support.rs`、`src/` 和 `tests/`。`build_support::source_status_arguments()` 是 build script、
+测试和 Compile CI 共用的 canonical pathspec，执行带 canonical inputs/exclusions 的
+`git status --porcelain --untracked-files=all -- ...` 并注册
 `rerun-if-changed`；`.git`、Cargo target 和 benchmark results 都不属于该集合，避免构建产物或
 结果归档造成自触发重编译。若这个受限 source 集合有未暂存或未跟踪修改，startup/outcome 必须
 标为 `non_publishable` 并包含 `dirty_source_tree`。
@@ -553,9 +555,22 @@ cargo test --package net
 cargo test --package runtime-baseline
 cargo test --workspace
 bash tests/run_python_integration.sh
-python3 tools/runtime-baseline/run_baseline.py \
-  --smoke \
-  --server-binary target/release/kiwi-runtime-baseline
+MEMTIER_PREFIX="${MEMTIER_PREFIX:?set MEMTIER_PREFIX to the memtier install prefix}"
+TMPDIR="${TMPDIR:-${RUNNER_TEMP:-/tmp}}"
+RESULTS_ROOT="$TMPDIR/runtime-baseline-results"
+python3 tools/runtime-baseline/run_baseline.py run \
+  --suite smoke \
+  --cases tools/runtime-baseline/cases/cases.yaml \
+  --server-binary target/release/kiwi-runtime-baseline \
+  --memtier-binary "$MEMTIER_PREFIX/bin/memtier_benchmark" \
+  --memtier-provenance "$MEMTIER_PREFIX/memtier-provenance.json" \
+  --results-root "$RESULTS_ROOT" \
+  --expected-git-sha "$(git rev-parse HEAD)"
+python3 tools/runtime-baseline/run_baseline.py verify \
+  --suite smoke \
+  --cases tools/runtime-baseline/cases/cases.yaml \
+  --results-root "$RESULTS_ROOT" \
+  --expected-git-sha "$(git rev-parse HEAD)"
 git diff --check
 ```
 

--- a/docs/superpowers/specs/2026-07-24-storage-runtime-baseline-design.md
+++ b/docs/superpowers/specs/2026-07-24-storage-runtime-baseline-design.md
@@ -148,8 +148,10 @@ harness 已运行。
 
 当前 StorageServer 的 `with_config`、`with_pause_controller` 和 `with_metrics` 不能同时组合
 自定义 config、共享 access gate 和 observer；RuntimeManager 又在内部创建 MessageChannel
-和 StorageClient。第一阶段允许增加最小的组合构造入口，把同一个可选
-`Arc<BaselineMetrics>` 注入完整请求链：
+和 StorageClient。第一阶段允许增加最小的组合构造入口，把同一个可选 observer contract
+注入完整请求链。`runtime` crate 只定义该 contract 和随请求传递的 token；具体
+`BaselineMetrics` 由工具 crate 拥有并实现 contract，避免形成 `runtime -> tools/runtime-baseline`
+依赖环：
 
 - RuntimeManager/MessageChannel：logical request 开始、physical attempt 创建、send accepted、
   send failed 和 channel queued；
@@ -160,8 +162,15 @@ harness 已运行。
 
 logical request id 与每次 retry 的 physical attempt id 分离；attempt id 从 enqueue 到 execution
 terminal 保持不变。现有生产构造路径统一传入 `None`，benchmark observer、原子更新和控制
-协议通过 `runtime-baseline` feature 编译，普通生产 `kiwi` 不包含这些 hooks。组合 API 不改变
-worker/batching 调度。
+协议通过 `runtime-baseline` feature 编译，普通生产 `kiwi` 不包含这些 hooks。根 workspace 的
+`default-members` 精确保留 12 个生产 crate 并排除工具 crate，使普通 root build 不与工具 target
+处于同一 Cargo invocation，隔离 feature unification。组合 API 不改变 worker/batching 调度。
+构建身份中的 `source_dirty` 是受限的可编译输入状态：根 `src/`、`.cargo/`、根
+`Cargo.toml`/`Cargo.lock`/`rust-toolchain.toml`，以及工具 crate 的 manifest、build script、
+`src/` 和 `tests/`。build script 以同一集合执行有 pathspec 的 `git status --porcelain` 并注册
+`rerun-if-changed`；`.git`、Cargo target 和 benchmark results 都不属于该集合，避免构建产物或
+结果归档造成自触发重编译。若这个受限 source 集合有未暂存或未跟踪修改，startup/outcome 必须
+标为 `non_publishable` 并包含 `dirty_source_tree`。
 
 target 接受明确参数：
 
@@ -266,8 +275,9 @@ Python 只负责编排，不生成主要负载。控制器使用标准库完成�
 不直接启用现有 `StorageMetricsTracker` 的每请求异步 Mutex 路径。其共享锁和样本
 `Vec::remove(0)` 会改变被测热路径，不能作为当前 runtime 基线的既定实现。
 
-工具 crate 使用独立的 `BaselineMetrics`。热路径只执行原子 current/max/counter 更新和
-单调时间戳采样；需要分位数的阶段延迟通过有界 non-blocking sample channel 交给单独
+工具 crate 使用独立的 `BaselineMetrics`，并通过 `runtime` crate 定义的 observer contract
+接收事件；`runtime` 不拥有或依赖这个具体指标实现。热路径只执行原子 current/max/counter
+更新和单调时间戳采样；需要分位数的阶段延迟通过有界 non-blocking sample channel 交给单独
 collector，channel 满时只增加 `dropped_metric_samples`，不得阻塞请求。默认生产 `kiwi`
 不创建该 observer、不暴露 endpoint，也不编译 benchmark 控制通道。
 
@@ -346,8 +356,10 @@ CURRENT、MANIFEST 和 OPTIONS 文件 SHA-256。主矩阵统一测 warm workload
 - SET，connections 1，pipeline 1，batching off；
 - SET，connections 8，pipeline 8，batching on。
 
-smoke value 固定 64 B，每 case 预热 0.5 秒、测量 2 秒、总超时 15 秒；整个 smoke job
-总超时 5 分钟。它只验证真实执行和 fail-closed，不用于性能比较。
+smoke value 固定 64 B。memtier 2.5.1 的 `--test-time` 只接受整数秒，不能表达 0.5 秒；因此每
+case 预热 1 秒、测量 2 秒、总超时 15 秒。controller 的 4-case smoke step 总超时 5 分钟；整个
+GitHub job 总超时为 45 分钟，以覆盖冷 runner 的 release RocksDB 编译。它只验证真实执行和
+fail-closed，不用于性能比较。
 
 第二阶段使用版本化 `cases.yaml` 作为唯一可执行 case 清单。下表是可选维度，不做全
 笛卡尔积。manifest 分为以下组，合计不得超过 60 个 case variant：

--- a/docs/superpowers/specs/2026-07-24-storage-runtime-baseline-design.md
+++ b/docs/superpowers/specs/2026-07-24-storage-runtime-baseline-design.md
@@ -80,11 +80,30 @@ workflow 已运行真实负载。当前 `.github/workflows/ci.yml` 调用
 pause、慢 storage 和 pending shutdown 场景。不采用完全自研高性能客户端，因为开发
 成本高，且客户端实现本身会成为新的性能变量。
 
-## 交付分段
+## 交付拓扑
 
-#350 通过两个小 PR 完成，避免把工具、观测接线和大量结果混在一个 PR 中。
+#350 通过三个有序 PR 完成，避免把基础设施、真实接线与 smoke、完整性能结果混在一个
+PR 中：
 
-### 第一阶段：基线 harness 与 smoke
+```text
+Foundation PR（Tasks 1-5，当前 PR #378）
+  -> Wiring and Smoke PR（Tasks 6-12，完成原第一阶段）
+  -> Baseline Results PR（原第二阶段）
+```
+
+### Foundation PR：Tasks 1-5（当前 PR #378）
+
+交付 workspace/tool binary 骨架、`StorageServer` 组合入口、`NetworkServer` 可等待生命周期、
+request sender 显式关闭点，以及 feature-gated observer contract、请求身份和状态 token。
+
+当前 binary 必须保持 fail-closed：只解析参数后以非零状态返回
+`harness not initialized`。它尚未接入真实 runtime、控制协议或 smoke，不能被描述为可运行
+的 baseline harness。
+
+PR #378 的 Ready/验收门禁是 Tasks 1-5 的构建、测试、feature 隔离和生产路径无影响均有
+证据；不得提前声称原第一阶段完成。PR #378 不关闭 #350。
+
+### Wiring and Smoke PR：Tasks 6-12（完成原第一阶段）
 
 建议标题：
 
@@ -101,9 +120,11 @@ test(runtime): add reproducible storage baseline harness
 - CI 继续编译所有 benchmark target，并额外运行不用于性能判定的短 smoke。
 - smoke 失败时上传 controller log、Kiwi log、环境清单和部分 JSON。
 
-第一阶段不发布“优化后更快”等性能结论，也不关闭 #350。
+该 PR 的 Ready/验收门禁包括：observer 已接入真实请求生命周期，benchmark-only server、
+控制器、4 个显式 smoke case、结果校验和 CI fail-closed 门禁均真实可运行，且生产 binary
+不暴露 benchmark 控制面。该 PR 不发布“优化后更快”等性能结论，也不关闭 #350。
 
-### 第二阶段：完整基线与阈值冻结
+### Baseline Results PR（原第二阶段）：完整基线与阈值冻结
 
 建议标题：
 
@@ -119,6 +140,10 @@ perf(runtime): publish storage execution baseline
 - 记录 storage-gate pause 与 shutdown 的请求归属和 drain 行为。
 - 在 #350 文档中冻结 #351 的量化验收阈值。
 - 给出 #351 executor 模型的选择建议，但不在该 PR 中实施。
+
+该 PR 的 Ready/验收门禁是：在固定 WSL/Linux 或固定 self-hosted 环境按版本化
+`cases.yaml` 完成全量矩阵，每个正式 case 重复 5 次并满足稳定性要求，提交可追溯原始结果，
+冻结 #351 阈值并给出 executor 选择建议。只有该 PR 验收后才关闭 #350。
 
 ## Harness 架构
 
@@ -148,7 +173,7 @@ harness 已运行。
 
 当前 StorageServer 的 `with_config`、`with_pause_controller` 和 `with_metrics` 不能同时组合
 自定义 config、共享 access gate 和 observer；RuntimeManager 又在内部创建 MessageChannel
-和 StorageClient。第一阶段允许增加最小的组合构造入口，把同一个可选 observer contract
+和 StorageClient。Foundation PR 与 Wiring and Smoke PR 允许增加最小的组合构造入口，把同一个可选 observer contract
 注入完整请求链。`runtime` crate 只定义该 contract 和随请求传递的 token；具体
 `BaselineMetrics` 由工具 crate 拥有并实现 contract，避免形成 `runtime -> tools/runtime-baseline`
 依赖环：
@@ -242,7 +267,7 @@ probe。若达到目标并发前已有 blocker completed，该 case 失败；控
 规定的更长 duration 重新执行，但不能把未形成重叠阻塞窗口的样本记为成功。
 
 `shutdown` 触发 benchmark target 中与当前 NetworkServer、StorageServer 和 RuntimeManager
-一致的 stop 路径，不预设当前实现一定 drain 或一定取消。第一阶段增加最小的 lifecycle
+一致的 stop 路径，不预设当前实现一定 drain 或一定取消。Foundation PR 增加最小的 lifecycle
 handle：停止 accept、停止从现有连接接受新命令、保留 accept/connection/StorageServer
 JoinHandle、关闭 request sender，然后观察当前 queued/batch/waiting/running 请求如何结束，
 最后关闭 runtime。该 handle 复用真正的 NetworkServer，不另写简化 TCP server。
@@ -349,7 +374,7 @@ CURRENT、MANIFEST 和 OPTIONS 文件 SHA-256。主矩阵统一测 warm workload
 
 ## 测量矩阵
 
-第一阶段 smoke 固定为 4 个显式 case，不做组合展开：
+Wiring and Smoke PR 的 smoke 固定为 4 个显式 case，不做组合展开：
 
 - GET，connections 1，pipeline 1，batching off；
 - GET，connections 8，pipeline 8，batching on；
@@ -361,7 +386,7 @@ case 预热 1 秒、测量 2 秒、总超时 15 秒。controller 的 4-case smok
 GitHub job 总超时为 45 分钟，以覆盖冷 runner 的 release RocksDB 编译。它只验证真实执行和
 fail-closed，不用于性能比较。
 
-第二阶段使用版本化 `cases.yaml` 作为唯一可执行 case 清单。下表是可选维度，不做全
+Baseline Results PR 使用版本化 `cases.yaml` 作为唯一可执行 case 清单。下表是可选维度，不做全
 笛卡尔积。manifest 分为以下组，合计不得超过 60 个 case variant：
 
 1. 基础吞吐：在 1 KiB value 下扫描 3 种 operation、3 种 connections、3 种 pipeline，
@@ -465,7 +490,7 @@ required 的 check。CI 只验证：
 避免把 target 编译成功表述为性能验证成功。
 
 workflow 只能创建独立 check，是否 required 由 GitHub ruleset/branch protection 控制。
-第一阶段收尾必须实时核验 ruleset；若执行账号无权修改，应把“将 Runtime Baseline Smoke
+Wiring and Smoke PR 收尾必须实时核验 ruleset；若执行账号无权修改，应把“将 Runtime Baseline Smoke
 设为 required”记录为明确的仓库配置待办，不能仅凭 job 存在声称 required 门禁已生效。
 
 ## 错误处理
@@ -518,7 +543,7 @@ workflow 只能创建独立 check，是否 required 由 GitHub ruleset/branch pr
 
 ## 验证命令
 
-第一阶段实现后至少执行：
+Wiring and Smoke PR 达到 Ready 前至少执行：
 
 ```bash
 cargo fmt --all -- --check
@@ -538,7 +563,7 @@ git diff --check
 
 ## #351 阈值冻结规则
 
-第二阶段不预先拍脑袋指定 executor 参数，但必须从稳定 baseline 产生以下阈值：
+Baseline Results PR 不预先拍脑袋指定 executor 参数，但必须从稳定 baseline 产生以下阈值：
 
 - 正常负载吞吐允许回退比例；
 - P99 与 max latency 允许变化；

--- a/src/common/runtime/Cargo.toml
+++ b/src/common/runtime/Cargo.toml
@@ -8,6 +8,10 @@ edition.workspace = true
 name = "runtime"
 path = "lib.rs"
 
+[features]
+default = []
+runtime-baseline = []
+
 [dependencies]
 tokio = { workspace = true }
 log = { workspace = true }

--- a/src/common/runtime/baseline.rs
+++ b/src/common/runtime/baseline.rs
@@ -324,25 +324,36 @@ impl BaselineAttempt {
         AttemptState::from_u8(self.inner.state.load(Ordering::Acquire))
     }
 
-    /// Prevent an attempt that was never accepted by the request channel from
-    /// producing an accepted terminal event when its final token is dropped.
+    /// Irrevocably reject a physical attempt before the request channel accepts it.
     ///
-    /// Returns `true` while the attempt is still pre-accept, including repeated
-    /// calls, and `false` once the attempt has reached `ChannelQueued`.
-    pub fn disarm_pre_accept(&self) -> bool {
+    /// Returns `Ok(true)` while the attempt is still pre-accept, including repeated
+    /// calls, and `Ok(false)` once the attempt has reached `ChannelQueued`. Observer
+    /// reentrancy and a previously poisoned observer are returned explicitly.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn disarm_pre_accept(&self) -> Result<bool, BaselineTransitionFailure> {
+        if CallbackScope::is_active() || self.inner.callback_active.load(Ordering::Acquire) {
+            return Err(BaselineTransitionFailure::ReentrantObserver);
+        }
+        if self.observer_failed() {
+            return Err(BaselineTransitionFailure::AttemptPoisoned);
+        }
+
         let _last_transition = self
             .inner
             .last_transition
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.observer_failed() {
+            return Err(BaselineTransitionFailure::AttemptPoisoned);
+        }
         if self.state() != AttemptState::Offered {
-            return false;
+            return Ok(false);
         }
 
         self.inner
             .pre_accept_disarmed
             .store(true, Ordering::Release);
-        true
+        Ok(true)
     }
 
     pub fn transition(&self, next: AttemptState) -> Result<(), BaselineTransitionError> {
@@ -695,6 +706,41 @@ mod tests {
     struct CrossAttemptObserver {
         target: Mutex<Option<BaselineAttempt>>,
         result: Mutex<Option<Result<(), BaselineTransitionError>>>,
+    }
+
+    #[derive(Default)]
+    struct CrossAttemptDisarmObserver {
+        target: Mutex<Option<BaselineAttempt>>,
+        result: Mutex<Option<Result<bool, BaselineTransitionFailure>>>,
+    }
+
+    impl BaselineObserver for CrossAttemptDisarmObserver {
+        fn on_event(&self, event: BaselineEvent) {
+            if !matches!(
+                event,
+                BaselineEvent::StateTransition {
+                    next: AttemptState::ChannelQueued,
+                    ..
+                }
+            ) {
+                return;
+            }
+            let Some(target) = self
+                .target
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .take()
+            else {
+                return;
+            };
+            let result = target.disarm_pre_accept();
+            *self
+                .result
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(result);
+        }
+
+        fn before_execute(&self, _trace: &BaselineTrace) {}
     }
 
     impl BaselineObserver for CrossAttemptObserver {
@@ -1207,6 +1253,59 @@ mod tests {
     }
 
     #[test]
+    fn observer_cross_attempt_disarm_is_rejected_without_mutation() {
+        let target_observer = Arc::new(RecordingObserver::default());
+        let target_handle = BaselineObserverHandle::new(target_observer);
+        let target = BaselineAttempt::new(LogicalRequestId::new(), 0, target_handle.clone());
+
+        let source_observer = Arc::new(CrossAttemptDisarmObserver::default());
+        *source_observer
+            .target
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(target.clone());
+        let source = BaselineAttempt::new(
+            LogicalRequestId::new(),
+            0,
+            BaselineObserverHandle::new(source_observer.clone()),
+        );
+
+        source.transition(AttemptState::ChannelQueued).unwrap();
+
+        let error = source_observer
+            .result
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+            .expect("observer must record the cross-attempt disarm result")
+            .expect_err("observer callback must not disarm another attempt");
+        assert_eq!(error, BaselineTransitionFailure::ReentrantObserver);
+        assert_eq!(target.state(), AttemptState::Offered);
+        assert!(!target_handle.failed());
+        target.transition(AttemptState::ChannelQueued).unwrap();
+        target
+            .transition(AttemptState::ShutdownRejectedAfterAccept)
+            .unwrap();
+        source
+            .transition(AttemptState::ShutdownRejectedAfterAccept)
+            .unwrap();
+    }
+
+    #[test]
+    fn poisoned_observer_rejects_pre_accept_disarm() {
+        let observer = BaselineObserverHandle::new(Arc::new(PanicBeforeExecuteObserver));
+        let attempt = BaselineAttempt::new(LogicalRequestId::new(), 0, observer.clone());
+        attempt.before_execute();
+
+        let error = attempt
+            .disarm_pre_accept()
+            .expect_err("poisoned observer must reject pre-accept disarm");
+
+        assert_eq!(error, BaselineTransitionFailure::AttemptPoisoned);
+        assert!(observer.failed());
+        assert_eq!(attempt.state(), AttemptState::Offered);
+    }
+
+    #[test]
     fn before_execute_panic_is_contained_and_poison_is_visible() {
         let observer = BaselineObserverHandle::new(Arc::new(PanicBeforeExecuteObserver));
         let attempt = BaselineAttempt::new(LogicalRequestId::new(), 0, observer.clone());
@@ -1388,8 +1487,8 @@ mod tests {
         let observer = Arc::new(RecordingObserver::default());
         let attempt = attempt(observer.clone());
 
-        assert!(attempt.disarm_pre_accept());
-        assert!(attempt.disarm_pre_accept());
+        assert!(attempt.disarm_pre_accept().unwrap());
+        assert!(attempt.disarm_pre_accept().unwrap());
         drop(attempt);
 
         assert!(observer.events().is_empty());
@@ -1399,7 +1498,7 @@ mod tests {
     fn disarmed_pre_accept_attempt_cannot_later_be_accepted() {
         let observer = Arc::new(RecordingObserver::default());
         let attempt = attempt(observer.clone());
-        assert!(attempt.disarm_pre_accept());
+        assert!(attempt.disarm_pre_accept().unwrap());
 
         let error = attempt.transition(AttemptState::ChannelQueued).unwrap_err();
 
@@ -1424,7 +1523,7 @@ mod tests {
         let attempt = attempt(observer.clone());
         attempt.transition(AttemptState::ChannelQueued).unwrap();
 
-        assert!(!attempt.disarm_pre_accept());
+        assert!(!attempt.disarm_pre_accept().unwrap());
         drop(attempt);
 
         assert_eq!(
@@ -1466,10 +1565,10 @@ mod tests {
         let disarmed = disarm.join().expect("disarm thread must not panic");
         let accepted = accept.join().expect("accept thread must not panic");
         match (disarmed, accepted) {
-            (true, Err(error)) => {
+            (Ok(true), Err(error)) => {
                 assert_eq!(error.reason(), BaselineTransitionFailure::InvalidTransition);
             }
-            (false, Ok(())) => {}
+            (Ok(false), Ok(())) => {}
             outcome => panic!("race must linearize to disarmed or accepted: {outcome:?}"),
         }
         drop(attempt);
@@ -1501,7 +1600,10 @@ mod tests {
             })
             .count();
         assert_eq!(accepted_count, abandoned_count);
-        assert_eq!(accepted_count, usize::from(!disarmed));
+        assert_eq!(
+            accepted_count,
+            usize::from(!disarmed.expect("disarm race must not fail"))
+        );
     }
 
     #[test]

--- a/src/common/runtime/baseline.rs
+++ b/src/common/runtime/baseline.rs
@@ -17,8 +17,10 @@
 
 //! Feature-gated request lifecycle contract for the storage runtime baseline harness.
 
+use std::cell::Cell;
 use std::fmt;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -154,17 +156,59 @@ pub enum BaselineEvent {
 }
 
 /// Consumer of baseline lifecycle events.
+///
+/// State callbacks for one attempt are delivered in transition order. Orthogonal callbacks (for
+/// example, execution hooks, timeouts, and response outcomes) may run concurrently with state
+/// callbacks and with callbacks from other attempts. Implementations must therefore be
+/// concurrency-safe and must not call [`BaselineAttempt`] APIs from inside a callback. A callback
+/// panic poisons the shared [`BaselineObserverHandle`].
 pub trait BaselineObserver: Send + Sync + 'static {
     fn on_event(&self, event: BaselineEvent);
     fn before_execute(&self, trace: &BaselineTrace);
 }
 
-/// Error returned when a lifecycle transition violates the frozen state graph.
+/// Runtime-owned observer state shared by every attempt using one observer.
+///
+/// Related attempts must reuse the same handle so that a callback panic poisons the observer for
+/// the whole related request lifecycle rather than only the attempt that observed the panic.
+pub struct BaselineObserverHandle {
+    observer: Arc<dyn BaselineObserver>,
+    failed: AtomicBool,
+}
+
+impl BaselineObserverHandle {
+    pub fn new(observer: Arc<dyn BaselineObserver>) -> Arc<Self> {
+        Arc::new(Self {
+            observer,
+            failed: AtomicBool::new(false),
+        })
+    }
+
+    pub fn failed(&self) -> bool {
+        self.failed.load(Ordering::Acquire)
+    }
+
+    fn mark_failed(&self) {
+        self.failed.store(true, Ordering::Release);
+    }
+}
+
+/// Reason a lifecycle transition could not complete observably.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BaselineTransitionFailure {
+    InvalidTransition,
+    ObserverPanicked,
+    AttemptPoisoned,
+    ReentrantObserver,
+}
+
+/// Error returned when a lifecycle transition cannot complete observably.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
-#[error("invalid baseline attempt transition from {previous:?} to {attempted:?}")]
+#[error("baseline attempt transition from {previous:?} to {attempted:?} failed: {reason:?}")]
 pub struct BaselineTransitionError {
     previous: AttemptState,
     attempted: AttemptState,
+    reason: BaselineTransitionFailure,
 }
 
 impl BaselineTransitionError {
@@ -175,18 +219,73 @@ impl BaselineTransitionError {
     pub fn attempted(self) -> AttemptState {
         self.attempted
     }
+
+    pub fn reason(self) -> BaselineTransitionFailure {
+        self.reason
+    }
+}
+
+thread_local! {
+    static CALLBACK_ACTIVE_ON_THREAD: Cell<bool> = const { Cell::new(false) };
+}
+
+struct CallbackScope;
+
+impl CallbackScope {
+    fn enter() -> Option<Self> {
+        CALLBACK_ACTIVE_ON_THREAD.with(|active| {
+            if active.replace(true) {
+                None
+            } else {
+                Some(Self)
+            }
+        })
+    }
+
+    fn is_active() -> bool {
+        CALLBACK_ACTIVE_ON_THREAD.with(Cell::get)
+    }
+}
+
+impl Drop for CallbackScope {
+    fn drop(&mut self) {
+        CALLBACK_ACTIVE_ON_THREAD.with(|active| active.set(false));
+    }
+}
+
+struct CallbackActiveGuard<'a> {
+    active: &'a AtomicBool,
+}
+
+impl<'a> CallbackActiveGuard<'a> {
+    fn enter(active: &'a AtomicBool) -> Self {
+        let was_active = active.swap(true, Ordering::AcqRel);
+        debug_assert!(!was_active);
+        Self { active }
+    }
+}
+
+impl Drop for CallbackActiveGuard<'_> {
+    fn drop(&mut self) {
+        self.active.store(false, Ordering::Release);
+    }
 }
 
 struct BaselineAttemptInner {
     trace: BaselineTrace,
     state: AtomicU8,
+    pre_accept_disarmed: AtomicBool,
+    // `Arc::strong_count` is only a snapshot: concurrent final drops can both
+    // observe more than one owner. This counter elects exactly one final token.
+    token_count: AtomicUsize,
     started_at: Instant,
     last_transition: Mutex<Instant>,
-    observer: Arc<dyn BaselineObserver>,
+    dispatch: Mutex<()>,
+    callback_active: AtomicBool,
+    observer: Arc<BaselineObserverHandle>,
 }
 
 /// Cloneable RAII token for one physical storage attempt.
-#[derive(Clone)]
 pub struct BaselineAttempt {
     inner: Arc<BaselineAttemptInner>,
 }
@@ -195,7 +294,7 @@ impl BaselineAttempt {
     pub fn new(
         logical_id: LogicalRequestId,
         attempt_index: u32,
-        observer: Arc<dyn BaselineObserver>,
+        observer: Arc<BaselineObserverHandle>,
     ) -> Self {
         let now = Instant::now();
         Self {
@@ -206,8 +305,12 @@ impl BaselineAttempt {
                     attempt_index,
                 },
                 state: AtomicU8::new(AttemptState::Offered as u8),
+                pre_accept_disarmed: AtomicBool::new(false),
+                token_count: AtomicUsize::new(1),
                 started_at: now,
                 last_transition: Mutex::new(now),
+                dispatch: Mutex::new(()),
+                callback_active: AtomicBool::new(false),
                 observer,
             }),
         }
@@ -219,6 +322,27 @@ impl BaselineAttempt {
 
     pub fn state(&self) -> AttemptState {
         AttemptState::from_u8(self.inner.state.load(Ordering::Acquire))
+    }
+
+    /// Prevent an attempt that was never accepted by the request channel from
+    /// producing an accepted terminal event when its final token is dropped.
+    ///
+    /// Returns `true` while the attempt is still pre-accept, including repeated
+    /// calls, and `false` once the attempt has reached `ChannelQueued`.
+    pub fn disarm_pre_accept(&self) -> bool {
+        let _last_transition = self
+            .inner
+            .last_transition
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.state() != AttemptState::Offered {
+            return false;
+        }
+
+        self.inner
+            .pre_accept_disarmed
+            .store(true, Ordering::Release);
+        true
     }
 
     pub fn transition(&self, next: AttemptState) -> Result<(), BaselineTransitionError> {
@@ -233,32 +357,32 @@ impl BaselineAttempt {
     }
 
     pub fn before_execute(&self) {
-        self.inner.observer.before_execute(&self.inner.trace);
+        let trace = self.inner.trace;
+        let _ = self.invoke_orthogonal_observer(|observer| observer.before_execute(&trace));
     }
 
     pub fn record_client_timeout(&self) {
-        self.inner.observer.on_event(BaselineEvent::ClientTimeout {
+        let event = BaselineEvent::ClientTimeout {
             trace: self.inner.trace,
             elapsed: self.inner.started_at.elapsed(),
-        });
+        };
+        let _ = self.invoke_orthogonal_observer(move |observer| observer.on_event(event));
     }
 
     pub fn record_response_dropped(&self) {
-        self.inner
-            .observer
-            .on_event(BaselineEvent::ResponseDropped {
-                trace: self.inner.trace,
-                elapsed: self.inner.started_at.elapsed(),
-            });
+        let event = BaselineEvent::ResponseDropped {
+            trace: self.inner.trace,
+            elapsed: self.inner.started_at.elapsed(),
+        };
+        let _ = self.invoke_orthogonal_observer(move |observer| observer.on_event(event));
     }
 
     pub fn record_response_delivered(&self) {
-        self.inner
-            .observer
-            .on_event(BaselineEvent::ResponseDelivered {
-                trace: self.inner.trace,
-                elapsed: self.inner.started_at.elapsed(),
-            });
+        let event = BaselineEvent::ResponseDelivered {
+            trace: self.inner.trace,
+            elapsed: self.inner.started_at.elapsed(),
+        };
+        let _ = self.invoke_orthogonal_observer(move |observer| observer.on_event(event));
     }
 
     fn transition_inner(
@@ -266,53 +390,144 @@ impl BaselineAttempt {
         next: AttemptState,
         outcome: Option<ExecutionOutcome>,
     ) -> Result<(), BaselineTransitionError> {
-        let (previous, elapsed) = {
+        if CallbackScope::is_active() || self.inner.callback_active.load(Ordering::Acquire) {
+            return Err(self.transition_error(next, BaselineTransitionFailure::ReentrantObserver));
+        }
+        if self.observer_failed() {
+            return Err(self.transition_error(next, BaselineTransitionFailure::AttemptPoisoned));
+        }
+
+        let _dispatch = self
+            .inner
+            .dispatch
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.observer_failed() {
+            return Err(self.transition_error(next, BaselineTransitionFailure::AttemptPoisoned));
+        }
+
+        let (previous, event, valid) = {
             let mut last_transition = self
                 .inner
                 .last_transition
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             let previous = self.state();
-            if !previous.permits(next)
+            if (previous == AttemptState::Offered
+                && self.inner.pre_accept_disarmed.load(Ordering::Acquire))
+                || !previous.permits(next)
                 || (next == AttemptState::ExecutionFinished && outcome.is_none())
                 || (next != AttemptState::ExecutionFinished && outcome.is_some())
             {
-                drop(last_transition);
-                self.record_invariant_violation(previous, next);
-                return Err(BaselineTransitionError {
+                let event = BaselineEvent::InvariantViolation {
+                    trace: self.inner.trace,
                     previous,
                     attempted: next,
-                });
+                    elapsed: self.inner.started_at.elapsed(),
+                };
+                (previous, event, false)
+            } else {
+                self.inner.state.store(next as u8, Ordering::Release);
+                let now = Instant::now();
+                let elapsed = now.saturating_duration_since(*last_transition);
+                *last_transition = now;
+                let event = BaselineEvent::StateTransition {
+                    trace: self.inner.trace,
+                    previous,
+                    next,
+                    elapsed,
+                    outcome,
+                };
+                (previous, event, true)
             }
-
-            self.inner.state.store(next as u8, Ordering::Release);
-            let now = Instant::now();
-            let elapsed = now.saturating_duration_since(*last_transition);
-            *last_transition = now;
-            (previous, elapsed)
         };
 
-        self.inner
-            .observer
-            .on_event(BaselineEvent::StateTransition {
-                trace: self.inner.trace,
+        let callback_result = self.invoke_observer(move |observer| observer.on_event(event));
+        match callback_result {
+            Ok(()) if valid => Ok(()),
+            Ok(()) => Err(BaselineTransitionError {
                 previous,
-                next,
-                elapsed,
-                outcome,
-            });
+                attempted: next,
+                reason: BaselineTransitionFailure::InvalidTransition,
+            }),
+            Err(reason) => Err(BaselineTransitionError {
+                previous,
+                attempted: next,
+                reason,
+            }),
+        }
+    }
+
+    fn transition_error(
+        &self,
+        attempted: AttemptState,
+        reason: BaselineTransitionFailure,
+    ) -> BaselineTransitionError {
+        BaselineTransitionError {
+            previous: self.state(),
+            attempted,
+            reason,
+        }
+    }
+
+    fn observer_failed(&self) -> bool {
+        self.inner.observer.failed()
+    }
+
+    fn invoke_orthogonal_observer<F>(&self, callback: F) -> Result<(), BaselineTransitionFailure>
+    where
+        F: FnOnce(&dyn BaselineObserver),
+    {
+        if CallbackScope::is_active() {
+            self.inner.observer.mark_failed();
+            return Err(BaselineTransitionFailure::ReentrantObserver);
+        }
+        if self.observer_failed() {
+            return Err(BaselineTransitionFailure::AttemptPoisoned);
+        }
+        let Some(_scope) = CallbackScope::enter() else {
+            self.inner.observer.mark_failed();
+            return Err(BaselineTransitionFailure::ReentrantObserver);
+        };
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            callback(self.inner.observer.observer.as_ref())
+        }));
+        if result.is_err() {
+            self.inner.observer.mark_failed();
+            return Err(BaselineTransitionFailure::ObserverPanicked);
+        }
         Ok(())
     }
 
-    fn record_invariant_violation(&self, previous: AttemptState, attempted: AttemptState) {
-        self.inner
-            .observer
-            .on_event(BaselineEvent::InvariantViolation {
-                trace: self.inner.trace,
-                previous,
-                attempted,
-                elapsed: self.inner.started_at.elapsed(),
-            });
+    fn invoke_observer<F>(&self, callback: F) -> Result<(), BaselineTransitionFailure>
+    where
+        F: FnOnce(&dyn BaselineObserver),
+    {
+        if self.observer_failed() {
+            return Err(BaselineTransitionFailure::AttemptPoisoned);
+        }
+        let Some(_scope) = CallbackScope::enter() else {
+            return Err(BaselineTransitionFailure::ReentrantObserver);
+        };
+        let _active = CallbackActiveGuard::enter(&self.inner.callback_active);
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            callback(self.inner.observer.observer.as_ref())
+        }));
+        if result.is_err() {
+            self.inner.observer.mark_failed();
+            return Err(BaselineTransitionFailure::ObserverPanicked);
+        }
+        Ok(())
+    }
+}
+
+impl Clone for BaselineAttempt {
+    fn clone(&self) -> Self {
+        let inner = Arc::clone(&self.inner);
+        self.inner.token_count.fetch_add(1, Ordering::Relaxed);
+        Self { inner }
     }
 }
 
@@ -328,10 +543,15 @@ impl fmt::Debug for BaselineAttempt {
 
 impl Drop for BaselineAttempt {
     fn drop(&mut self) {
-        if Arc::strong_count(&self.inner) != 1 {
+        if self.inner.token_count.fetch_sub(1, Ordering::AcqRel) != 1 {
             return;
         }
 
+        let _dispatch = self
+            .inner
+            .dispatch
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let transition = {
             let mut last_transition = self
                 .inner
@@ -339,7 +559,7 @@ impl Drop for BaselineAttempt {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             let previous = self.state();
-            if previous.is_terminal() {
+            if previous == AttemptState::Offered || previous.is_terminal() {
                 None
             } else {
                 self.inner
@@ -353,15 +573,19 @@ impl Drop for BaselineAttempt {
         };
 
         if let Some((previous, elapsed)) = transition {
-            self.inner
-                .observer
-                .on_event(BaselineEvent::StateTransition {
-                    trace: self.inner.trace,
-                    previous,
-                    next: AttemptState::Abandoned,
-                    elapsed,
-                    outcome: None,
-                });
+            let event = BaselineEvent::StateTransition {
+                trace: self.inner.trace,
+                previous,
+                next: AttemptState::Abandoned,
+                elapsed,
+                outcome: None,
+            };
+            if matches!(
+                self.invoke_observer(move |observer| observer.on_event(event)),
+                Err(BaselineTransitionFailure::ReentrantObserver)
+            ) {
+                self.inner.observer.mark_failed();
+            }
         }
     }
 }
@@ -369,7 +593,11 @@ impl Drop for BaselineAttempt {
 #[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::process::Command;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Barrier, Condvar, Mutex, mpsc};
+    use std::thread;
 
     use super::*;
 
@@ -398,8 +626,346 @@ mod tests {
         fn before_execute(&self, _trace: &BaselineTrace) {}
     }
 
+    struct BlockingOrderObserver {
+        events: Mutex<Vec<AttemptState>>,
+        first_entered: mpsc::Sender<()>,
+        second_entered: mpsc::Sender<()>,
+        release_first: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl BaselineObserver for BlockingOrderObserver {
+        fn on_event(&self, event: BaselineEvent) {
+            let BaselineEvent::StateTransition { next, .. } = event else {
+                return;
+            };
+
+            if next == AttemptState::ChannelQueued {
+                self.first_entered
+                    .send(())
+                    .expect("first callback receiver must remain open");
+                let (released, release_ready) = &*self.release_first;
+                let mut released = released
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                while !*released {
+                    released = release_ready
+                        .wait(released)
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                }
+            }
+
+            self.events
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(next);
+            if next == AttemptState::WaitingGate {
+                self.second_entered
+                    .send(())
+                    .expect("second callback receiver must remain open");
+            }
+        }
+
+        fn before_execute(&self, _trace: &BaselineTrace) {}
+    }
+
+    struct PanicOnEventObserver;
+
+    impl BaselineObserver for PanicOnEventObserver {
+        fn on_event(&self, _event: BaselineEvent) {
+            panic!("observer event panic");
+        }
+
+        fn before_execute(&self, _trace: &BaselineTrace) {}
+    }
+
+    #[derive(Default)]
+    struct ReentrantObserver {
+        attempt: Mutex<Option<BaselineAttempt>>,
+        result: Mutex<Option<Result<(), BaselineTransitionError>>>,
+    }
+
+    #[derive(Default)]
+    struct SpawnThreadReentrantObserver {
+        attempt: Mutex<Option<BaselineAttempt>>,
+        child: Mutex<Option<thread::JoinHandle<Result<(), BaselineTransitionError>>>>,
+        timed_out: AtomicBool,
+    }
+
+    #[derive(Default)]
+    struct CrossAttemptObserver {
+        target: Mutex<Option<BaselineAttempt>>,
+        result: Mutex<Option<Result<(), BaselineTransitionError>>>,
+    }
+
+    impl BaselineObserver for CrossAttemptObserver {
+        fn on_event(&self, event: BaselineEvent) {
+            if !matches!(
+                event,
+                BaselineEvent::StateTransition {
+                    next: AttemptState::ChannelQueued,
+                    ..
+                }
+            ) {
+                return;
+            }
+            let Some(target) = self
+                .target
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .take()
+            else {
+                return;
+            };
+            let result = target.transition(AttemptState::ChannelQueued);
+            *self
+                .result
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(result);
+        }
+
+        fn before_execute(&self, _trace: &BaselineTrace) {}
+    }
+
+    impl BaselineObserver for SpawnThreadReentrantObserver {
+        fn on_event(&self, event: BaselineEvent) {
+            if !matches!(
+                event,
+                BaselineEvent::StateTransition {
+                    next: AttemptState::ChannelQueued,
+                    ..
+                }
+            ) {
+                return;
+            }
+            let attempt = self
+                .attempt
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .take()
+                .expect("spawn-thread reentrant attempt must be installed");
+            let (result_sender, result_receiver) = mpsc::channel();
+            let child = thread::spawn(move || {
+                let result = attempt.transition(AttemptState::WaitingGate);
+                let _ = result_sender.send(result);
+                result
+            });
+            *self
+                .child
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(child);
+            if result_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .is_err()
+            {
+                self.timed_out.store(true, Ordering::Release);
+            }
+        }
+
+        fn before_execute(&self, _trace: &BaselineTrace) {}
+    }
+
+    impl BaselineObserver for ReentrantObserver {
+        fn on_event(&self, event: BaselineEvent) {
+            if !matches!(
+                event,
+                BaselineEvent::StateTransition {
+                    next: AttemptState::ChannelQueued,
+                    ..
+                }
+            ) {
+                return;
+            }
+            let attempt = self
+                .attempt
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .take()
+                .expect("reentrant test attempt must be installed");
+            let result = attempt.transition(AttemptState::WaitingGate);
+            *self
+                .result
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(result);
+        }
+
+        fn before_execute(&self, _trace: &BaselineTrace) {}
+    }
+
+    struct PanicBeforeExecuteObserver;
+
+    impl BaselineObserver for PanicBeforeExecuteObserver {
+        fn on_event(&self, _event: BaselineEvent) {}
+
+        fn before_execute(&self, _trace: &BaselineTrace) {
+            panic!("observer before_execute panic");
+        }
+    }
+
+    struct PanicOnAbandonedObserver;
+
+    impl BaselineObserver for PanicOnAbandonedObserver {
+        fn on_event(&self, event: BaselineEvent) {
+            if matches!(
+                event,
+                BaselineEvent::StateTransition {
+                    next: AttemptState::Abandoned,
+                    ..
+                }
+            ) {
+                panic!("observer abandoned panic");
+            }
+        }
+
+        fn before_execute(&self, _trace: &BaselineTrace) {}
+    }
+
+    #[derive(Clone, Copy)]
+    enum BlockedCallback {
+        Timeout,
+        Running,
+    }
+
+    struct OrthogonalOverlapObserver {
+        events: Mutex<Vec<BaselineEvent>>,
+        blocked: BlockedCallback,
+        entered: mpsc::Sender<()>,
+        release: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl BaselineObserver for OrthogonalOverlapObserver {
+        fn on_event(&self, event: BaselineEvent) {
+            let should_block = matches!(
+                (&self.blocked, &event),
+                (
+                    BlockedCallback::Timeout,
+                    BaselineEvent::ClientTimeout { .. }
+                ) | (
+                    BlockedCallback::Running,
+                    BaselineEvent::StateTransition {
+                        next: AttemptState::Running,
+                        ..
+                    }
+                )
+            );
+            if should_block {
+                self.entered
+                    .send(())
+                    .expect("blocked callback receiver must remain open");
+                let (released, release_ready) = &*self.release;
+                let mut released = released
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                while !*released {
+                    released = release_ready
+                        .wait(released)
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                }
+            }
+            self.events
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(event);
+        }
+
+        fn before_execute(&self, _trace: &BaselineTrace) {}
+    }
+
+    struct BlockingBeforeExecuteObserver {
+        entered: mpsc::Sender<()>,
+        release: Arc<(Mutex<bool>, Condvar)>,
+        timeout_seen: AtomicBool,
+    }
+
+    impl BaselineObserver for BlockingBeforeExecuteObserver {
+        fn on_event(&self, event: BaselineEvent) {
+            if matches!(event, BaselineEvent::ClientTimeout { .. }) {
+                self.timeout_seen.store(true, Ordering::Release);
+            }
+        }
+
+        fn before_execute(&self, _trace: &BaselineTrace) {
+            self.entered
+                .send(())
+                .expect("before_execute receiver must remain open");
+            let (released, release_ready) = &*self.release;
+            let mut released = released
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            while !*released {
+                released = release_ready
+                    .wait(released)
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct ReentrantVoidObserver {
+        attempt: Mutex<Option<BaselineAttempt>>,
+    }
+
+    impl BaselineObserver for ReentrantVoidObserver {
+        fn on_event(&self, event: BaselineEvent) {
+            if matches!(
+                event,
+                BaselineEvent::StateTransition {
+                    next: AttemptState::ChannelQueued,
+                    ..
+                }
+            ) {
+                self.attempt
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .take()
+                    .expect("reentrant void attempt must be installed")
+                    .record_client_timeout();
+            }
+        }
+
+        fn before_execute(&self, _trace: &BaselineTrace) {}
+    }
+
+    #[derive(Default)]
+    struct DropAcceptedAttemptObserver {
+        target: Mutex<Option<BaselineAttempt>>,
+    }
+
+    impl BaselineObserver for DropAcceptedAttemptObserver {
+        fn on_event(&self, event: BaselineEvent) {
+            if matches!(
+                event,
+                BaselineEvent::StateTransition {
+                    next: AttemptState::ChannelQueued,
+                    ..
+                }
+            ) {
+                drop(
+                    self.target
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .take()
+                        .expect("accepted drop target must be installed"),
+                );
+            }
+        }
+
+        fn before_execute(&self, _trace: &BaselineTrace) {}
+    }
+
+    fn release_blocked_callback(release: &Arc<(Mutex<bool>, Condvar)>) {
+        let (released, release_ready) = &**release;
+        *released
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = true;
+        release_ready.notify_all();
+    }
+
     fn attempt(observer: Arc<RecordingObserver>) -> BaselineAttempt {
-        BaselineAttempt::new(LogicalRequestId::new(), 0, observer)
+        BaselineAttempt::new(
+            LogicalRequestId::new(),
+            0,
+            BaselineObserverHandle::new(observer),
+        )
     }
 
     #[test]
@@ -440,6 +1006,261 @@ mod tests {
                 (AttemptState::WaitingGate, AttemptState::Running),
                 (AttemptState::Running, AttemptState::ExecutionFinished),
             ]
+        );
+    }
+
+    #[test]
+    fn transition_during_callback_fails_fast_then_retry_preserves_order() {
+        let (first_entered_tx, first_entered_rx) = mpsc::channel();
+        let (second_entered_tx, second_entered_rx) = mpsc::channel();
+        let release_first = Arc::new((Mutex::new(false), Condvar::new()));
+        let observer = Arc::new(BlockingOrderObserver {
+            events: Mutex::new(Vec::new()),
+            first_entered: first_entered_tx,
+            second_entered: second_entered_tx,
+            release_first: release_first.clone(),
+        });
+        let attempt = BaselineAttempt::new(
+            LogicalRequestId::new(),
+            0,
+            BaselineObserverHandle::new(observer.clone()),
+        );
+        let first = attempt.clone();
+        let first_transition = thread::spawn(move || first.transition(AttemptState::ChannelQueued));
+        first_entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("first callback must enter");
+
+        let second = attempt.clone();
+        let (second_result_sender, second_result_receiver) = mpsc::channel();
+        let second_transition = thread::spawn(move || {
+            let result = second.transition(AttemptState::WaitingGate);
+            let _ = second_result_sender.send(result);
+            result
+        });
+        let second_result = second_result_receiver.recv_timeout(Duration::from_secs(1));
+
+        let (released, release_ready) = &*release_first;
+        *released
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = true;
+        release_ready.notify_all();
+
+        first_transition
+            .join()
+            .expect("first transition thread must not panic")
+            .expect("first transition must succeed");
+        let joined_second = second_transition
+            .join()
+            .expect("second transition thread must not panic");
+
+        let error = second_result
+            .expect("transition during callback must fail fast")
+            .expect_err("transition during callback must be rejected");
+        assert_eq!(error.reason(), BaselineTransitionFailure::ReentrantObserver);
+        assert_eq!(joined_second, Err(error));
+
+        attempt.transition(AttemptState::WaitingGate).unwrap();
+        second_entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("retry callback must run after the first callback completes");
+        assert_eq!(
+            observer
+                .events
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .as_slice(),
+            &[AttemptState::ChannelQueued, AttemptState::WaitingGate]
+        );
+    }
+
+    #[test]
+    fn observer_callback_panic_is_contained_and_reported() {
+        let observer = BaselineObserverHandle::new(Arc::new(PanicOnEventObserver));
+        let attempt = BaselineAttempt::new(LogicalRequestId::new(), 0, observer.clone());
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            attempt.transition(AttemptState::ChannelQueued)
+        }));
+
+        assert!(result.is_ok(), "observer panic must not escape runtime");
+        let error = result
+            .expect("observer panic must be converted into a transition error")
+            .expect_err("observer panic must fail the transition observably");
+        assert_eq!(error.reason(), BaselineTransitionFailure::ObserverPanicked);
+        assert!(observer.failed());
+
+        let poisoned = attempt
+            .transition(AttemptState::WaitingGate)
+            .expect_err("the same attempt must fail closed after observer panic");
+        assert_eq!(
+            poisoned.reason(),
+            BaselineTransitionFailure::AttemptPoisoned
+        );
+
+        let shared_observer_attempt =
+            BaselineAttempt::new(LogicalRequestId::new(), 1, observer.clone());
+        let shared_poisoned = shared_observer_attempt
+            .transition(AttemptState::ChannelQueued)
+            .expect_err("all attempts sharing the observer must fail closed");
+        assert_eq!(
+            shared_poisoned.reason(),
+            BaselineTransitionFailure::AttemptPoisoned
+        );
+    }
+
+    #[test]
+    fn observer_reentrant_transition_returns_error_without_deadlock() {
+        let observer = Arc::new(ReentrantObserver::default());
+        let observer_handle = BaselineObserverHandle::new(observer.clone());
+        let attempt = BaselineAttempt::new(LogicalRequestId::new(), 0, observer_handle.clone());
+        *observer
+            .attempt
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(attempt.clone());
+
+        attempt.transition(AttemptState::ChannelQueued).unwrap();
+
+        let error = observer
+            .result
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+            .expect("observer must record the reentrant result")
+            .expect_err("reentrant transition must be rejected");
+        assert_eq!(error.reason(), BaselineTransitionFailure::ReentrantObserver);
+        assert_eq!(attempt.state(), AttemptState::ChannelQueued);
+        assert!(!observer_handle.failed());
+        attempt
+            .transition(AttemptState::ShutdownRejectedAfterAccept)
+            .unwrap();
+    }
+
+    #[test]
+    fn observer_spawned_thread_reentrant_transition_fails_without_deadlock() {
+        let observer = Arc::new(SpawnThreadReentrantObserver::default());
+        let attempt = BaselineAttempt::new(
+            LogicalRequestId::new(),
+            0,
+            BaselineObserverHandle::new(observer.clone()),
+        );
+        *observer
+            .attempt
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(attempt.clone());
+
+        attempt.transition(AttemptState::ChannelQueued).unwrap();
+
+        let child_result = observer
+            .child
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+            .expect("observer must store the child thread")
+            .join()
+            .expect("observer child thread must not panic");
+        assert!(
+            !observer.timed_out.load(Ordering::Acquire),
+            "child transition must fail fast while its parent callback is active"
+        );
+        let error = child_result.expect_err("cross-thread reentrant transition must be rejected");
+        assert_eq!(error.reason(), BaselineTransitionFailure::ReentrantObserver);
+        assert_eq!(attempt.state(), AttemptState::ChannelQueued);
+        attempt
+            .transition(AttemptState::ShutdownRejectedAfterAccept)
+            .unwrap();
+    }
+
+    #[test]
+    fn observer_cross_attempt_transition_is_rejected_before_dispatch() {
+        let first_observer = Arc::new(CrossAttemptObserver::default());
+        let second_observer = Arc::new(CrossAttemptObserver::default());
+        let first = BaselineAttempt::new(
+            LogicalRequestId::new(),
+            0,
+            BaselineObserverHandle::new(first_observer.clone()),
+        );
+        let second = BaselineAttempt::new(
+            LogicalRequestId::new(),
+            0,
+            BaselineObserverHandle::new(second_observer),
+        );
+        *first_observer
+            .target
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(second.clone());
+
+        first.transition(AttemptState::ChannelQueued).unwrap();
+
+        let error = first_observer
+            .result
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+            .expect("cross-attempt callback must record its result")
+            .expect_err("callback must not enter another attempt dispatch");
+        assert_eq!(error.reason(), BaselineTransitionFailure::ReentrantObserver);
+        assert_eq!(second.state(), AttemptState::Offered);
+        first
+            .transition(AttemptState::ShutdownRejectedAfterAccept)
+            .unwrap();
+    }
+
+    #[test]
+    fn before_execute_panic_is_contained_and_poison_is_visible() {
+        let observer = BaselineObserverHandle::new(Arc::new(PanicBeforeExecuteObserver));
+        let attempt = BaselineAttempt::new(LogicalRequestId::new(), 0, observer.clone());
+
+        let result = catch_unwind(AssertUnwindSafe(|| attempt.before_execute()));
+
+        assert!(
+            result.is_ok(),
+            "before_execute panic must not escape runtime"
+        );
+        assert!(observer.failed());
+        let error = attempt
+            .transition(AttemptState::ChannelQueued)
+            .expect_err("observer poison must reject later mutation");
+        assert_eq!(error.reason(), BaselineTransitionFailure::AttemptPoisoned);
+    }
+
+    #[test]
+    fn drop_callback_panic_during_unwind_does_not_abort_process() {
+        const CHILD_ENV: &str = "KIWI_BASELINE_DROP_PANIC_CHILD";
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let observer = BaselineObserverHandle::new(Arc::new(PanicOnAbandonedObserver));
+            let unwind = catch_unwind(AssertUnwindSafe({
+                let observer = observer.clone();
+                move || {
+                    let attempt =
+                        BaselineAttempt::new(LogicalRequestId::new(), 0, observer.clone());
+                    attempt.transition(AttemptState::ChannelQueued).unwrap();
+                    panic!("outer panic");
+                }
+            }));
+            assert!(unwind.is_err(), "outer panic must remain observable");
+            assert!(
+                observer.failed(),
+                "drop callback panic must set the shared failure flag"
+            );
+            return;
+        }
+
+        let output = Command::new(std::env::current_exe().expect("test executable must exist"))
+            .arg("--exact")
+            .arg("baseline::tests::drop_callback_panic_during_unwind_does_not_abort_process")
+            .arg("--nocapture")
+            .env(CHILD_ENV, "1")
+            .output()
+            .expect("child test process must start");
+        assert!(
+            output.status.success(),
+            "child must not abort: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !String::from_utf8_lossy(&output.stderr)
+                .contains("panic in a destructor during cleanup")
         );
     }
 
@@ -518,6 +1339,172 @@ mod tests {
     }
 
     #[test]
+    fn concurrent_final_clone_drops_emit_exactly_one_abandoned_event() {
+        const TOKEN_COUNT: usize = 8;
+
+        let observer = Arc::new(RecordingObserver::default());
+        let attempt = attempt(observer.clone());
+        attempt.transition(AttemptState::ChannelQueued).unwrap();
+        let mut tokens = (1..TOKEN_COUNT)
+            .map(|_| attempt.clone())
+            .collect::<Vec<_>>();
+        tokens.push(attempt);
+        let barrier = Arc::new(Barrier::new(TOKEN_COUNT));
+
+        let drops = tokens
+            .into_iter()
+            .map(|token| {
+                let barrier = barrier.clone();
+                thread::spawn(move || {
+                    barrier.wait();
+                    drop(token);
+                })
+            })
+            .collect::<Vec<_>>();
+        for drop_thread in drops {
+            drop_thread
+                .join()
+                .expect("concurrent token drop must not panic");
+        }
+
+        assert_eq!(
+            observer
+                .events()
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    BaselineEvent::StateTransition {
+                        next: AttemptState::Abandoned,
+                        ..
+                    }
+                ))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn pre_accept_disarm_is_idempotent_and_drop_emits_no_terminal_event() {
+        let observer = Arc::new(RecordingObserver::default());
+        let attempt = attempt(observer.clone());
+
+        assert!(attempt.disarm_pre_accept());
+        assert!(attempt.disarm_pre_accept());
+        drop(attempt);
+
+        assert!(observer.events().is_empty());
+    }
+
+    #[test]
+    fn disarmed_pre_accept_attempt_cannot_later_be_accepted() {
+        let observer = Arc::new(RecordingObserver::default());
+        let attempt = attempt(observer.clone());
+        assert!(attempt.disarm_pre_accept());
+
+        let error = attempt.transition(AttemptState::ChannelQueued).unwrap_err();
+
+        assert_eq!(error.previous(), AttemptState::Offered);
+        assert_eq!(error.attempted(), AttemptState::ChannelQueued);
+        assert_eq!(attempt.state(), AttemptState::Offered);
+        drop(attempt);
+        assert!(!observer.events().iter().any(|event| matches!(
+            event,
+            BaselineEvent::StateTransition {
+                next: AttemptState::ExecutionFinished
+                    | AttemptState::ShutdownRejectedAfterAccept
+                    | AttemptState::Abandoned,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn pre_accept_disarm_cannot_mask_an_accepted_attempt() {
+        let observer = Arc::new(RecordingObserver::default());
+        let attempt = attempt(observer.clone());
+        attempt.transition(AttemptState::ChannelQueued).unwrap();
+
+        assert!(!attempt.disarm_pre_accept());
+        drop(attempt);
+
+        assert_eq!(
+            observer
+                .events()
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    BaselineEvent::StateTransition {
+                        next: AttemptState::Abandoned,
+                        ..
+                    }
+                ))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn disarm_and_accept_race_has_one_linearized_outcome() {
+        let observer = Arc::new(RecordingObserver::default());
+        let attempt = attempt(observer.clone());
+        let barrier = Arc::new(Barrier::new(3));
+
+        let disarm_attempt = attempt.clone();
+        let disarm_barrier = barrier.clone();
+        let disarm = thread::spawn(move || {
+            disarm_barrier.wait();
+            disarm_attempt.disarm_pre_accept()
+        });
+        let accept_attempt = attempt.clone();
+        let accept_barrier = barrier.clone();
+        let accept = thread::spawn(move || {
+            accept_barrier.wait();
+            accept_attempt.transition(AttemptState::ChannelQueued)
+        });
+        barrier.wait();
+
+        let disarmed = disarm.join().expect("disarm thread must not panic");
+        let accepted = accept.join().expect("accept thread must not panic");
+        match (disarmed, accepted) {
+            (true, Err(error)) => {
+                assert_eq!(error.reason(), BaselineTransitionFailure::InvalidTransition);
+            }
+            (false, Ok(())) => {}
+            outcome => panic!("race must linearize to disarmed or accepted: {outcome:?}"),
+        }
+        drop(attempt);
+
+        let events = observer.events();
+        let accepted_count = events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    BaselineEvent::StateTransition {
+                        previous: AttemptState::Offered,
+                        next: AttemptState::ChannelQueued,
+                        ..
+                    }
+                )
+            })
+            .count();
+        let abandoned_count = events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    BaselineEvent::StateTransition {
+                        next: AttemptState::Abandoned,
+                        ..
+                    }
+                )
+            })
+            .count();
+        assert_eq!(accepted_count, abandoned_count);
+        assert_eq!(accepted_count, usize::from(!disarmed));
+    }
+
+    #[test]
     fn dropping_one_clone_does_not_abandon_shared_attempt() {
         let observer = Arc::new(RecordingObserver::default());
         let attempt = attempt(observer.clone());
@@ -542,6 +1529,7 @@ mod tests {
     #[test]
     fn retry_attempts_share_logical_identity_but_not_physical_identity() {
         let observer = Arc::new(RecordingObserver::default());
+        let observer = BaselineObserverHandle::new(observer);
         let logical_id = LogicalRequestId::new();
         let first = BaselineAttempt::new(logical_id, 0, observer.clone());
         let retry = BaselineAttempt::new(logical_id, 1, observer);
@@ -593,5 +1581,248 @@ mod tests {
                 .iter()
                 .any(|event| matches!(event, BaselineEvent::ResponseDropped { .. }))
         );
+    }
+
+    #[test]
+    fn execution_can_finish_while_timeout_callback_is_active() {
+        let (entered_sender, entered_receiver) = mpsc::channel();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let observer = Arc::new(OrthogonalOverlapObserver {
+            events: Mutex::new(Vec::new()),
+            blocked: BlockedCallback::Timeout,
+            entered: entered_sender,
+            release: release.clone(),
+        });
+        let attempt = BaselineAttempt::new(
+            LogicalRequestId::new(),
+            0,
+            BaselineObserverHandle::new(observer.clone()),
+        );
+        attempt.transition(AttemptState::ChannelQueued).unwrap();
+        attempt.transition(AttemptState::WaitingGate).unwrap();
+        attempt.transition(AttemptState::Running).unwrap();
+
+        let timeout_attempt = attempt.clone();
+        let timeout_thread = thread::spawn(move || timeout_attempt.record_client_timeout());
+        entered_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("timeout callback must enter");
+
+        let (finish_started_sender, finish_started_receiver) = mpsc::channel();
+        let (finish_completion_sender, finish_completion_receiver) = mpsc::channel();
+        let finish_attempt = attempt.clone();
+        let finish_thread = thread::spawn(move || {
+            finish_started_sender
+                .send(())
+                .expect("finish start receiver must remain alive");
+            let result = finish_attempt.finish_execution(ExecutionOutcome::Success);
+            finish_completion_sender
+                .send(result)
+                .expect("finish completion receiver must remain alive");
+        });
+        finish_started_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("finish thread must start");
+        let finish_completion = finish_completion_receiver.recv_timeout(Duration::from_secs(1));
+
+        release_blocked_callback(&release);
+        timeout_thread
+            .join()
+            .expect("timeout callback thread must not panic");
+        finish_thread.join().expect("finish thread must not panic");
+
+        finish_completion
+            .expect("execution finish must complete while timeout callback is blocked")
+            .expect("execution finish must not be rejected by timeout callback overlap");
+        let events = observer
+            .events
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, BaselineEvent::ClientTimeout { .. }))
+        );
+        assert!(events.iter().any(|event| matches!(
+            event,
+            BaselineEvent::StateTransition {
+                next: AttemptState::ExecutionFinished,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn timeout_is_recorded_while_state_callback_is_active() {
+        let (entered_sender, entered_receiver) = mpsc::channel();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let observer = Arc::new(OrthogonalOverlapObserver {
+            events: Mutex::new(Vec::new()),
+            blocked: BlockedCallback::Running,
+            entered: entered_sender,
+            release: release.clone(),
+        });
+        let attempt = BaselineAttempt::new(
+            LogicalRequestId::new(),
+            0,
+            BaselineObserverHandle::new(observer.clone()),
+        );
+        attempt.transition(AttemptState::ChannelQueued).unwrap();
+        attempt.transition(AttemptState::WaitingGate).unwrap();
+
+        let running_attempt = attempt.clone();
+        let running_thread =
+            thread::spawn(move || running_attempt.transition(AttemptState::Running));
+        entered_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("running callback must enter");
+
+        let (timeout_started_sender, timeout_started_receiver) = mpsc::channel();
+        let (timeout_completion_sender, timeout_completion_receiver) = mpsc::channel();
+        let timeout_attempt = attempt.clone();
+        let timeout_thread = thread::spawn(move || {
+            timeout_started_sender
+                .send(())
+                .expect("timeout start receiver must remain alive");
+            timeout_attempt.record_client_timeout();
+            timeout_completion_sender
+                .send(())
+                .expect("timeout completion receiver must remain alive");
+        });
+        timeout_started_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("timeout thread must start");
+        let timeout_completion = timeout_completion_receiver.recv_timeout(Duration::from_secs(1));
+
+        release_blocked_callback(&release);
+        running_thread
+            .join()
+            .expect("running transition thread must not panic")
+            .expect("running transition must succeed");
+        timeout_thread
+            .join()
+            .expect("timeout callback thread must not panic");
+        timeout_completion.expect("timeout callback must complete while state callback is blocked");
+        attempt.finish_execution(ExecutionOutcome::Success).unwrap();
+
+        let events = observer
+            .events
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, BaselineEvent::ClientTimeout { .. })),
+            "timeout event must not be silently dropped during state callback"
+        );
+        assert!(events.iter().any(|event| matches!(
+            event,
+            BaselineEvent::StateTransition {
+                next: AttemptState::ExecutionFinished,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn timeout_can_overlap_blocking_before_execute_without_poisoning_observer() {
+        let (entered_sender, entered_receiver) = mpsc::channel();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let observer = Arc::new(BlockingBeforeExecuteObserver {
+            entered: entered_sender,
+            release: release.clone(),
+            timeout_seen: AtomicBool::new(false),
+        });
+        let observer_handle = BaselineObserverHandle::new(observer.clone());
+        let attempt = BaselineAttempt::new(LogicalRequestId::new(), 0, observer_handle.clone());
+
+        let before_attempt = attempt.clone();
+        let before_thread = thread::spawn(move || before_attempt.before_execute());
+        entered_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("before_execute callback must enter");
+
+        let (timeout_started_sender, timeout_started_receiver) = mpsc::channel();
+        let (timeout_completion_sender, timeout_completion_receiver) = mpsc::channel();
+        let timeout_attempt = attempt.clone();
+        let timeout_thread = thread::spawn(move || {
+            timeout_started_sender
+                .send(())
+                .expect("timeout start receiver must remain alive");
+            timeout_attempt.record_client_timeout();
+            timeout_completion_sender
+                .send(())
+                .expect("timeout completion receiver must remain alive");
+        });
+        timeout_started_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("timeout thread must start");
+        let timeout_completion = timeout_completion_receiver.recv_timeout(Duration::from_secs(1));
+
+        release_blocked_callback(&release);
+        before_thread
+            .join()
+            .expect("before_execute callback thread must not panic");
+        timeout_thread
+            .join()
+            .expect("timeout callback thread must not panic");
+        timeout_completion
+            .expect("timeout callback must complete while before_execute callback is blocked");
+        assert!(observer.timeout_seen.load(Ordering::Acquire));
+        assert!(!observer_handle.failed());
+    }
+
+    #[test]
+    fn same_thread_reentrant_void_callback_marks_observer_failed() {
+        let observer = Arc::new(ReentrantVoidObserver::default());
+        let observer_handle = BaselineObserverHandle::new(observer.clone());
+        let attempt = BaselineAttempt::new(LogicalRequestId::new(), 0, observer_handle.clone());
+        *observer
+            .attempt
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(attempt.clone());
+
+        attempt.transition(AttemptState::ChannelQueued).unwrap();
+
+        assert!(observer_handle.failed());
+        assert_eq!(attempt.state(), AttemptState::ChannelQueued);
+    }
+
+    #[test]
+    fn reentrant_drop_terminalizes_state_and_marks_target_observer_failed() {
+        let target_observer = Arc::new(RecordingObserver::default());
+        let target_handle = BaselineObserverHandle::new(target_observer.clone());
+        let target = BaselineAttempt::new(LogicalRequestId::new(), 0, target_handle.clone());
+        target.transition(AttemptState::ChannelQueued).unwrap();
+        let target_inner = target.inner.clone();
+
+        let source_observer = Arc::new(DropAcceptedAttemptObserver::default());
+        *source_observer
+            .target
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(target);
+        let source = BaselineAttempt::new(
+            LogicalRequestId::new(),
+            0,
+            BaselineObserverHandle::new(source_observer),
+        );
+
+        source.transition(AttemptState::ChannelQueued).unwrap();
+
+        assert_eq!(
+            AttemptState::from_u8(target_inner.state.load(Ordering::Acquire)),
+            AttemptState::Abandoned
+        );
+        assert!(target_handle.failed());
+        assert!(!target_observer.events().iter().any(|event| matches!(
+            event,
+            BaselineEvent::StateTransition {
+                next: AttemptState::Abandoned,
+                ..
+            }
+        )));
+        source
+            .transition(AttemptState::ShutdownRejectedAfterAccept)
+            .unwrap();
     }
 }

--- a/src/common/runtime/baseline.rs
+++ b/src/common/runtime/baseline.rs
@@ -1,0 +1,597 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Feature-gated request lifecycle contract for the storage runtime baseline harness.
+
+use std::fmt;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::RequestId;
+
+/// Logical identity shared by all physical attempts for one client request.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize)]
+pub struct LogicalRequestId(Uuid);
+
+impl LogicalRequestId {
+    /// Create a new logical request identity.
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    /// Return the underlying UUID.
+    pub fn inner(self) -> Uuid {
+        self.0
+    }
+}
+
+impl Default for LogicalRequestId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for LogicalRequestId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// Identity carried unchanged across the complete lifetime of one physical attempt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct BaselineTrace {
+    pub logical_id: LogicalRequestId,
+    pub attempt_id: RequestId,
+    pub attempt_index: u32,
+}
+
+/// Observable lifecycle states for an accepted storage attempt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[repr(u8)]
+pub enum AttemptState {
+    Offered = 0,
+    ChannelQueued = 1,
+    BatchQueued = 2,
+    WaitingGate = 3,
+    Running = 4,
+    ExecutionFinished = 5,
+    ShutdownRejectedAfterAccept = 6,
+    Abandoned = 7,
+}
+
+impl AttemptState {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::Offered,
+            1 => Self::ChannelQueued,
+            2 => Self::BatchQueued,
+            3 => Self::WaitingGate,
+            4 => Self::Running,
+            5 => Self::ExecutionFinished,
+            6 => Self::ShutdownRejectedAfterAccept,
+            7 => Self::Abandoned,
+            _ => unreachable!("baseline attempt state is only written from AttemptState"),
+        }
+    }
+
+    fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::ExecutionFinished | Self::ShutdownRejectedAfterAccept | Self::Abandoned
+        )
+    }
+
+    fn permits(self, next: Self) -> bool {
+        matches!(
+            (self, next),
+            (Self::Offered, Self::ChannelQueued)
+                | (Self::ChannelQueued, Self::BatchQueued | Self::WaitingGate)
+                | (Self::BatchQueued, Self::WaitingGate)
+                | (Self::WaitingGate, Self::Running)
+                | (
+                    Self::ChannelQueued | Self::BatchQueued | Self::WaitingGate,
+                    Self::ShutdownRejectedAfterAccept
+                )
+                | (Self::Running, Self::ExecutionFinished)
+        )
+    }
+}
+
+/// Storage execution result, independent of response delivery to the client.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub enum ExecutionOutcome {
+    Success,
+    CommandError,
+    InternalFailure,
+}
+
+/// Synchronous events emitted by a baseline attempt.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub enum BaselineEvent {
+    StateTransition {
+        trace: BaselineTrace,
+        previous: AttemptState,
+        next: AttemptState,
+        elapsed: Duration,
+        outcome: Option<ExecutionOutcome>,
+    },
+    ClientTimeout {
+        trace: BaselineTrace,
+        elapsed: Duration,
+    },
+    ResponseDropped {
+        trace: BaselineTrace,
+        elapsed: Duration,
+    },
+    ResponseDelivered {
+        trace: BaselineTrace,
+        elapsed: Duration,
+    },
+    InvariantViolation {
+        trace: BaselineTrace,
+        previous: AttemptState,
+        attempted: AttemptState,
+        elapsed: Duration,
+    },
+}
+
+/// Consumer of baseline lifecycle events.
+pub trait BaselineObserver: Send + Sync + 'static {
+    fn on_event(&self, event: BaselineEvent);
+    fn before_execute(&self, trace: &BaselineTrace);
+}
+
+/// Error returned when a lifecycle transition violates the frozen state graph.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("invalid baseline attempt transition from {previous:?} to {attempted:?}")]
+pub struct BaselineTransitionError {
+    previous: AttemptState,
+    attempted: AttemptState,
+}
+
+impl BaselineTransitionError {
+    pub fn previous(self) -> AttemptState {
+        self.previous
+    }
+
+    pub fn attempted(self) -> AttemptState {
+        self.attempted
+    }
+}
+
+struct BaselineAttemptInner {
+    trace: BaselineTrace,
+    state: AtomicU8,
+    started_at: Instant,
+    last_transition: Mutex<Instant>,
+    observer: Arc<dyn BaselineObserver>,
+}
+
+/// Cloneable RAII token for one physical storage attempt.
+#[derive(Clone)]
+pub struct BaselineAttempt {
+    inner: Arc<BaselineAttemptInner>,
+}
+
+impl BaselineAttempt {
+    pub fn new(
+        logical_id: LogicalRequestId,
+        attempt_index: u32,
+        observer: Arc<dyn BaselineObserver>,
+    ) -> Self {
+        let now = Instant::now();
+        Self {
+            inner: Arc::new(BaselineAttemptInner {
+                trace: BaselineTrace {
+                    logical_id,
+                    attempt_id: RequestId::new(),
+                    attempt_index,
+                },
+                state: AtomicU8::new(AttemptState::Offered as u8),
+                started_at: now,
+                last_transition: Mutex::new(now),
+                observer,
+            }),
+        }
+    }
+
+    pub fn trace(&self) -> BaselineTrace {
+        self.inner.trace
+    }
+
+    pub fn state(&self) -> AttemptState {
+        AttemptState::from_u8(self.inner.state.load(Ordering::Acquire))
+    }
+
+    pub fn transition(&self, next: AttemptState) -> Result<(), BaselineTransitionError> {
+        self.transition_inner(next, None)
+    }
+
+    pub fn finish_execution(
+        &self,
+        outcome: ExecutionOutcome,
+    ) -> Result<(), BaselineTransitionError> {
+        self.transition_inner(AttemptState::ExecutionFinished, Some(outcome))
+    }
+
+    pub fn before_execute(&self) {
+        self.inner.observer.before_execute(&self.inner.trace);
+    }
+
+    pub fn record_client_timeout(&self) {
+        self.inner.observer.on_event(BaselineEvent::ClientTimeout {
+            trace: self.inner.trace,
+            elapsed: self.inner.started_at.elapsed(),
+        });
+    }
+
+    pub fn record_response_dropped(&self) {
+        self.inner
+            .observer
+            .on_event(BaselineEvent::ResponseDropped {
+                trace: self.inner.trace,
+                elapsed: self.inner.started_at.elapsed(),
+            });
+    }
+
+    pub fn record_response_delivered(&self) {
+        self.inner
+            .observer
+            .on_event(BaselineEvent::ResponseDelivered {
+                trace: self.inner.trace,
+                elapsed: self.inner.started_at.elapsed(),
+            });
+    }
+
+    fn transition_inner(
+        &self,
+        next: AttemptState,
+        outcome: Option<ExecutionOutcome>,
+    ) -> Result<(), BaselineTransitionError> {
+        let (previous, elapsed) = {
+            let mut last_transition = self
+                .inner
+                .last_transition
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let previous = self.state();
+            if !previous.permits(next)
+                || (next == AttemptState::ExecutionFinished && outcome.is_none())
+                || (next != AttemptState::ExecutionFinished && outcome.is_some())
+            {
+                drop(last_transition);
+                self.record_invariant_violation(previous, next);
+                return Err(BaselineTransitionError {
+                    previous,
+                    attempted: next,
+                });
+            }
+
+            self.inner.state.store(next as u8, Ordering::Release);
+            let now = Instant::now();
+            let elapsed = now.saturating_duration_since(*last_transition);
+            *last_transition = now;
+            (previous, elapsed)
+        };
+
+        self.inner
+            .observer
+            .on_event(BaselineEvent::StateTransition {
+                trace: self.inner.trace,
+                previous,
+                next,
+                elapsed,
+                outcome,
+            });
+        Ok(())
+    }
+
+    fn record_invariant_violation(&self, previous: AttemptState, attempted: AttemptState) {
+        self.inner
+            .observer
+            .on_event(BaselineEvent::InvariantViolation {
+                trace: self.inner.trace,
+                previous,
+                attempted,
+                elapsed: self.inner.started_at.elapsed(),
+            });
+    }
+}
+
+impl fmt::Debug for BaselineAttempt {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BaselineAttempt")
+            .field("trace", &self.trace())
+            .field("state", &self.state())
+            .finish()
+    }
+}
+
+impl Drop for BaselineAttempt {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self.inner) != 1 {
+            return;
+        }
+
+        let transition = {
+            let mut last_transition = self
+                .inner
+                .last_transition
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let previous = self.state();
+            if previous.is_terminal() {
+                None
+            } else {
+                self.inner
+                    .state
+                    .store(AttemptState::Abandoned as u8, Ordering::Release);
+                let now = Instant::now();
+                let elapsed = now.saturating_duration_since(*last_transition);
+                *last_transition = now;
+                Some((previous, elapsed))
+            }
+        };
+
+        if let Some((previous, elapsed)) = transition {
+            self.inner
+                .observer
+                .on_event(BaselineEvent::StateTransition {
+                    trace: self.inner.trace,
+                    previous,
+                    next: AttemptState::Abandoned,
+                    elapsed,
+                    outcome: None,
+                });
+        }
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingObserver {
+        events: Mutex<Vec<BaselineEvent>>,
+    }
+
+    impl RecordingObserver {
+        fn events(&self) -> Vec<BaselineEvent> {
+            self.events
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+        }
+    }
+
+    impl BaselineObserver for RecordingObserver {
+        fn on_event(&self, event: BaselineEvent) {
+            self.events
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(event);
+        }
+
+        fn before_execute(&self, _trace: &BaselineTrace) {}
+    }
+
+    fn attempt(observer: Arc<RecordingObserver>) -> BaselineAttempt {
+        BaselineAttempt::new(LogicalRequestId::new(), 0, observer)
+    }
+
+    #[test]
+    fn legal_transitions_record_previous_and_next_state() {
+        let observer = Arc::new(RecordingObserver::default());
+        let attempt = attempt(observer.clone());
+
+        attempt.transition(AttemptState::ChannelQueued).unwrap();
+        attempt.transition(AttemptState::BatchQueued).unwrap();
+        attempt.transition(AttemptState::WaitingGate).unwrap();
+        attempt.transition(AttemptState::Running).unwrap();
+        attempt.finish_execution(ExecutionOutcome::Success).unwrap();
+
+        assert_eq!(attempt.state(), AttemptState::ExecutionFinished);
+        let transitions: Vec<_> = observer
+            .events()
+            .into_iter()
+            .filter_map(|event| match event {
+                BaselineEvent::StateTransition {
+                    previous,
+                    next,
+                    elapsed,
+                    ..
+                } => Some((previous, next, elapsed)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(transitions.len(), 5);
+        assert_eq!(
+            transitions
+                .iter()
+                .map(|(previous, next, _)| (*previous, *next))
+                .collect::<Vec<_>>(),
+            vec![
+                (AttemptState::Offered, AttemptState::ChannelQueued),
+                (AttemptState::ChannelQueued, AttemptState::BatchQueued),
+                (AttemptState::BatchQueued, AttemptState::WaitingGate),
+                (AttemptState::WaitingGate, AttemptState::Running),
+                (AttemptState::Running, AttemptState::ExecutionFinished),
+            ]
+        );
+    }
+
+    #[test]
+    fn illegal_transition_returns_error_and_records_invariant_violation() {
+        let observer = Arc::new(RecordingObserver::default());
+        let attempt = attempt(observer.clone());
+
+        let error = attempt.transition(AttemptState::Running).unwrap_err();
+
+        assert_eq!(error.previous(), AttemptState::Offered);
+        assert_eq!(error.attempted(), AttemptState::Running);
+        assert_eq!(attempt.state(), AttemptState::Offered);
+        assert!(matches!(
+            observer.events().as_slice(),
+            [BaselineEvent::InvariantViolation {
+                previous: AttemptState::Offered,
+                attempted: AttemptState::Running,
+                ..
+            }]
+        ));
+    }
+
+    #[test]
+    fn repeated_or_post_terminal_transition_is_rejected() {
+        let observer = Arc::new(RecordingObserver::default());
+        let attempt = attempt(observer.clone());
+        attempt.transition(AttemptState::ChannelQueued).unwrap();
+        attempt.transition(AttemptState::WaitingGate).unwrap();
+        attempt.transition(AttemptState::Running).unwrap();
+        attempt
+            .finish_execution(ExecutionOutcome::CommandError)
+            .unwrap();
+
+        assert!(
+            attempt
+                .finish_execution(ExecutionOutcome::InternalFailure)
+                .is_err()
+        );
+        assert!(attempt.transition(AttemptState::Abandoned).is_err());
+        assert_eq!(attempt.state(), AttemptState::ExecutionFinished);
+        assert_eq!(
+            observer
+                .events()
+                .into_iter()
+                .filter(|event| matches!(event, BaselineEvent::InvariantViolation { .. }))
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn last_token_drop_marks_non_terminal_attempt_abandoned_once() {
+        let observer = Arc::new(RecordingObserver::default());
+        let attempt = attempt(observer.clone());
+        let trace = attempt.trace();
+        attempt.transition(AttemptState::ChannelQueued).unwrap();
+
+        drop(attempt);
+
+        let abandonments: Vec<_> = observer
+            .events()
+            .into_iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    BaselineEvent::StateTransition {
+                        trace: event_trace,
+                        next: AttemptState::Abandoned,
+                        ..
+                    } if *event_trace == trace
+                )
+            })
+            .collect();
+        assert_eq!(abandonments.len(), 1);
+    }
+
+    #[test]
+    fn dropping_one_clone_does_not_abandon_shared_attempt() {
+        let observer = Arc::new(RecordingObserver::default());
+        let attempt = attempt(observer.clone());
+        attempt.transition(AttemptState::ChannelQueued).unwrap();
+        let clone = attempt.clone();
+
+        drop(clone);
+
+        assert_eq!(attempt.state(), AttemptState::ChannelQueued);
+        assert!(!observer.events().iter().any(|event| matches!(
+            event,
+            BaselineEvent::StateTransition {
+                next: AttemptState::Abandoned,
+                ..
+            }
+        )));
+        attempt
+            .transition(AttemptState::ShutdownRejectedAfterAccept)
+            .unwrap();
+    }
+
+    #[test]
+    fn retry_attempts_share_logical_identity_but_not_physical_identity() {
+        let observer = Arc::new(RecordingObserver::default());
+        let logical_id = LogicalRequestId::new();
+        let first = BaselineAttempt::new(logical_id, 0, observer.clone());
+        let retry = BaselineAttempt::new(logical_id, 1, observer);
+
+        assert_eq!(first.trace().logical_id, retry.trace().logical_id);
+        assert_ne!(first.trace().attempt_id, retry.trace().attempt_id);
+        assert_eq!(first.trace().attempt_index, 0);
+        assert_eq!(retry.trace().attempt_index, 1);
+
+        first.transition(AttemptState::ChannelQueued).unwrap();
+        first
+            .transition(AttemptState::ShutdownRejectedAfterAccept)
+            .unwrap();
+        retry.transition(AttemptState::ChannelQueued).unwrap();
+        retry
+            .transition(AttemptState::ShutdownRejectedAfterAccept)
+            .unwrap();
+    }
+
+    #[test]
+    fn client_timeout_is_orthogonal_to_execution_and_response_delivery() {
+        let observer = Arc::new(RecordingObserver::default());
+        let attempt = attempt(observer.clone());
+        attempt.transition(AttemptState::ChannelQueued).unwrap();
+        attempt.transition(AttemptState::WaitingGate).unwrap();
+        attempt.transition(AttemptState::Running).unwrap();
+
+        attempt.record_client_timeout();
+        attempt.finish_execution(ExecutionOutcome::Success).unwrap();
+        attempt.record_response_dropped();
+
+        assert_eq!(attempt.state(), AttemptState::ExecutionFinished);
+        let events = observer.events();
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, BaselineEvent::ClientTimeout { .. }))
+        );
+        assert!(events.iter().any(|event| matches!(
+            event,
+            BaselineEvent::StateTransition {
+                next: AttemptState::ExecutionFinished,
+                outcome: Some(ExecutionOutcome::Success),
+                ..
+            }
+        )));
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, BaselineEvent::ResponseDropped { .. }))
+        );
+    }
+}

--- a/src/common/runtime/lib.rs
+++ b/src/common/runtime/lib.rs
@@ -29,6 +29,9 @@ pub mod message;
 pub mod metrics;
 pub mod storage_server;
 
+#[cfg(feature = "runtime-baseline")]
+pub mod baseline;
+
 #[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod tests;
@@ -67,4 +70,10 @@ pub use storage_server::{
     BackgroundTaskConfig, BackgroundTaskManager, BackgroundTaskStats, BatchConfig, BatchProcessor,
     BatchStats, RocksDbStats, StorageAccessGate, StorageAccessPermit, StorageServer,
     StorageServerConfig, StorageServerPauseController, initialize_storage_command_table,
+};
+
+#[cfg(feature = "runtime-baseline")]
+pub use baseline::{
+    AttemptState, BaselineAttempt, BaselineEvent, BaselineObserver, BaselineTrace,
+    BaselineTransitionError, ExecutionOutcome, LogicalRequestId,
 };

--- a/src/common/runtime/lib.rs
+++ b/src/common/runtime/lib.rs
@@ -74,6 +74,7 @@ pub use storage_server::{
 
 #[cfg(feature = "runtime-baseline")]
 pub use baseline::{
-    AttemptState, BaselineAttempt, BaselineEvent, BaselineObserver, BaselineTrace,
-    BaselineTransitionError, ExecutionOutcome, LogicalRequestId,
+    AttemptState, BaselineAttempt, BaselineEvent, BaselineObserver, BaselineObserverHandle,
+    BaselineTrace, BaselineTransitionError, BaselineTransitionFailure, ExecutionOutcome,
+    LogicalRequestId,
 };

--- a/src/common/runtime/manager.rs
+++ b/src/common/runtime/manager.rs
@@ -405,6 +405,15 @@ impl RuntimeManager {
         })
     }
 
+    /// Drop the manager-owned storage request sender.
+    ///
+    /// The request receiver closes once all other [`StorageClient`] clones have
+    /// also been dropped. Returns `true` only when this call releases the
+    /// manager-owned client.
+    pub fn close_storage_requests(&mut self) -> bool {
+        self.storage_client.take().is_some()
+    }
+
     /// Initialize storage components by extracting the receiver and creating the storage client
     /// This must be called before the storage server is started and before the storage client is used
     /// Returns the receiver that should be passed to the storage server

--- a/src/common/runtime/message.rs
+++ b/src/common/runtime/message.rs
@@ -145,6 +145,31 @@ pub struct StorageRequest {
     pub timestamp: Instant,
     /// Priority level for request processing
     pub priority: RequestPriority,
+    /// Baseline lifecycle token carried across the storage runtime boundary.
+    #[cfg(feature = "runtime-baseline")]
+    pub baseline_attempt: Option<crate::baseline::BaselineAttempt>,
+}
+
+impl StorageRequest {
+    /// Create a request without feature-specific instrumentation.
+    pub fn new(
+        id: RequestId,
+        command: StorageCommand,
+        response_channel: oneshot::Sender<StorageResponse>,
+        timeout: Duration,
+        priority: RequestPriority,
+    ) -> Self {
+        Self {
+            id,
+            command,
+            response_channel,
+            timeout,
+            timestamp: Instant::now(),
+            priority,
+            #[cfg(feature = "runtime-baseline")]
+            baseline_attempt: None,
+        }
+    }
 }
 
 /// Priority levels for storage request processing
@@ -1008,6 +1033,8 @@ impl StorageClient {
             timeout,
             timestamp: Instant::now(),
             priority,
+            #[cfg(feature = "runtime-baseline")]
+            baseline_attempt: None,
         };
 
         // Store the response receiver for tracking
@@ -1223,6 +1250,8 @@ impl StorageClient {
             timeout,
             timestamp: Instant::now(),
             priority,
+            #[cfg(feature = "runtime-baseline")]
+            baseline_attempt: None,
         };
 
         // Try to queue the request
@@ -1413,6 +1442,30 @@ mod tests {
         assert_eq!(stats.bytes_written, 0);
         assert!(!stats.cache_hit);
         assert_eq!(stats.compaction_level, None);
+    }
+
+    #[test]
+    fn test_storage_request_constructor_preserves_request_metadata() {
+        let id = RequestId::new();
+        let command = StorageCommand::Execute {
+            cmd_name: b"get".to_vec(),
+            argv: vec![b"get".to_vec(), b"key".to_vec()],
+        };
+        let (response_channel, _response_receiver) = oneshot::channel();
+
+        let request = StorageRequest::new(
+            id,
+            command,
+            response_channel,
+            Duration::from_secs(3),
+            RequestPriority::High,
+        );
+
+        assert_eq!(request.id, id);
+        assert_eq!(request.timeout, Duration::from_secs(3));
+        assert_eq!(request.priority, RequestPriority::High);
+        #[cfg(feature = "runtime-baseline")]
+        assert!(request.baseline_attempt.is_none());
     }
 
     #[tokio::test]

--- a/src/common/runtime/message.rs
+++ b/src/common/runtime/message.rs
@@ -134,7 +134,11 @@ impl StorageStatsCollector for NoopStorageStatsCollector {
 #[derive(Debug)]
 pub struct StorageRequest {
     /// Unique identifier for this request
+    #[cfg(not(feature = "runtime-baseline"))]
     pub id: RequestId,
+    /// Unique identifier for this request, bound to the baseline attempt trace.
+    #[cfg(feature = "runtime-baseline")]
+    pub(crate) id: RequestId,
     /// The storage command to execute
     pub command: StorageCommand,
     /// Channel to send the response back
@@ -147,7 +151,7 @@ pub struct StorageRequest {
     pub priority: RequestPriority,
     /// Baseline lifecycle token carried across the storage runtime boundary.
     #[cfg(feature = "runtime-baseline")]
-    pub baseline_attempt: Option<crate::baseline::BaselineAttempt>,
+    pub(crate) baseline_attempt: Option<crate::baseline::BaselineAttempt>,
 }
 
 impl StorageRequest {
@@ -169,6 +173,62 @@ impl StorageRequest {
             #[cfg(feature = "runtime-baseline")]
             baseline_attempt: None,
         }
+    }
+
+    /// Return the immutable physical request identity.
+    pub fn id(&self) -> RequestId {
+        self.id
+    }
+
+    /// Create an instrumented request whose physical identity is derived from
+    /// its baseline attempt token.
+    ///
+    /// Instrumented request identities cannot be overwritten by callers:
+    ///
+    /// ```compile_fail
+    /// use runtime::{RequestId, StorageRequest};
+    ///
+    /// fn overwrite_id(request: &mut StorageRequest) {
+    ///     request.id = RequestId::new();
+    /// }
+    /// ```
+    ///
+    /// Instrumented requests also cannot be reconstructed with a mismatched ID:
+    ///
+    /// ```compile_fail
+    /// use runtime::{RequestId, StorageRequest};
+    ///
+    /// fn forge_id(request: StorageRequest) -> StorageRequest {
+    ///     StorageRequest {
+    ///         id: RequestId::new(),
+    ///         ..request
+    ///     }
+    /// }
+    /// ```
+    #[cfg(feature = "runtime-baseline")]
+    pub fn new_with_baseline_attempt(
+        baseline_attempt: crate::baseline::BaselineAttempt,
+        command: StorageCommand,
+        response_channel: oneshot::Sender<StorageResponse>,
+        timeout: Duration,
+        priority: RequestPriority,
+    ) -> Self {
+        Self {
+            id: baseline_attempt.trace().attempt_id,
+            command,
+            response_channel,
+            timeout,
+            timestamp: Instant::now(),
+            priority,
+            baseline_attempt: Some(baseline_attempt),
+        }
+    }
+
+    /// Return the baseline token without permitting callers to replace it with
+    /// an identity that diverges from [`StorageRequest::id()`].
+    #[cfg(feature = "runtime-baseline")]
+    pub fn baseline_attempt(&self) -> Option<&crate::baseline::BaselineAttempt> {
+        self.baseline_attempt.as_ref()
     }
 }
 
@@ -1406,6 +1466,16 @@ impl StorageClient {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "runtime-baseline")]
+    struct NoopBaselineObserver;
+
+    #[cfg(feature = "runtime-baseline")]
+    impl crate::baseline::BaselineObserver for NoopBaselineObserver {
+        fn on_event(&self, _event: crate::baseline::BaselineEvent) {}
+
+        fn before_execute(&self, _trace: &crate::baseline::BaselineTrace) {}
+    }
+
     #[test]
     fn test_request_id_creation() {
         let id1 = RequestId::new();
@@ -1466,6 +1536,36 @@ mod tests {
         assert_eq!(request.priority, RequestPriority::High);
         #[cfg(feature = "runtime-baseline")]
         assert!(request.baseline_attempt.is_none());
+    }
+
+    #[cfg(feature = "runtime-baseline")]
+    #[test]
+    fn storage_request_id_matches_its_baseline_attempt_trace() {
+        let attempt = crate::baseline::BaselineAttempt::new(
+            crate::baseline::LogicalRequestId::new(),
+            0,
+            crate::baseline::BaselineObserverHandle::new(std::sync::Arc::new(NoopBaselineObserver)),
+        );
+        let (response_channel, _response_receiver) = oneshot::channel();
+        let request = StorageRequest::new_with_baseline_attempt(
+            attempt.clone(),
+            StorageCommand::Execute {
+                cmd_name: b"get".to_vec(),
+                argv: vec![b"get".to_vec(), b"key".to_vec()],
+            },
+            response_channel,
+            Duration::from_secs(3),
+            RequestPriority::High,
+        );
+
+        assert_eq!(request.id, attempt.trace().attempt_id);
+        assert_eq!(
+            request
+                .baseline_attempt()
+                .expect("instrumented request must retain the baseline token")
+                .trace(),
+            attempt.trace()
+        );
     }
 
     #[tokio::test]

--- a/src/common/runtime/storage_server.rs
+++ b/src/common/runtime/storage_server.rs
@@ -281,10 +281,11 @@ impl StorageServer {
         global_storage: GlobalStorage,
         request_receiver: mpsc::Receiver<StorageRequest>,
     ) -> Self {
-        Self::with_config(
+        Self::with_config_and_gate(
             global_storage,
             request_receiver,
             StorageServerConfig::default(),
+            StorageAccessGate::new(),
         )
     }
 
@@ -298,6 +299,21 @@ impl StorageServer {
             global_storage,
             request_receiver,
             StorageServerConfig::default(),
+            pause_controller.access_gate(),
+        )
+    }
+
+    /// Create a storage server with custom configuration and a pause controller.
+    pub fn with_config_and_pause_controller(
+        global_storage: GlobalStorage,
+        request_receiver: mpsc::Receiver<StorageRequest>,
+        config: StorageServerConfig,
+        pause_controller: StorageServerPauseController,
+    ) -> Self {
+        Self::with_config_and_gate(
+            global_storage,
+            request_receiver,
+            config,
             pause_controller.access_gate(),
         )
     }
@@ -1426,6 +1442,44 @@ mod tests {
         assert_eq!(config.worker_count, 4);
         assert!(config.enable_batching);
         assert!(config.enable_background_tasks);
+    }
+
+    #[test]
+    fn test_config_and_pause_controller_share_gate() {
+        let global_storage = GlobalStorage::new(Storage::new(1, 0));
+        let (_request_sender, request_receiver) = mpsc::channel(1);
+        let pause_controller = StorageServerPauseController::new();
+        let config = StorageServerConfig {
+            max_batch_size: 7,
+            batch_timeout_ms: 13,
+            worker_count: 2,
+            enable_batching: true,
+            enable_background_tasks: false,
+        };
+
+        let server = StorageServer::with_config_and_pause_controller(
+            global_storage,
+            request_receiver,
+            config,
+            pause_controller.clone(),
+        );
+
+        assert!(Arc::ptr_eq(
+            &server.access_gate.inner,
+            &pause_controller.access_gate.inner
+        ));
+        assert_eq!(server.config.max_batch_size, 7);
+        assert_eq!(server.config.batch_timeout_ms, 13);
+        assert_eq!(server.config.worker_count, 2);
+        assert!(server.config.enable_batching);
+        assert!(!server.config.enable_background_tasks);
+
+        let batch_processor = server
+            .batch_processor
+            .as_ref()
+            .expect("batching config should create a batch processor");
+        assert_eq!(batch_processor.max_batch_size, 7);
+        assert_eq!(batch_processor.batch_timeout_ms, 13);
     }
 
     #[test]

--- a/src/common/runtime/storage_server.rs
+++ b/src/common/runtime/storage_server.rs
@@ -1753,6 +1753,8 @@ mod tests {
             timeout: Duration::from_secs(1),
             timestamp: Instant::now(),
             priority: RequestPriority::Normal,
+            #[cfg(feature = "runtime-baseline")]
+            baseline_attempt: None,
         };
         let batch = vec![request];
         let batch_processing = server.process_request_batch(batch);

--- a/src/common/runtime/tests.rs
+++ b/src/common/runtime/tests.rs
@@ -187,6 +187,44 @@ mod runtime_manager_tests {
 
         manager.stop().await.unwrap();
     }
+
+    #[tokio::test]
+    async fn test_close_storage_requests_releases_receiver_after_external_clients_drop() {
+        let mut manager = RuntimeManager::with_defaults().unwrap();
+        let mut request_receiver = manager.initialize_storage_components().unwrap();
+        let external_client = manager.storage_client().unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), request_receiver.recv())
+                .await
+                .is_err(),
+            "manager-owned StorageClient must keep the request receiver open"
+        );
+
+        drop(external_client);
+        assert!(manager.close_storage_requests());
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), request_receiver.recv())
+                .await
+                .expect("request receiver should close within the test deadline")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_close_storage_requests_is_idempotent_and_preserves_manager_state() {
+        let mut manager = RuntimeManager::with_defaults().unwrap();
+        let _request_receiver = manager.initialize_storage_components().unwrap();
+        let state_before_close = manager.state().await;
+        let network_threads = manager.config().network_threads;
+        let storage_threads = manager.config().storage_threads;
+
+        assert!(manager.close_storage_requests());
+        assert!(!manager.close_storage_requests());
+        assert_eq!(manager.state().await, state_before_close);
+        assert_eq!(manager.config().network_threads, network_threads);
+        assert_eq!(manager.config().storage_threads, storage_threads);
+    }
 }
 
 // MessageChannel Tests

--- a/src/common/runtime/tests.rs
+++ b/src/common/runtime/tests.rs
@@ -1071,3 +1071,87 @@ mod integration_tests {
         assert_eq!(success_count + error_count, num_requests);
     }
 }
+
+#[cfg(test)]
+mod storage_server_composition_tests {
+    use std::time::{Duration, Instant};
+
+    use resp::RespData;
+    use storage::storage::Storage;
+    use tokio::sync::{mpsc, oneshot};
+
+    use crate::{
+        GlobalStorage, RequestId, RequestPriority, StorageCommand, StorageRequest, StorageServer,
+        StorageServerConfig, StorageServerPauseController,
+    };
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn combined_config_pause_blocks_request_until_resume() {
+        let global_storage = GlobalStorage::new(Storage::new(1, 0));
+        let (request_sender, request_receiver) = mpsc::channel(1);
+        let pause_controller = StorageServerPauseController::new();
+        pause_controller.request_pause().await;
+
+        let config = StorageServerConfig {
+            max_batch_size: 1,
+            batch_timeout_ms: 1,
+            worker_count: 1,
+            enable_batching: true,
+            enable_background_tasks: false,
+        };
+        let server = StorageServer::with_config_and_pause_controller(
+            global_storage,
+            request_receiver,
+            config,
+            pause_controller.clone(),
+        );
+        let server_task = tokio::spawn(server.run());
+
+        let (response_sender, mut response_receiver) = oneshot::channel();
+        request_sender
+            .send(StorageRequest {
+                id: RequestId::new(),
+                command: StorageCommand::Batch {
+                    commands: Vec::new(),
+                },
+                response_channel: response_sender,
+                timeout: Duration::from_secs(1),
+                timestamp: Instant::now(),
+                priority: RequestPriority::Normal,
+            })
+            .await
+            .expect("request channel should remain open");
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while request_sender.capacity() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("storage server should accept the paused request");
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut response_receiver)
+                .await
+                .is_err(),
+            "request execution must remain blocked while the supplied controller is paused"
+        );
+
+        pause_controller.resume();
+        let response = tokio::time::timeout(Duration::from_secs(1), &mut response_receiver)
+            .await
+            .expect("request should finish after resume")
+            .expect("storage server should send a response");
+        assert_eq!(
+            response.result.expect("empty batch should succeed"),
+            RespData::Array(Some(Vec::new()))
+        );
+
+        drop(request_sender);
+        tokio::time::timeout(Duration::from_secs(1), server_task)
+            .await
+            .expect("storage server should stop after the request channel closes")
+            .expect("storage server task should not panic")
+            .expect("storage server should stop cleanly");
+    }
+}

--- a/src/common/runtime/tests.rs
+++ b/src/common/runtime/tests.rs
@@ -657,6 +657,8 @@ mod integration_tests {
             timeout: Duration::from_secs(1),
             timestamp: Instant::now(),
             priority: RequestPriority::Normal,
+            #[cfg(feature = "runtime-baseline")]
+            baseline_attempt: None,
         };
 
         // Send request
@@ -1156,6 +1158,8 @@ mod storage_server_composition_tests {
                 timeout: Duration::from_secs(1),
                 timestamp: Instant::now(),
                 priority: RequestPriority::Normal,
+                #[cfg(feature = "runtime-baseline")]
+                baseline_attempt: None,
             })
             .await
             .expect("request channel should remain open");

--- a/src/net/Cargo.toml
+++ b/src/net/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 [dependencies]
 log.workspace = true
 tokio = { workspace = true, features = ["net", "io-util", "macros", "rt", "rt-multi-thread", "time"] }
+tokio-util.workspace = true
 storage.workspace = true
 async-trait = "0.1"
 snafu = "0.8"

--- a/src/net/src/handle.rs
+++ b/src/net/src/handle.rs
@@ -27,6 +27,7 @@ use resp::encode::RespEncoder;
 use resp::{Parse, RespData, RespEncode, RespParseResult};
 use storage::storage::Storage;
 use tokio::select;
+use tokio_util::sync::CancellationToken;
 
 use crate::storage_client::StorageClient;
 
@@ -131,13 +132,35 @@ pub async fn process_connection_with_storage_client(
     executor: Arc<CmdExecutor>,
     leader_gate: Option<std::sync::Arc<dyn raft::leader_gate::LeaderGate>>,
 ) -> std::io::Result<()> {
-    // Delegate to the network-aware connection handler
-    crate::network_handle::process_network_connection(
+    process_connection_with_storage_client_until_cancelled(
         client,
         storage_client,
         cmd_table,
         executor,
         leader_gate,
+        CancellationToken::new(),
+    )
+    .await
+}
+
+/// Process a dual-runtime connection and observe cancellation only before the
+/// next socket read, never by dropping an in-flight storage request.
+pub async fn process_connection_with_storage_client_until_cancelled(
+    client: Arc<Client>,
+    storage_client: Arc<StorageClient>,
+    cmd_table: Arc<CmdTable>,
+    executor: Arc<CmdExecutor>,
+    leader_gate: Option<std::sync::Arc<dyn raft::leader_gate::LeaderGate>>,
+    shutdown: CancellationToken,
+) -> std::io::Result<()> {
+    // Delegate to the network-aware connection handler
+    crate::network_handle::process_network_connection_until_cancelled(
+        client,
+        storage_client,
+        cmd_table,
+        executor,
+        leader_gate,
+        shutdown,
     )
     .await
 }

--- a/src/net/src/network_handle.rs
+++ b/src/net/src/network_handle.rs
@@ -33,6 +33,7 @@ use log::{debug, error, warn};
 use resp::encode::RespEncoder;
 use resp::{Parse, RespData, RespEncode, RespParseResult};
 use tokio::select;
+use tokio_util::sync::CancellationToken;
 
 use crate::executor_ext::CmdExecutorNetworkExt;
 use crate::storage_client::StorageClient;
@@ -51,6 +52,28 @@ pub async fn process_network_connection(
     executor: Arc<CmdExecutor>,
     leader_gate: Option<std::sync::Arc<dyn raft::leader_gate::LeaderGate>>,
 ) -> std::io::Result<()> {
+    process_network_connection_until_cancelled(
+        client,
+        storage_client,
+        cmd_table,
+        executor,
+        leader_gate,
+        CancellationToken::new(),
+    )
+    .await
+}
+
+/// Process a network connection until cancellation is observed at a safe read
+/// boundary. Once a read completes, every command from that read is allowed to
+/// reach a terminal result before cancellation is checked again.
+pub async fn process_network_connection_until_cancelled(
+    client: Arc<Client>,
+    storage_client: Arc<StorageClient>,
+    cmd_table: Arc<CmdTable>,
+    executor: Arc<CmdExecutor>,
+    leader_gate: Option<std::sync::Arc<dyn raft::leader_gate::LeaderGate>>,
+    shutdown: CancellationToken,
+) -> std::io::Result<()> {
     let mut buf = vec![0; 4096]; // Increased buffer size for better performance
     let mut resp_parser = resp::RespParse::new(client.resp_version());
     let mut pending_commands = Vec::new();
@@ -59,6 +82,12 @@ pub async fn process_network_connection(
 
     loop {
         select! {
+            biased;
+
+            _ = shutdown.cancelled() => {
+                debug!("Connection cancelled before next read");
+                return Ok(());
+            }
             result = client.read(&mut buf) => {
                 match result {
                     Ok(n) => {

--- a/src/net/src/network_handle.rs
+++ b/src/net/src/network_handle.rs
@@ -102,12 +102,14 @@ pub async fn process_network_connection_until_cancelled(
                                     cmd_table.clone(),
                                     executor.clone(),
                                     leader_gate.clone(),
+                                    &shutdown,
                                 ).await;
                             }
                             return Ok(());
                         }
 
                         debug!("Received {} bytes from client", n);
+                        let mut shutdown_after_current_read = false;
 
                         // Parse RESP data with support for multiple commands
                         let mut parse_result = resp_parser.parse(Bytes::copy_from_slice(&buf[..n]));
@@ -122,13 +124,14 @@ pub async fn process_network_connection_until_cancelled(
 
                                         // Check if we should process the batch
                                         if should_process_batch(&pending_commands) {
-                                            process_command_batch(
+                                            shutdown_after_current_read |= process_command_batch(
                                                 &pending_commands,
                                                 client.clone(),
                                                 storage_client.clone(),
                                                 cmd_table.clone(),
                                                 executor.clone(),
                                                 leader_gate.clone(),
+                                                &shutdown,
                                             ).await;
                                             pending_commands.clear();
                                         }
@@ -150,15 +153,21 @@ pub async fn process_network_connection_until_cancelled(
 
                         // Process any remaining commands if we have a complete batch
                         if !pending_commands.is_empty() && should_flush_batch(&pending_commands) {
-                            process_command_batch(
+                            shutdown_after_current_read |= process_command_batch(
                                 &pending_commands,
                                 client.clone(),
                                 storage_client.clone(),
                                 cmd_table.clone(),
                                 executor.clone(),
                                 leader_gate.clone(),
+                                &shutdown,
                             ).await;
                             pending_commands.clear();
+                        }
+
+                        if shutdown_after_current_read || shutdown.is_cancelled() {
+                            debug!("Connection cancelled after completing the current socket read");
+                            return Ok(());
                         }
                     }
                     Err(e) => {
@@ -364,7 +373,8 @@ pub fn is_write_command(cmd: &str) -> bool {
     )
 }
 
-/// Process a batch of commands, potentially in parallel for read operations
+/// Process every command in a batch to a terminal result. If shutdown interrupts
+/// a response write, subsequent responses are suppressed and `true` is returned.
 async fn process_command_batch(
     commands: &[ParsedCommand],
     client: Arc<Client>,
@@ -372,8 +382,10 @@ async fn process_command_batch(
     cmd_table: Arc<CmdTable>,
     executor: Arc<CmdExecutor>,
     leader_gate: Option<std::sync::Arc<dyn raft::leader_gate::LeaderGate>>,
-) {
+    shutdown: &CancellationToken,
+) -> bool {
     debug!("Processing command batch of {} commands", commands.len());
+    let mut response_writes_cancelled = false;
 
     // For now, process commands sequentially to maintain order
     // TODO: Implement parallel processing for read-only commands
@@ -383,30 +395,28 @@ async fn process_command_batch(
         client.set_argv(&command.argv);
 
         // Auth check: deny non-NO_AUTH commands when not authenticated
+        let mut auth_rejected = false;
         if !client.is_authenticated() {
             let cmd_name_str = String::from_utf8_lossy(&command.cmd_name).to_lowercase();
             if let Some(cmd) = cmd_table.get(&cmd_name_str) {
                 if !cmd.has_flag(CmdFlags::NO_AUTH) {
                     client.set_reply(RespData::Error("NOAUTH Authentication required.".into()));
-                    let response = client.take_reply();
-                    let encoder_version = client.resp_version();
-                    let mut encoder = RespEncoder::new(encoder_version);
-                    encoder.encode_resp_data(&response);
-                    let _ = client.write(encoder.get_response().as_ref()).await;
-                    continue;
+                    auth_rejected = true;
                 }
             }
         }
 
         // Handle the command
-        handle_network_command(
-            client.clone(),
-            storage_client.clone(),
-            cmd_table.clone(),
-            executor.clone(),
-            leader_gate.clone(),
-        )
-        .await;
+        if !auth_rejected {
+            handle_network_command(
+                client.clone(),
+                storage_client.clone(),
+                cmd_table.clone(),
+                executor.clone(),
+                leader_gate.clone(),
+            )
+            .await;
+        }
 
         // Send the response immediately for pipelining
         let response = client.take_reply();
@@ -415,8 +425,26 @@ async fn process_command_batch(
         let encoder_version = client.resp_version();
         let mut encoder = RespEncoder::new(encoder_version);
         encoder.encode_resp_data(&response);
+        let encoded_response = encoder.get_response();
 
-        match client.write(encoder.get_response().as_ref()).await {
+        if response_writes_cancelled {
+            continue;
+        }
+
+        let write_result = tokio::select! {
+            biased;
+
+            _ = shutdown.cancelled() => {
+                response_writes_cancelled = true;
+                None
+            }
+            result = client.write(encoded_response.as_ref()) => Some(result),
+        };
+        let Some(write_result) = write_result else {
+            continue;
+        };
+
+        match write_result {
             Ok(_) => debug!("Pipelined response sent successfully"),
             Err(e) => {
                 error!("Write error in pipeline: {}", e);
@@ -424,6 +452,8 @@ async fn process_command_batch(
             }
         }
     }
+
+    response_writes_cancelled
 }
 
 /// Enhanced error response generation for storage failures
@@ -516,11 +546,40 @@ fn generate_storage_error_response(error: &DualRuntimeError, command: &str) -> R
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use client::StreamTrait;
     use cmd::table::create_command_table;
     use executor::CmdExecutorBuilder;
     use runtime::{MessageChannel, StorageClient as RuntimeStorageClient};
+    use std::future::pending;
     use std::sync::Arc;
     use std::time::Duration;
+    use tokio::sync::Semaphore;
+
+    struct BlockingWriteStream {
+        inbound: Option<Vec<u8>>,
+        write_started: Arc<Semaphore>,
+    }
+
+    #[async_trait]
+    impl StreamTrait for BlockingWriteStream {
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error> {
+            let Some(inbound) = self.inbound.take() else {
+                return pending::<Result<usize, std::io::Error>>().await;
+            };
+            assert!(
+                inbound.len() <= buf.len(),
+                "test payload exceeds read buffer"
+            );
+            buf[..inbound.len()].copy_from_slice(&inbound);
+            Ok(inbound.len())
+        }
+
+        async fn write(&mut self, _data: &[u8]) -> Result<usize, std::io::Error> {
+            self.write_started.add_permits(1);
+            pending::<Result<usize, std::io::Error>>().await
+        }
+    }
 
     fn create_test_components() -> (
         Arc<crate::storage_client::StorageClient>,
@@ -547,6 +606,45 @@ mod tests {
         // For now, we'll just test that the storage client is healthy
         // without creating actual network connections
         assert!(storage_client.is_healthy());
+    }
+
+    #[tokio::test]
+    async fn shutdown_unblocks_response_write_and_finishes_commands_from_same_read() {
+        let write_started = Arc::new(Semaphore::new(0));
+        let client = Arc::new(Client::new(Box::new(BlockingWriteStream {
+            inbound: Some(b"*1\r\n$4\r\nPING\r\n*2\r\n$4\r\nAUTH\r\n$6\r\nsecret\r\n".to_vec()),
+            write_started: write_started.clone(),
+        })));
+        let (storage_client, _cmd_table, executor) = create_test_components();
+        let cmd_table = Arc::new(create_command_table(Arc::new(|| {
+            Some("secret".to_string())
+        })));
+        let shutdown = CancellationToken::new();
+        let connection_task = tokio::spawn(process_network_connection_until_cancelled(
+            client.clone(),
+            storage_client,
+            cmd_table,
+            executor,
+            None,
+            shutdown.clone(),
+        ));
+
+        let write_permit = tokio::time::timeout(Duration::from_secs(1), write_started.acquire())
+            .await
+            .expect("first response write did not start")
+            .expect("write-start semaphore closed");
+        drop(write_permit);
+        shutdown.cancel();
+
+        tokio::time::timeout(Duration::from_secs(1), connection_task)
+            .await
+            .expect("connection stayed blocked in response write after shutdown")
+            .expect("connection task panicked")
+            .expect("connection processing failed");
+        assert!(
+            client.is_authenticated(),
+            "AUTH from the same socket read did not reach a terminal result"
+        );
     }
 
     #[test]

--- a/src/net/src/network_server.rs
+++ b/src/net/src/network_server.rs
@@ -550,21 +550,23 @@ impl NetworkServer {
 
         while let Some(join_result) = connection_tasks.join_next().await {
             self.lifecycle.connection_reaped();
-            if let Err(error) = join_result {
-                if server_error.is_none() {
+            match join_result {
+                Err(error) if server_error.is_none() => {
                     server_error = Some(std::io::Error::other(format!(
                         "network connection task failed during shutdown: {error}"
                     )));
                 }
+                _ => {}
             }
         }
 
-        if let Err(error) = cleanup_task.join().await {
-            if server_error.is_none() {
+        match cleanup_task.join().await {
+            Err(error) if server_error.is_none() => {
                 server_error = Some(std::io::Error::other(format!(
                     "network pool cleanup task failed: {error}"
                 )));
             }
+            _ => {}
         }
 
         self.connection_pool.clear_idle().await;

--- a/src/net/src/network_server.rs
+++ b/src/net/src/network_server.rs
@@ -119,6 +119,9 @@ pub struct NetworkLifecycleStats {
     pub accepted_connection_tasks: u64,
     pub completed_connection_tasks: u64,
     pub reaped_connection_tasks: u64,
+    /// Connection tasks that ended with a Tokio `JoinError`, including panic
+    /// and cancellation. Ordinary protocol and socket errors are not counted.
+    pub failed_connection_tasks: u64,
     pub tracked_connection_tasks: usize,
     pub max_tracked_connection_tasks: usize,
     pub pool_cleanup_running: bool,
@@ -130,6 +133,7 @@ struct NetworkLifecycleCounters {
     accepted_connection_tasks: AtomicU64,
     completed_connection_tasks: AtomicU64,
     reaped_connection_tasks: AtomicU64,
+    failed_connection_tasks: AtomicU64,
     tracked_connection_tasks: AtomicUsize,
     max_tracked_connection_tasks: AtomicUsize,
     pool_cleanup_running: AtomicBool,
@@ -160,11 +164,16 @@ impl NetworkLifecycleCounters {
         debug_assert!(result.is_ok(), "reaped an untracked connection task");
     }
 
+    fn connection_failed(&self) {
+        self.failed_connection_tasks.fetch_add(1, Ordering::SeqCst);
+    }
+
     fn snapshot(&self) -> NetworkLifecycleStats {
         NetworkLifecycleStats {
             accepted_connection_tasks: self.accepted_connection_tasks.load(Ordering::SeqCst),
             completed_connection_tasks: self.completed_connection_tasks.load(Ordering::SeqCst),
             reaped_connection_tasks: self.reaped_connection_tasks.load(Ordering::SeqCst),
+            failed_connection_tasks: self.failed_connection_tasks.load(Ordering::SeqCst),
             tracked_connection_tasks: self.tracked_connection_tasks.load(Ordering::SeqCst),
             max_tracked_connection_tasks: self.max_tracked_connection_tasks.load(Ordering::SeqCst),
             pool_cleanup_running: self.pool_cleanup_running.load(Ordering::SeqCst),
@@ -334,6 +343,14 @@ impl NetworkServer {
         self.lifecycle.snapshot()
     }
 
+    fn record_connection_join(&self, join_result: Result<(), tokio::task::JoinError>) {
+        self.lifecycle.connection_reaped();
+        if let Err(error) = join_result {
+            self.lifecycle.connection_failed();
+            warn!("network connection task failed: {error}");
+        }
+    }
+
     /// Check if the server is healthy
     pub fn is_healthy(&self) -> bool {
         self.storage_client.is_healthy()
@@ -461,13 +478,7 @@ impl NetworkServer {
                 _ = shutdown.cancelled() => break,
                 join_result = connection_tasks.join_next(), if !connection_tasks.is_empty() => {
                     if let Some(join_result) = join_result {
-                        self.lifecycle.connection_reaped();
-                        if let Err(error) = join_result {
-                            server_error = Some(std::io::Error::other(format!(
-                                "network connection task failed: {error}"
-                            )));
-                            break;
-                        }
+                        self.record_connection_join(join_result);
                     }
                 }
                 accept_result = listener.accept() => {
@@ -549,15 +560,7 @@ impl NetworkServer {
         lifecycle_shutdown.cancel();
 
         while let Some(join_result) = connection_tasks.join_next().await {
-            self.lifecycle.connection_reaped();
-            match join_result {
-                Err(error) if server_error.is_none() => {
-                    server_error = Some(std::io::Error::other(format!(
-                        "network connection task failed during shutdown: {error}"
-                    )));
-                }
-                _ => {}
-            }
+            self.record_connection_join(join_result);
         }
 
         match cleanup_task.join().await {
@@ -681,6 +684,39 @@ mod tests {
         assert!(server.is_ok());
         let server = server.unwrap();
         assert_eq!(server.addr(), "127.0.0.1:7379");
+    }
+
+    #[tokio::test]
+    async fn live_connection_task_panic_is_recorded_without_stopping_server() {
+        let message_channel = Arc::new(MessageChannel::new(1000));
+        let runtime_client = Arc::new(RuntimeStorageClient::new(
+            message_channel,
+            Duration::from_secs(30),
+        ));
+        let storage_client = Arc::new(crate::storage_client::StorageClient::new(runtime_client));
+        let cmd_table = Arc::new(create_command_table(Arc::new(|| None)));
+        let executor = Arc::new(CmdExecutorBuilder::new().build());
+        let server = NetworkServer::new(
+            Some("127.0.0.1:0".to_string()),
+            storage_client,
+            cmd_table,
+            executor,
+            None,
+            None,
+        )
+        .expect("network server");
+        server.lifecycle.connection_spawned();
+
+        let join_error = tokio::spawn(async { panic!("simulated connection panic") })
+            .await
+            .expect_err("connection task unexpectedly completed");
+        server.lifecycle.connection_completed();
+        server.record_connection_join(Err(join_error));
+
+        let stats = server.lifecycle_stats();
+        assert_eq!(stats.failed_connection_tasks, 1);
+        assert_eq!(stats.reaped_connection_tasks, 1);
+        assert_eq!(stats.tracked_connection_tasks, 0);
     }
 
     #[test]

--- a/src/net/src/network_server.rs
+++ b/src/net/src/network_server.rs
@@ -17,6 +17,7 @@
 
 use std::error::Error;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -26,7 +27,9 @@ use cmd::table::CmdTable;
 use executor::CmdExecutor;
 use log::{info, warn};
 use tokio::net::TcpListener;
+use tokio::task::{JoinHandle, JoinSet};
 use tokio::time::interval;
+use tokio_util::sync::CancellationToken;
 
 use crate::ServerTrait;
 use crate::pool::{ConnectionPool, PoolConfig};
@@ -43,11 +46,156 @@ fn default_network_pool_config() -> PoolConfig {
     }
 }
 
+fn create_lifecycle_shutdown(shutdown: &CancellationToken) -> CancellationToken {
+    shutdown.child_token()
+}
+
+const SERVER_STATE_NEW: u8 = 0;
+const SERVER_STATE_BINDING: u8 = 1;
+const SERVER_STATE_BOUND: u8 = 2;
+const SERVER_STATE_RUNNING: u8 = 3;
+const SERVER_STATE_TERMINATED: u8 = 4;
+
+struct BindStateGuard<'a> {
+    state: &'a AtomicU8,
+    committed: bool,
+}
+
+impl BindStateGuard<'_> {
+    fn commit(&mut self) {
+        self.committed = true;
+        self.state.store(SERVER_STATE_BOUND, Ordering::Release);
+    }
+}
+
+impl Drop for BindStateGuard<'_> {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.state.store(SERVER_STATE_NEW, Ordering::Release);
+        }
+    }
+}
+
+struct RunStateGuard<'a> {
+    state: &'a AtomicU8,
+    was_bound: bool,
+}
+
+impl Drop for RunStateGuard<'_> {
+    fn drop(&mut self) {
+        self.state.store(SERVER_STATE_TERMINATED, Ordering::Release);
+    }
+}
+
+struct AbortOnDropJoinHandle<T> {
+    handle: JoinHandle<T>,
+}
+
+impl<T> AbortOnDropJoinHandle<T> {
+    fn new(handle: JoinHandle<T>) -> Self {
+        Self { handle }
+    }
+
+    async fn join(&mut self) -> Result<T, tokio::task::JoinError> {
+        (&mut self.handle).await
+    }
+}
+
+impl<T> Drop for AbortOnDropJoinHandle<T> {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
 /// Network connection handler resources that can be pooled
 pub struct NetworkResources {
     pub storage_client: Arc<StorageClient>,
     pub cmd_table: Arc<CmdTable>,
     pub executor: Arc<CmdExecutor>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NetworkLifecycleStats {
+    pub accepted_connection_tasks: u64,
+    pub completed_connection_tasks: u64,
+    pub reaped_connection_tasks: u64,
+    pub tracked_connection_tasks: usize,
+    pub max_tracked_connection_tasks: usize,
+    pub pool_cleanup_running: bool,
+    pub pool_cleanup_finished: bool,
+}
+
+#[derive(Default)]
+struct NetworkLifecycleCounters {
+    accepted_connection_tasks: AtomicU64,
+    completed_connection_tasks: AtomicU64,
+    reaped_connection_tasks: AtomicU64,
+    tracked_connection_tasks: AtomicUsize,
+    max_tracked_connection_tasks: AtomicUsize,
+    pool_cleanup_running: AtomicBool,
+    pool_cleanup_finished: AtomicBool,
+}
+
+impl NetworkLifecycleCounters {
+    fn connection_spawned(&self) {
+        self.accepted_connection_tasks
+            .fetch_add(1, Ordering::SeqCst);
+        let tracked = self.tracked_connection_tasks.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_tracked_connection_tasks
+            .fetch_max(tracked, Ordering::SeqCst);
+    }
+
+    fn connection_completed(&self) {
+        self.completed_connection_tasks
+            .fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn connection_reaped(&self) {
+        self.reaped_connection_tasks.fetch_add(1, Ordering::SeqCst);
+        let result = self.tracked_connection_tasks.fetch_update(
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+            |tracked| tracked.checked_sub(1),
+        );
+        debug_assert!(result.is_ok(), "reaped an untracked connection task");
+    }
+
+    fn snapshot(&self) -> NetworkLifecycleStats {
+        NetworkLifecycleStats {
+            accepted_connection_tasks: self.accepted_connection_tasks.load(Ordering::SeqCst),
+            completed_connection_tasks: self.completed_connection_tasks.load(Ordering::SeqCst),
+            reaped_connection_tasks: self.reaped_connection_tasks.load(Ordering::SeqCst),
+            tracked_connection_tasks: self.tracked_connection_tasks.load(Ordering::SeqCst),
+            max_tracked_connection_tasks: self.max_tracked_connection_tasks.load(Ordering::SeqCst),
+            pool_cleanup_running: self.pool_cleanup_running.load(Ordering::SeqCst),
+            pool_cleanup_finished: self.pool_cleanup_finished.load(Ordering::SeqCst),
+        }
+    }
+}
+
+struct ConnectionTaskCompletion {
+    lifecycle: Arc<NetworkLifecycleCounters>,
+}
+
+impl Drop for ConnectionTaskCompletion {
+    fn drop(&mut self) {
+        self.lifecycle.connection_completed();
+    }
+}
+
+struct PoolCleanupCompletion {
+    lifecycle: Arc<NetworkLifecycleCounters>,
+}
+
+impl Drop for PoolCleanupCompletion {
+    fn drop(&mut self) {
+        self.lifecycle
+            .pool_cleanup_running
+            .store(false, Ordering::SeqCst);
+        self.lifecycle
+            .pool_cleanup_finished
+            .store(true, Ordering::SeqCst);
+    }
 }
 
 /// NetworkServer replaces TcpServer with dual runtime architecture support
@@ -71,6 +219,8 @@ pub struct NetworkServer {
     leader_gate: Option<std::sync::Arc<dyn raft::leader_gate::LeaderGate>>,
     /// Pre-bound listener for tests that need an ephemeral port.
     listener: Mutex<Option<TcpListener>>,
+    lifecycle: Arc<NetworkLifecycleCounters>,
+    lifecycle_state: AtomicU8,
 }
 
 impl NetworkServer {
@@ -96,6 +246,8 @@ impl NetworkServer {
             requirepass,
             leader_gate,
             listener: Mutex::new(None),
+            lifecycle: Arc::new(NetworkLifecycleCounters::default()),
+            lifecycle_state: AtomicU8::new(SERVER_STATE_NEW),
         })
     }
 
@@ -118,30 +270,47 @@ impl NetworkServer {
             requirepass,
             leader_gate,
             listener: Mutex::new(None),
+            lifecycle: Arc::new(NetworkLifecycleCounters::default()),
+            lifecycle_state: AtomicU8::new(SERVER_STATE_NEW),
         })
     }
 
-    /// Start background task for connection pool cleanup
-    async fn start_pool_cleanup(&self) {
+    /// Start a cancellable background task for connection pool cleanup.
+    fn start_pool_cleanup(&self, shutdown: CancellationToken) -> JoinHandle<()> {
         let pool = self.connection_pool.clone();
+        let lifecycle = self.lifecycle.clone();
+        lifecycle
+            .pool_cleanup_finished
+            .store(false, Ordering::SeqCst);
+        lifecycle.pool_cleanup_running.store(true, Ordering::SeqCst);
+
         tokio::spawn(async move {
+            let _completion = PoolCleanupCompletion {
+                lifecycle: lifecycle.clone(),
+            };
             let mut cleanup_interval = interval(Duration::from_secs(60)); // Cleanup every minute
 
             loop {
-                cleanup_interval.tick().await;
-                pool.cleanup_idle().await;
+                tokio::select! {
+                    biased;
 
-                let stats = pool.stats().await;
-                if stats.active_connections > 0 || stats.available_connections > 0 {
-                    info!(
-                        "Network server pool stats - Active: {}, Available: {}, Max: {}",
-                        stats.active_connections,
-                        stats.available_connections,
-                        stats.max_connections
-                    );
+                    _ = shutdown.cancelled() => break,
+                    _ = cleanup_interval.tick() => {
+                        pool.cleanup_idle().await;
+
+                        let stats = pool.stats().await;
+                        if stats.active_connections > 0 || stats.available_connections > 0 {
+                            info!(
+                                "Network server pool stats - Active: {}, Available: {}, Max: {}",
+                                stats.active_connections,
+                                stats.available_connections,
+                                stats.max_connections
+                            );
+                        }
+                    }
                 }
             }
-        });
+        })
     }
 
     /// Get the server address
@@ -159,6 +328,12 @@ impl NetworkServer {
         self.connection_pool.stats().await
     }
 
+    /// Return lifecycle counters used to verify that completed connection tasks
+    /// are reaped while the server remains online.
+    pub fn lifecycle_stats(&self) -> NetworkLifecycleStats {
+        self.lifecycle.snapshot()
+    }
+
     /// Check if the server is healthy
     pub fn is_healthy(&self) -> bool {
         self.storage_client.is_healthy()
@@ -170,19 +345,90 @@ impl NetworkServer {
     /// while still querying the actual bound address. If `run()` is called
     /// without calling `bind()` first, it binds lazily as before.
     pub async fn bind(&self) -> Result<SocketAddr, Box<dyn Error>> {
+        self.lifecycle_state
+            .compare_exchange(
+                SERVER_STATE_NEW,
+                SERVER_STATE_BINDING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .map_err(|state| {
+                let message = match state {
+                    SERVER_STATE_BINDING => "network server bind already in progress",
+                    SERVER_STATE_BOUND => "network server already bound",
+                    SERVER_STATE_RUNNING => "network server already running",
+                    SERVER_STATE_TERMINATED => "network server already terminated",
+                    _ => "network server has an invalid lifecycle state",
+                };
+                std::io::Error::other(message)
+            })?;
+        let mut state_guard = BindStateGuard {
+            state: &self.lifecycle_state,
+            committed: false,
+        };
         let listener = TcpListener::bind(&self.addr).await?;
         let addr = listener.local_addr()?;
         *self
             .listener
             .lock()
             .expect("network server listener lock poisoned") = Some(listener);
+        state_guard.commit();
         Ok(addr)
     }
-}
 
-#[async_trait]
-impl ServerTrait for NetworkServer {
-    async fn run(&self) -> Result<(), Box<dyn Error>> {
+    fn begin_run(&self) -> Result<RunStateGuard<'_>, Box<dyn Error>> {
+        loop {
+            let state = self.lifecycle_state.load(Ordering::Acquire);
+            let was_bound = match state {
+                SERVER_STATE_NEW => false,
+                SERVER_STATE_BOUND => true,
+                SERVER_STATE_BINDING => {
+                    return Err(Box::new(std::io::Error::other(
+                        "network server bind already in progress",
+                    )));
+                }
+                SERVER_STATE_RUNNING => {
+                    return Err(Box::new(std::io::Error::other(
+                        "network server already running",
+                    )));
+                }
+                SERVER_STATE_TERMINATED => {
+                    return Err(Box::new(std::io::Error::other(
+                        "network server already terminated",
+                    )));
+                }
+                _ => {
+                    return Err(Box::new(std::io::Error::other(
+                        "network server has an invalid lifecycle state",
+                    )));
+                }
+            };
+
+            if self
+                .lifecycle_state
+                .compare_exchange(
+                    state,
+                    SERVER_STATE_RUNNING,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+            {
+                return Ok(RunStateGuard {
+                    state: &self.lifecycle_state,
+                    was_bound,
+                });
+            }
+        }
+    }
+
+    /// Run the network server until cancellation and wait for every owned task
+    /// to finish before returning.
+    pub async fn run_until_cancelled(
+        &self,
+        shutdown: CancellationToken,
+    ) -> Result<(), Box<dyn Error>> {
+        let run_state = self.begin_run()?;
         let listener = {
             let mut guard = self
                 .listener
@@ -190,79 +436,159 @@ impl ServerTrait for NetworkServer {
                 .expect("network server listener lock poisoned");
             guard.take()
         };
-        let listener = match listener {
-            Some(listener) => listener,
-            None => TcpListener::bind(&self.addr).await?,
+        let listener = match (listener, run_state.was_bound) {
+            (Some(listener), _) => listener,
+            (None, false) => TcpListener::bind(&self.addr).await?,
+            (None, true) => {
+                return Err(Box::new(std::io::Error::other(
+                    "network server bound listener is missing",
+                )));
+            }
         };
 
         info!("NetworkServer listening on: {}", listener.local_addr()?);
 
-        // Start background cleanup task
-        self.start_pool_cleanup().await;
+        let lifecycle_shutdown = create_lifecycle_shutdown(&shutdown);
+        let mut cleanup_task =
+            AbortOnDropJoinHandle::new(self.start_pool_cleanup(lifecycle_shutdown.child_token()));
+        let mut connection_tasks = JoinSet::new();
+        let mut server_error = None;
 
         loop {
-            let (socket, client_addr) = listener.accept().await?;
+            tokio::select! {
+                biased;
 
-            let pool = self.connection_pool.clone();
-            let storage_client = self.storage_client.clone();
-            let cmd_table = self.cmd_table.clone();
-            let executor = self.executor.clone();
-            let requirepass = self.requirepass.clone();
-            let leader_gate = self.leader_gate.clone();
-
-            tokio::spawn(async move {
-                // Get or create resources from the pool
-                let pooled_resources = match pool
-                    .get_connection(|| async {
-                        Ok(NetworkResources {
-                            storage_client: storage_client.clone(),
-                            cmd_table: cmd_table.clone(),
-                            executor: executor.clone(),
-                        })
-                    })
-                    .await
-                {
-                    Ok(resources) => resources,
-                    Err(e) => {
-                        warn!(
-                            "Failed to get network resources from pool for {}: {}",
-                            client_addr, e
-                        );
-                        return;
+                _ = shutdown.cancelled() => break,
+                join_result = connection_tasks.join_next(), if !connection_tasks.is_empty() => {
+                    if let Some(join_result) = join_result {
+                        self.lifecycle.connection_reaped();
+                        if let Err(error) = join_result {
+                            server_error = Some(std::io::Error::other(format!(
+                                "network connection task failed: {error}"
+                            )));
+                            break;
+                        }
                     }
-                };
-
-                // Create client for this specific connection.
-                // `Client::new` is fail-closed (`authenticated = false`); when
-                // no password is configured we must grant authentication here.
-                let stream = TcpStreamWrapper::new(socket);
-                let client = Arc::new(Client::new(Box::new(stream)));
-
-                if requirepass.is_none() {
-                    client.set_authenticated(true);
                 }
+                accept_result = listener.accept() => {
+                    let (socket, client_addr) = match accept_result {
+                        Ok(connection) => connection,
+                        Err(error) => {
+                            server_error = Some(error);
+                            break;
+                        }
+                    };
 
-                // Process the connection
-                let result = crate::handle::process_connection_with_storage_client(
-                    client,
-                    pooled_resources.inner().storage_client.clone(),
-                    pooled_resources.inner().cmd_table.clone(),
-                    pooled_resources.inner().executor.clone(),
-                    leader_gate,
-                )
-                .await;
+                    let pool = self.connection_pool.clone();
+                    let storage_client = self.storage_client.clone();
+                    let cmd_table = self.cmd_table.clone();
+                    let executor = self.executor.clone();
+                    let requirepass = self.requirepass.clone();
+                    let leader_gate = self.leader_gate.clone();
+                    let connection_shutdown = lifecycle_shutdown.child_token();
+                    let lifecycle = self.lifecycle.clone();
+                    lifecycle.connection_spawned();
 
-                if let Err(e) = result {
-                    warn!(
-                        "Network connection processing error for {}: {}",
-                        client_addr, e
-                    );
+                    connection_tasks.spawn(async move {
+                        let _completion = ConnectionTaskCompletion {
+                            lifecycle: lifecycle.clone(),
+                        };
+
+                        let pooled_resources = tokio::select! {
+                            biased;
+
+                            _ = connection_shutdown.cancelled() => return,
+                            result = pool.get_connection(|| async {
+                                Ok(NetworkResources {
+                                    storage_client: storage_client.clone(),
+                                    cmd_table: cmd_table.clone(),
+                                    executor: executor.clone(),
+                                })
+                            }) => match result {
+                                Ok(resources) => resources,
+                                Err(error) => {
+                                    warn!(
+                                        "Failed to get network resources from pool for {}: {}",
+                                        client_addr, error
+                                    );
+                                    return;
+                                }
+                            },
+                        };
+
+                        let stream = TcpStreamWrapper::new(socket);
+                        let client = Arc::new(Client::new(Box::new(stream)));
+                        if requirepass.is_none() {
+                            client.set_authenticated(true);
+                        }
+
+                        let result =
+                            crate::handle::process_connection_with_storage_client_until_cancelled(
+                            client,
+                            pooled_resources.inner().storage_client.clone(),
+                            pooled_resources.inner().cmd_table.clone(),
+                            pooled_resources.inner().executor.clone(),
+                            leader_gate,
+                            connection_shutdown,
+                        )
+                        .await;
+                        if let Err(error) = result {
+                            warn!(
+                                "Network connection processing error for {}: {}",
+                                client_addr, error
+                            );
+                        }
+
+                        pool.return_connection(pooled_resources).await;
+                    });
                 }
-
-                // Return resources to pool
-                pool.return_connection(pooled_resources).await;
-            });
+            }
         }
+
+        drop(listener);
+        lifecycle_shutdown.cancel();
+
+        while let Some(join_result) = connection_tasks.join_next().await {
+            self.lifecycle.connection_reaped();
+            if let Err(error) = join_result {
+                if server_error.is_none() {
+                    server_error = Some(std::io::Error::other(format!(
+                        "network connection task failed during shutdown: {error}"
+                    )));
+                }
+            }
+        }
+
+        if let Err(error) = cleanup_task.join().await {
+            if server_error.is_none() {
+                server_error = Some(std::io::Error::other(format!(
+                    "network pool cleanup task failed: {error}"
+                )));
+            }
+        }
+
+        self.connection_pool.clear_idle().await;
+        let pool_stats = self.connection_pool.stats().await;
+        if (pool_stats.active_connections != 0 || pool_stats.available_connections != 0)
+            && server_error.is_none()
+        {
+            server_error = Some(std::io::Error::other(format!(
+                "network pool not empty after shutdown: active={}, available={}",
+                pool_stats.active_connections, pool_stats.available_connections
+            )));
+        }
+
+        match server_error {
+            Some(error) => Err(Box::new(error)),
+            None => Ok(()),
+        }
+    }
+}
+
+#[async_trait]
+impl ServerTrait for NetworkServer {
+    async fn run(&self) -> Result<(), Box<dyn Error>> {
+        self.run_until_cancelled(CancellationToken::new()).await
     }
 }
 
@@ -353,5 +679,15 @@ mod tests {
         assert!(server.is_ok());
         let server = server.unwrap();
         assert_eq!(server.addr(), "127.0.0.1:7379");
+    }
+
+    #[test]
+    fn lifecycle_shutdown_is_cancelled_synchronously_with_parent() {
+        let shutdown = CancellationToken::new();
+        let lifecycle_shutdown = create_lifecycle_shutdown(&shutdown);
+
+        shutdown.cancel();
+
+        assert!(lifecycle_shutdown.is_cancelled());
     }
 }

--- a/src/net/src/pool.rs
+++ b/src/net/src/pool.rs
@@ -241,6 +241,19 @@ where
             log::debug!("Cleaned up {} idle connections from pool", removed_count);
         }
     }
+
+    /// Drop every currently available connection, regardless of the configured
+    /// minimum. Active connections are unaffected and remain accounted for by
+    /// their semaphore permits.
+    pub async fn clear_idle(&self) -> usize {
+        let removed = {
+            let mut available = self.available.lock().await;
+            available.drain(..).collect::<Vec<_>>()
+        };
+        let removed_count = removed.len();
+        drop(removed);
+        removed_count
+    }
 }
 
 /// Pool statistics
@@ -364,5 +377,25 @@ mod tests {
 
         let active_stats = pool.stats().await;
         assert_eq!(active_stats.active_connections, 1);
+    }
+
+    #[tokio::test]
+    async fn clear_idle_connections_removes_all_available_entries() {
+        let pool = ConnectionPool::new(PoolConfig {
+            max_connections: 2,
+            connection_timeout: Duration::from_millis(100),
+            idle_timeout: Duration::from_secs(60),
+            min_connections: 1,
+        });
+        let connection = pool
+            .get_connection(|| async { Ok(MockConnection { id: 1 }) })
+            .await
+            .expect("create pooled connection");
+        pool.return_connection(connection).await;
+
+        assert_eq!(pool.clear_idle().await, 1);
+        let stats = pool.stats().await;
+        assert_eq!(stats.active_connections, 0);
+        assert_eq!(stats.available_connections, 0);
     }
 }

--- a/src/net/tests/storage_command_e2e_tests.rs
+++ b/src/net/tests/storage_command_e2e_tests.rs
@@ -15,6 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::unwrap_used)]
+
 //! End-to-end regression tests for the unified storage command dispatch path.
 //!
 //! These tests start a full dual-runtime stack (real `RuntimeManager`, RocksDB
@@ -32,7 +34,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
-use net::{ServerTrait, network_server::NetworkServer, storage_client::StorageClient};
+use net::network_server::NetworkServer;
+use net::storage_client::StorageClient;
 use resp::{
     Parse, RespData, RespEncode, RespParse, RespParseResult, RespVersion, encode::RespEncoder,
 };
@@ -42,6 +45,8 @@ use runtime::{
 };
 use storage::{StorageOptions, safe_cleanup_test_db, storage::Storage, unique_test_db_path};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 /// A full dual-runtime test stack with a bound TCP endpoint.
 struct TestServer {
@@ -49,6 +54,9 @@ struct TestServer {
     runtime_manager: RuntimeManager,
     db_path: PathBuf,
     storage_client: Arc<StorageClient>,
+    network_server: Arc<NetworkServer>,
+    network_shutdown: CancellationToken,
+    network_task: Option<JoinHandle<Result<(), String>>>,
 }
 
 impl TestServer {
@@ -110,9 +118,14 @@ impl TestServer {
         );
         let addr = network_server.bind().await.expect("bind network server");
 
+        let network_shutdown = CancellationToken::new();
+        let shutdown_for_task = network_shutdown.clone();
         let server_clone = network_server.clone();
-        network_handle.spawn(async move {
-            let _ = server_clone.run().await;
+        let network_task = network_handle.spawn(async move {
+            server_clone
+                .run_until_cancelled(shutdown_for_task)
+                .await
+                .map_err(|error| error.to_string())
         });
 
         // Start the storage server on the storage runtime.
@@ -136,11 +149,32 @@ impl TestServer {
             runtime_manager,
             db_path,
             storage_client: net_storage_client,
+            network_server,
+            network_shutdown,
+            network_task: Some(network_task),
+        }
+    }
+
+    async fn stop_network(&mut self) -> Result<(), String> {
+        self.network_shutdown.cancel();
+        self.wait_for_network_stop().await
+    }
+
+    async fn wait_for_network_stop(&mut self) -> Result<(), String> {
+        let Some(network_task) = self.network_task.take() else {
+            return Ok(());
+        };
+
+        match tokio::time::timeout(Duration::from_secs(1), network_task).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(error)) => Err(format!("network task join failed: {error}")),
+            Err(_) => Err("network task did not stop within one second".to_string()),
         }
     }
 
     /// Stop the runtimes and clean up the temporary storage directory.
     async fn shutdown(mut self) {
+        self.stop_network().await.expect("stop network server");
         let _ = tokio::time::timeout(Duration::from_secs(5), self.runtime_manager.stop()).await;
         safe_cleanup_test_db(&self.db_path);
     }
@@ -244,6 +278,473 @@ async fn send_command_and_read_line(stream: &mut tokio::net::TcpStream, args: &[
     })
     .await
     .expect("timed out waiting for RESP line")
+}
+
+async fn wait_for_connection_tasks_reaped(server: &NetworkServer, minimum_accepted: u64) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+    loop {
+        let stats = server.lifecycle_stats();
+        if stats.accepted_connection_tasks >= minimum_accepted
+            && stats.completed_connection_tasks == stats.accepted_connection_tasks
+            && stats.reaped_connection_tasks == stats.accepted_connection_tasks
+            && stats.tracked_connection_tasks == 0
+        {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "connection tasks did not drain: {stats:?}"
+        );
+        tokio::task::yield_now().await;
+    }
+}
+
+async fn wait_for_idle_pool_entry(server: &NetworkServer) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+    loop {
+        let stats = server.pool_stats().await;
+        if stats.active_connections == 0 && stats.available_connections > 0 {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "network resource did not return to pool: {stats:?}"
+        );
+        tokio::task::yield_now().await;
+    }
+}
+
+#[tokio::test]
+async fn network_server_cancel_stops_listener_and_existing_connection() {
+    let mut server = TestServer::start(None).await;
+    let mut stream = tokio::net::TcpStream::connect(server.addr)
+        .await
+        .expect("connect to server");
+
+    let reply = send_command(&mut stream, &["PING"]).await;
+    assert_eq!(reply, RespData::SimpleString(Bytes::from_static(b"PONG")));
+
+    let key = "cancelled-connection-must-not-write";
+    server.network_shutdown.cancel();
+    let command = encode_command(&["SET", key, "unexpected"]);
+    let _ = stream.write_all(command.as_ref()).await;
+    server
+        .wait_for_network_stop()
+        .await
+        .expect("cancel network server");
+
+    let reply = server
+        .storage_client
+        .execute_command(b"GET", &[b"GET".to_vec(), key.as_bytes().to_vec()])
+        .await
+        .expect("read directly through storage client");
+    assert_eq!(
+        reply,
+        RespData::BulkString(None),
+        "the keep-alive connection executed SET after cancellation"
+    );
+
+    assert!(
+        tokio::net::TcpStream::connect(server.addr).await.is_err(),
+        "listener still accepted connections after shutdown completed"
+    );
+
+    let mut byte = [0u8; 1];
+    match tokio::time::timeout(Duration::from_secs(1), stream.read(&mut byte)).await {
+        Ok(Ok(0)) | Ok(Err(_)) => {}
+        Ok(Ok(_)) => panic!("existing connection returned a response after cancellation"),
+        Err(_) => panic!("existing connection remained open after cancellation"),
+    }
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn network_server_reaps_short_lived_connection_tasks_while_running() {
+    const WAVE_SIZE: u64 = 8;
+    const WAVES: u64 = 8;
+
+    let server = TestServer::start(None).await;
+    wait_for_connection_tasks_reaped(&server.network_server, 1).await;
+    let baseline = server.network_server.lifecycle_stats();
+
+    for wave in 1..=WAVES {
+        for _ in 0..WAVE_SIZE {
+            let mut stream = tokio::net::TcpStream::connect(server.addr)
+                .await
+                .expect("connect short-lived client");
+            let reply = send_command(&mut stream, &["PING"]).await;
+            assert_eq!(reply, RespData::SimpleString(Bytes::from_static(b"PONG")));
+            stream
+                .shutdown()
+                .await
+                .expect("shutdown short-lived client");
+        }
+
+        wait_for_connection_tasks_reaped(
+            &server.network_server,
+            baseline.accepted_connection_tasks + wave * WAVE_SIZE,
+        )
+        .await;
+    }
+
+    let stats = server.network_server.lifecycle_stats();
+    assert_eq!(stats.tracked_connection_tasks, 0);
+    assert_eq!(
+        stats.reaped_connection_tasks,
+        stats.accepted_connection_tasks
+    );
+    assert!(stats.reaped_connection_tasks >= baseline.reaped_connection_tasks + WAVE_SIZE * WAVES);
+    assert!(
+        stats.max_tracked_connection_tasks <= WAVE_SIZE as usize,
+        "tracked task high-water mark followed historical connections: {stats:?}"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn network_server_protocol_error_only_closes_the_bad_connection() {
+    let server = TestServer::start(None).await;
+    let mut malformed = tokio::net::TcpStream::connect(server.addr)
+        .await
+        .expect("connect malformed client");
+    malformed
+        .write_all(b"$not-a-number\r\n")
+        .await
+        .expect("write malformed RESP");
+    let mut byte = [0u8; 1];
+    match tokio::time::timeout(Duration::from_secs(1), malformed.read(&mut byte)).await {
+        Ok(Ok(0)) | Ok(Err(_)) => {}
+        Ok(Ok(_)) => panic!("malformed connection unexpectedly received a response"),
+        Err(_) => panic!("malformed connection was not closed"),
+    }
+
+    let mut healthy = tokio::net::TcpStream::connect(server.addr)
+        .await
+        .expect("connect healthy client after protocol error");
+    assert_eq!(
+        send_command(&mut healthy, &["PING"]).await,
+        RespData::SimpleString(Bytes::from_static(b"PONG"))
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn network_server_shutdown_joins_cleanup_clears_pool_and_releases_channel() {
+    let mut message_channel = runtime::MessageChannel::new(16);
+    let mut request_receiver = message_channel
+        .take_request_receiver()
+        .expect("take request receiver");
+    let message_channel = Arc::new(message_channel);
+    let runtime_storage_client = Arc::new(runtime::StorageClient::new(
+        message_channel.clone(),
+        Duration::from_secs(1),
+    ));
+    let storage_client = Arc::new(StorageClient::new(runtime_storage_client.clone()));
+    let cmd_table = Arc::new(cmd::table::create_command_table(Arc::new(|| None)));
+    let executor = Arc::new(executor::CmdExecutorBuilder::new().build());
+    let server = Arc::new(
+        NetworkServer::new(
+            Some("127.0.0.1:0".to_string()),
+            storage_client.clone(),
+            cmd_table,
+            executor,
+            None,
+            None,
+        )
+        .expect("network server"),
+    );
+    let addr = server.bind().await.expect("bind network server");
+    let shutdown = CancellationToken::new();
+    let shutdown_for_task = shutdown.clone();
+    let server_for_task = server.clone();
+    let network_task = tokio::spawn(async move {
+        server_for_task
+            .run_until_cancelled(shutdown_for_task)
+            .await
+            .map_err(|error| error.to_string())
+    });
+
+    let mut stream = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("connect to server");
+    assert_eq!(
+        send_command(&mut stream, &["PING"]).await,
+        RespData::SimpleString(Bytes::from_static(b"PONG"))
+    );
+    stream.shutdown().await.expect("shutdown client");
+    wait_for_idle_pool_entry(&server).await;
+
+    shutdown.cancel();
+    tokio::time::timeout(Duration::from_secs(1), network_task)
+        .await
+        .expect("network shutdown timeout")
+        .expect("network task join")
+        .expect("network server shutdown");
+
+    let pool_stats = server.pool_stats().await;
+    assert_eq!(pool_stats.active_connections, 0);
+    assert_eq!(pool_stats.available_connections, 0);
+    let lifecycle_stats = server.lifecycle_stats();
+    assert!(!lifecycle_stats.pool_cleanup_running);
+    assert!(lifecycle_stats.pool_cleanup_finished);
+
+    drop(server);
+    drop(storage_client);
+    drop(runtime_storage_client);
+    drop(message_channel);
+
+    assert!(
+        tokio::time::timeout(Duration::from_secs(1), request_receiver.recv())
+            .await
+            .expect("request receiver EOF timeout")
+            .is_none(),
+        "request receiver remained open after the minimal ownership chain was dropped"
+    );
+}
+
+#[tokio::test]
+async fn network_server_abort_releases_cleanup_pool_and_storage_sender() {
+    let mut message_channel = runtime::MessageChannel::new(16);
+    let mut request_receiver = message_channel
+        .take_request_receiver()
+        .expect("take request receiver");
+    let message_channel = Arc::new(message_channel);
+    let runtime_storage_client = Arc::new(runtime::StorageClient::new(
+        message_channel.clone(),
+        Duration::from_secs(1),
+    ));
+    let storage_client = Arc::new(StorageClient::new(runtime_storage_client.clone()));
+    let server = Arc::new(
+        NetworkServer::new(
+            Some("127.0.0.1:0".to_string()),
+            storage_client.clone(),
+            Arc::new(cmd::table::create_command_table(Arc::new(|| None))),
+            Arc::new(executor::CmdExecutorBuilder::new().build()),
+            None,
+            None,
+        )
+        .expect("network server"),
+    );
+    let addr = server.bind().await.expect("bind network server");
+    let server_for_task = server.clone();
+    let network_task = tokio::spawn(async move {
+        server_for_task
+            .run_until_cancelled(CancellationToken::new())
+            .await
+            .map_err(|error| error.to_string())
+    });
+
+    let mut stream = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("connect to server");
+    assert_eq!(
+        send_command(&mut stream, &["PING"]).await,
+        RespData::SimpleString(Bytes::from_static(b"PONG"))
+    );
+    stream.shutdown().await.expect("shutdown client");
+    wait_for_idle_pool_entry(&server).await;
+
+    network_task.abort();
+    let join_error = network_task
+        .await
+        .expect_err("aborted network task joined cleanly");
+    assert!(join_error.is_cancelled());
+
+    let repeated_error = server
+        .run_until_cancelled(CancellationToken::new())
+        .await
+        .expect_err("aborted server ran again");
+    assert!(repeated_error.to_string().contains("already terminated"));
+    assert!(server.bind().await.is_err(), "aborted server rebound");
+
+    drop(server);
+    drop(storage_client);
+    drop(runtime_storage_client);
+    drop(message_channel);
+
+    assert!(
+        tokio::time::timeout(Duration::from_secs(1), request_receiver.recv())
+            .await
+            .expect("request receiver EOF timeout after abort")
+            .is_none(),
+        "detached cleanup task retained a pooled storage sender after abort"
+    );
+}
+
+#[tokio::test]
+async fn network_server_waits_for_inflight_storage_request_before_shutdown() {
+    let message_channel = Arc::new(runtime::MessageChannel::new(1));
+    let request_sender = message_channel.request_sender();
+    let (response_sender, _response_receiver) = tokio::sync::oneshot::channel();
+    request_sender
+        .send(runtime::StorageRequest {
+            id: runtime::RequestId::new(),
+            command: runtime::StorageCommand::Execute {
+                cmd_name: b"GET".to_vec(),
+                argv: vec![b"GET".to_vec(), b"channel-saturation".to_vec()],
+            },
+            response_channel: response_sender,
+            timeout: Duration::from_secs(1),
+            timestamp: std::time::Instant::now(),
+            priority: runtime::RequestPriority::Normal,
+        })
+        .await
+        .expect("saturate storage request channel");
+
+    let runtime_storage_client = Arc::new(runtime::StorageClient::new(
+        message_channel.clone(),
+        Duration::from_millis(250),
+    ));
+    let storage_client = Arc::new(StorageClient::new(runtime_storage_client.clone()));
+    let server = Arc::new(
+        NetworkServer::new(
+            Some("127.0.0.1:0".to_string()),
+            storage_client,
+            Arc::new(cmd::table::create_command_table(Arc::new(|| None))),
+            Arc::new(executor::CmdExecutorBuilder::new().build()),
+            None,
+            None,
+        )
+        .expect("network server"),
+    );
+    let addr = server.bind().await.expect("bind network server");
+    let shutdown = CancellationToken::new();
+    let shutdown_for_task = shutdown.clone();
+    let server_for_task = server.clone();
+    let network_task = tokio::spawn(async move {
+        server_for_task
+            .run_until_cancelled(shutdown_for_task)
+            .await
+            .map_err(|error| error.to_string())
+    });
+
+    let mut stream = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("connect to server");
+    assert_eq!(
+        send_command(&mut stream, &["PING"]).await,
+        RespData::SimpleString(Bytes::from_static(b"PONG"))
+    );
+    stream
+        .write_all(encode_command(&["SET", "inflight", "value"]).as_ref())
+        .await
+        .expect("start storage command");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+    while runtime_storage_client.pending_request_count().await == 0 {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "storage command never entered pending state"
+        );
+        tokio::task::yield_now().await;
+    }
+
+    shutdown.cancel();
+    tokio::time::timeout(Duration::from_secs(1), network_task)
+        .await
+        .expect("network shutdown timeout")
+        .expect("network task join")
+        .expect("network server shutdown");
+    assert_eq!(
+        runtime_storage_client.pending_request_count().await,
+        0,
+        "cancellation dropped an in-flight storage future and leaked pending state"
+    );
+}
+
+#[tokio::test]
+async fn network_server_rejects_concurrent_and_repeated_run() {
+    let message_channel = Arc::new(runtime::MessageChannel::new(16));
+    let runtime_storage_client = Arc::new(runtime::StorageClient::new(
+        message_channel,
+        Duration::from_secs(1),
+    ));
+    let server = Arc::new(
+        NetworkServer::new(
+            Some("127.0.0.1:0".to_string()),
+            Arc::new(StorageClient::new(runtime_storage_client)),
+            Arc::new(cmd::table::create_command_table(Arc::new(|| None))),
+            Arc::new(executor::CmdExecutorBuilder::new().build()),
+            None,
+            None,
+        )
+        .expect("network server"),
+    );
+    let addr = server.bind().await.expect("bind network server");
+    let shutdown = CancellationToken::new();
+    let shutdown_for_task = shutdown.clone();
+    let server_for_task = server.clone();
+    let first_run = tokio::spawn(async move {
+        server_for_task
+            .run_until_cancelled(shutdown_for_task)
+            .await
+            .map_err(|error| error.to_string())
+    });
+
+    let mut stream = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("connect to first run");
+    assert_eq!(
+        send_command(&mut stream, &["PING"]).await,
+        RespData::SimpleString(Bytes::from_static(b"PONG"))
+    );
+
+    let concurrent_error = tokio::time::timeout(
+        Duration::from_millis(100),
+        server.run_until_cancelled(CancellationToken::new()),
+    )
+    .await
+    .expect("concurrent run did not fail fast")
+    .expect_err("concurrent run unexpectedly succeeded");
+    assert!(concurrent_error.to_string().contains("already running"));
+
+    assert_eq!(
+        send_command(&mut stream, &["PING"]).await,
+        RespData::SimpleString(Bytes::from_static(b"PONG")),
+        "failed concurrent run disrupted the active server"
+    );
+
+    shutdown.cancel();
+    tokio::time::timeout(Duration::from_secs(1), first_run)
+        .await
+        .expect("first run shutdown timeout")
+        .expect("first run join")
+        .expect("first run shutdown");
+
+    let repeated_error = tokio::time::timeout(
+        Duration::from_millis(100),
+        server.run_until_cancelled(CancellationToken::new()),
+    )
+    .await
+    .expect("repeated run did not fail fast")
+    .expect_err("repeated run unexpectedly succeeded");
+    assert!(repeated_error.to_string().contains("already terminated"));
+    assert!(server.bind().await.is_err(), "terminated server rebound");
+}
+
+#[tokio::test]
+async fn network_server_rejects_duplicate_bind() {
+    let message_channel = Arc::new(runtime::MessageChannel::new(16));
+    let runtime_storage_client = Arc::new(runtime::StorageClient::new(
+        message_channel,
+        Duration::from_secs(1),
+    ));
+    let server = NetworkServer::new(
+        Some("127.0.0.1:0".to_string()),
+        Arc::new(StorageClient::new(runtime_storage_client)),
+        Arc::new(cmd::table::create_command_table(Arc::new(|| None))),
+        Arc::new(executor::CmdExecutorBuilder::new().build()),
+        None,
+        None,
+    )
+    .expect("network server");
+
+    server.bind().await.expect("first bind");
+    let error = server.bind().await.expect_err("duplicate bind succeeded");
+    assert!(error.to_string().contains("already bound"));
 }
 
 #[tokio::test]

--- a/src/net/tests/storage_command_e2e_tests.rs
+++ b/src/net/tests/storage_command_e2e_tests.rs
@@ -580,17 +580,16 @@ async fn network_server_waits_for_inflight_storage_request_before_shutdown() {
     let request_sender = message_channel.request_sender();
     let (response_sender, _response_receiver) = tokio::sync::oneshot::channel();
     request_sender
-        .send(runtime::StorageRequest {
-            id: runtime::RequestId::new(),
-            command: runtime::StorageCommand::Execute {
+        .send(runtime::StorageRequest::new(
+            runtime::RequestId::new(),
+            runtime::StorageCommand::Execute {
                 cmd_name: b"GET".to_vec(),
                 argv: vec![b"GET".to_vec(), b"channel-saturation".to_vec()],
             },
-            response_channel: response_sender,
-            timeout: Duration::from_secs(1),
-            timestamp: std::time::Instant::now(),
-            priority: runtime::RequestPriority::Normal,
-        })
+            response_sender,
+            Duration::from_secs(1),
+            runtime::RequestPriority::Normal,
+        ))
         .await
         .expect("saturate storage request channel");
 

--- a/src/net/tests/storage_command_e2e_tests.rs
+++ b/src/net/tests/storage_command_e2e_tests.rs
@@ -34,6 +34,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
+use client::Client;
+use cmd::{AclCategory, Cmd, CmdFlags, CmdMeta};
 use net::network_server::NetworkServer;
 use net::storage_client::StorageClient;
 use resp::{
@@ -47,6 +49,43 @@ use storage::{StorageOptions, safe_cleanup_test_db, storage::Storage, unique_tes
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+
+#[derive(Clone)]
+struct PanickingPingCmd {
+    meta: CmdMeta,
+}
+
+impl PanickingPingCmd {
+    fn new() -> Self {
+        Self {
+            meta: CmdMeta {
+                name: "ping".to_string(),
+                arity: -1,
+                flags: CmdFlags::READONLY | CmdFlags::FAST | CmdFlags::NO_AUTH,
+                acl_category: AclCategory::FAST | AclCategory::CONNECTION,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl Cmd for PanickingPingCmd {
+    fn meta(&self) -> &CmdMeta {
+        &self.meta
+    }
+
+    fn do_initial(&self, _client: &Client) -> bool {
+        true
+    }
+
+    fn do_cmd(&self, _client: &Client, _storage: Arc<Storage>) {
+        panic!("simulated connection task panic");
+    }
+
+    fn clone_box(&self) -> Box<dyn Cmd> {
+        Box::new(self.clone())
+    }
+}
 
 /// A full dual-runtime test stack with a bound TCP endpoint.
 struct TestServer {
@@ -429,6 +468,93 @@ async fn network_server_protocol_error_only_closes_the_bad_connection() {
     );
 
     server.shutdown().await;
+}
+
+#[tokio::test]
+async fn network_server_continues_after_connection_task_panic() {
+    let message_channel = Arc::new(runtime::MessageChannel::new(16));
+    let runtime_storage_client = Arc::new(runtime::StorageClient::new(
+        message_channel,
+        Duration::from_secs(1),
+    ));
+    let mut cmd_table = cmd::table::create_command_table(Arc::new(|| Some("secret".to_string())));
+    cmd_table.insert("ping".to_string(), Arc::new(PanickingPingCmd::new()));
+    let server = Arc::new(
+        NetworkServer::new(
+            Some("127.0.0.1:0".to_string()),
+            Arc::new(StorageClient::new(runtime_storage_client)),
+            Arc::new(cmd_table),
+            Arc::new(executor::CmdExecutorBuilder::new().build()),
+            Some("secret".to_string()),
+            None,
+        )
+        .expect("network server"),
+    );
+    let addr = server.bind().await.expect("bind network server");
+    let shutdown = CancellationToken::new();
+    let server_for_task = server.clone();
+    let shutdown_for_task = shutdown.clone();
+    let network_task = tokio::spawn(async move {
+        server_for_task
+            .run_until_cancelled(shutdown_for_task)
+            .await
+            .map_err(|error| error.to_string())
+    });
+
+    let mut panicking_client = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("connect panicking client");
+    panicking_client
+        .write_all(encode_command(&["PING"]).as_ref())
+        .await
+        .expect("send panicking command");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+    loop {
+        let stats = server.lifecycle_stats();
+        if stats.failed_connection_tasks == 1
+            && stats.reaped_connection_tasks >= 1
+            && stats.tracked_connection_tasks == 0
+        {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "panicking connection task was not recorded and reaped: {stats:?}"
+        );
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        !network_task.is_finished(),
+        "one connection panic stopped the network server"
+    );
+
+    let mut healthy_client = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("connect healthy client after panic");
+    assert_eq!(
+        send_command(&mut healthy_client, &["AUTH", "secret"]).await,
+        RespData::SimpleString(Bytes::from_static(b"OK"))
+    );
+
+    shutdown.cancel();
+    tokio::time::timeout(Duration::from_secs(1), network_task)
+        .await
+        .expect("network shutdown timeout")
+        .expect("network task join")
+        .expect("network server shutdown");
+
+    let stats = server.lifecycle_stats();
+    assert_eq!(stats.failed_connection_tasks, 1);
+    assert_eq!(
+        stats.accepted_connection_tasks,
+        stats.completed_connection_tasks
+    );
+    assert_eq!(
+        stats.accepted_connection_tasks,
+        stats.reaped_connection_tasks
+    );
+    assert_eq!(stats.tracked_connection_tasks, 0);
 }
 
 #[tokio::test]

--- a/tools/runtime-baseline/Cargo.toml
+++ b/tools/runtime-baseline/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 description = "Kiwi storage runtime baseline harness"
 repository.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 build = "build.rs"
 
 [[bin]]

--- a/tools/runtime-baseline/Cargo.toml
+++ b/tools/runtime-baseline/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "runtime-baseline"
+version.workspace = true
+description = "Kiwi storage runtime baseline harness"
+repository.workspace = true
+edition.workspace = true
+build = "build.rs"
+
+[[bin]]
+name = "kiwi-runtime-baseline"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/tools/runtime-baseline/Cargo.toml
+++ b/tools/runtime-baseline/Cargo.toml
@@ -18,5 +18,8 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tempfile.workspace = true
 
+[dev-dependencies]
+yaml_serde = "0.10.4"
+
 [lints]
 workspace = true

--- a/tools/runtime-baseline/build.rs
+++ b/tools/runtime-baseline/build.rs
@@ -1,0 +1,73 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+#[path = "build_support.rs"]
+mod build_support;
+
+use build_support::BuildIdentity;
+
+const BUILD_GIT_SHA_ENV: &str = "KIWI_BASELINE_BUILD_GIT_SHA";
+
+fn main() {
+    if let Err(error) = configure_build_identity() {
+        panic!("failed to configure runtime baseline build identity: {error}");
+    }
+}
+
+fn configure_build_identity() -> Result<(), String> {
+    println!("cargo:rerun-if-env-changed={BUILD_GIT_SHA_ENV}");
+
+    let source_root = source_root()?;
+    let explicit_git_sha = match env::var(BUILD_GIT_SHA_ENV) {
+        Ok(git_sha) => Some(git_sha),
+        Err(env::VarError::NotPresent) => None,
+        Err(error) => return Err(format!("cannot read {BUILD_GIT_SHA_ENV}: {error}")),
+    };
+    let identity = BuildIdentity::collect(&source_root, explicit_git_sha.as_deref())?;
+    for path in identity.rerun_paths {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+
+    println!(
+        "cargo:rustc-env=KIWI_BASELINE_COMPILED_GIT_SHA={}",
+        identity.compiled_git_sha
+    );
+    println!(
+        "cargo:rustc-env=KIWI_BASELINE_SOURCE_DIRTY={}",
+        identity.source_dirty
+    );
+    Ok(())
+}
+
+fn source_root() -> Result<PathBuf, String> {
+    let manifest_dir = PathBuf::from(
+        env::var("CARGO_MANIFEST_DIR").map_err(|error| format!("CARGO_MANIFEST_DIR: {error}"))?,
+    );
+    manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .ok_or_else(|| {
+            format!(
+                "cannot locate workspace root from {}",
+                manifest_dir.display()
+            )
+        })
+}

--- a/tools/runtime-baseline/build.rs
+++ b/tools/runtime-baseline/build.rs
@@ -35,12 +35,12 @@ fn configure_build_identity() -> Result<(), String> {
     println!("cargo:rerun-if-env-changed={BUILD_GIT_SHA_ENV}");
 
     let source_root = source_root()?;
-    let explicit_git_sha = match env::var(BUILD_GIT_SHA_ENV) {
+    let expected_git_sha = match env::var(BUILD_GIT_SHA_ENV) {
         Ok(git_sha) => Some(git_sha),
         Err(env::VarError::NotPresent) => None,
         Err(error) => return Err(format!("cannot read {BUILD_GIT_SHA_ENV}: {error}")),
     };
-    let identity = BuildIdentity::collect(&source_root, explicit_git_sha.as_deref())?;
+    let identity = BuildIdentity::collect(&source_root, expected_git_sha.as_deref())?;
     for path in identity.rerun_paths {
         println!("cargo:rerun-if-changed={}", path.display());
     }

--- a/tools/runtime-baseline/build_support.rs
+++ b/tools/runtime-baseline/build_support.rs
@@ -1,0 +1,279 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SOURCE_INPUTS: &[&str] = &[
+    "Cargo.toml",
+    "Cargo.lock",
+    "rust-toolchain.toml",
+    ".cargo",
+    "src",
+    "tools/runtime-baseline/Cargo.toml",
+    "tools/runtime-baseline/build.rs",
+    "tools/runtime-baseline/build_support.rs",
+    "tools/runtime-baseline/src",
+    "tools/runtime-baseline/tests",
+];
+const SOURCE_EXCLUSIONS: &[&str] = &[
+    ":(exclude,glob)**/.git",
+    ":(exclude,glob)**/.git/**",
+    ":(exclude,glob)**/target",
+    ":(exclude,glob)**/target/**",
+    ":(exclude,glob)**/results",
+    ":(exclude,glob)**/results/**",
+];
+
+pub struct BuildIdentity {
+    pub compiled_git_sha: String,
+    pub source_dirty: bool,
+    pub rerun_paths: BTreeSet<PathBuf>,
+}
+
+#[allow(dead_code)]
+pub struct GitMetadata {
+    pub dot_git: PathBuf,
+    pub git_dir: PathBuf,
+    pub common_dir: PathBuf,
+    pub rerun_paths: BTreeSet<PathBuf>,
+}
+
+impl BuildIdentity {
+    pub fn collect(source_root: &Path, explicit_git_sha: Option<&str>) -> Result<Self, String> {
+        let metadata = GitMetadata::discover(source_root)?;
+        let git_sha = match explicit_git_sha {
+            Some(git_sha) => git_sha.to_owned(),
+            None => metadata
+                .git_output(source_root, &["rev-parse", "HEAD"])?
+                .trim()
+                .to_owned(),
+        };
+        validate_git_sha(&git_sha, "KIWI_BASELINE_BUILD_GIT_SHA")?;
+
+        let mut status_arguments = vec!["status", "--porcelain", "--untracked-files=all", "--"];
+        status_arguments.extend(SOURCE_INPUTS);
+        status_arguments.extend(SOURCE_EXCLUSIONS);
+        let source_dirty = !metadata
+            .git_output(source_root, &status_arguments)?
+            .trim()
+            .is_empty();
+        let source_paths = source_rerun_paths(source_root, &metadata)?;
+        let mut rerun_paths = metadata.rerun_paths;
+        rerun_paths.extend(source_paths);
+
+        Ok(Self {
+            compiled_git_sha: git_sha.to_ascii_lowercase(),
+            source_dirty,
+            rerun_paths,
+        })
+    }
+}
+
+impl GitMetadata {
+    pub fn discover(source_root: &Path) -> Result<Self, String> {
+        let dot_git = source_root.join(".git");
+        let git_dir = if dot_git.is_dir() {
+            accessible_path(&dot_git, source_root)
+        } else {
+            let contents = fs::read_to_string(&dot_git)
+                .map_err(|error| format!("cannot read {}: {error}", dot_git.display()))?;
+            git_dir_from_gitfile(&dot_git, source_root, &contents)?
+        };
+        let commondir = git_dir.join("commondir");
+        let common_dir = if commondir.is_file() {
+            let contents = fs::read_to_string(&commondir)
+                .map_err(|error| format!("cannot read {}: {error}", commondir.display()))?;
+            let relative = contents.trim();
+            if relative.is_empty() {
+                return Err(format!("{} is empty", commondir.display()));
+            }
+            accessible_path(Path::new(relative), &git_dir)
+        } else {
+            git_dir.clone()
+        };
+        let head = git_dir.join("HEAD");
+        let index = git_dir.join("index");
+        let packed_refs = common_dir.join("packed-refs");
+        let mut rerun_paths =
+            BTreeSet::from([dot_git.clone(), head.clone(), index, commondir, packed_refs]);
+
+        if let Some(reference) = symbolic_head_reference(&head)? {
+            let reference = accessible_path(&reference, &common_dir);
+            if let Some(parent) = reference.parent() {
+                rerun_paths.insert(parent.to_path_buf());
+            }
+            rerun_paths.insert(reference);
+        }
+
+        Ok(Self {
+            dot_git,
+            git_dir,
+            common_dir,
+            rerun_paths,
+        })
+    }
+
+    fn git_output(&self, source_root: &Path, args: &[&str]) -> Result<String, String> {
+        let output = run_git(source_root, self, args)?;
+        String::from_utf8(output.stdout)
+            .map_err(|error| format!("git output is not UTF-8: {error}"))
+    }
+}
+
+pub fn git_dir_from_gitfile(
+    dot_git: &Path,
+    source_root: &Path,
+    contents: &str,
+) -> Result<PathBuf, String> {
+    let git_dir = contents
+        .trim()
+        .strip_prefix("gitdir:")
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .ok_or_else(|| format!("{} is not a valid Git gitfile", dot_git.display()))?;
+    Ok(accessible_path(Path::new(git_dir), source_root))
+}
+
+pub fn accessible_path(path: &Path, relative_to: &Path) -> PathBuf {
+    let raw = path.as_os_str().to_string_lossy();
+    let resolved = if let Some(converted) = windows_path_to_wsl(&raw) {
+        converted
+    } else if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        relative_to.join(path)
+    };
+    let accessible = resolved.canonicalize().unwrap_or(resolved);
+    strip_windows_verbatim_prefix(accessible)
+}
+
+fn symbolic_head_reference(head: &Path) -> Result<Option<PathBuf>, String> {
+    let contents = fs::read_to_string(head)
+        .map_err(|error| format!("cannot read {}: {error}", head.display()))?;
+    Ok(contents
+        .trim()
+        .strip_prefix("ref: ")
+        .map(|reference| PathBuf::from(reference.trim())))
+}
+
+fn source_rerun_paths(
+    source_root: &Path,
+    metadata: &GitMetadata,
+) -> Result<BTreeSet<PathBuf>, String> {
+    let mut paths = SOURCE_INPUTS
+        .iter()
+        .map(|path| source_root.join(path))
+        .collect::<BTreeSet<_>>();
+
+    for command in [
+        ["ls-files", "-z"].as_slice(),
+        ["ls-files", "--others", "--exclude-standard", "-z"].as_slice(),
+    ] {
+        let mut arguments = command.to_vec();
+        arguments.push("--");
+        arguments.extend(SOURCE_INPUTS);
+        arguments.extend(SOURCE_EXCLUSIONS);
+        let output = metadata.git_output(source_root, &arguments)?;
+        for path in output.split('\0').filter(|path| !path.is_empty()) {
+            paths.insert(source_root.join(path));
+        }
+    }
+
+    Ok(paths)
+}
+
+fn validate_git_sha(git_sha: &str, source: &str) -> Result<(), String> {
+    if git_sha.len() != 40 || !git_sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(format!(
+            "{source} must be a 40-character hexadecimal Git SHA"
+        ));
+    }
+    Ok(())
+}
+
+fn run_git(source_root: &Path, metadata: &GitMetadata, args: &[&str]) -> Result<Output, String> {
+    for candidate in git_candidates() {
+        match Command::new(candidate)
+            .arg(format!("--git-dir={}", metadata.git_dir.display()))
+            .arg(format!("--work-tree={}", source_root.display()))
+            .args(args)
+            .current_dir(source_root)
+            .output()
+        {
+            Ok(output) if output.status.success() => return Ok(output),
+            Ok(_) | Err(_) => continue,
+        }
+    }
+
+    Err(format!(
+        "git {} failed in {}",
+        args.join(" "),
+        source_root.display()
+    ))
+}
+
+#[cfg(unix)]
+fn git_candidates() -> &'static [&'static str] {
+    &["git", "git.exe"]
+}
+
+#[cfg(not(unix))]
+fn git_candidates() -> &'static [&'static str] {
+    &["git"]
+}
+
+#[cfg(unix)]
+fn windows_path_to_wsl(raw: &str) -> Option<PathBuf> {
+    let bytes = raw.as_bytes();
+    if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'\\' | b'/')
+    {
+        let drive = (bytes[0] as char).to_ascii_lowercase();
+        let suffix = raw[3..].replace('\\', "/");
+        return Some(PathBuf::from(format!("/mnt/{drive}/{suffix}")));
+    }
+
+    None
+}
+
+#[cfg(not(unix))]
+fn windows_path_to_wsl(_: &str) -> Option<PathBuf> {
+    None
+}
+
+#[cfg(windows)]
+fn strip_windows_verbatim_prefix(path: PathBuf) -> PathBuf {
+    let raw = path.to_string_lossy();
+    if let Some(path) = raw.strip_prefix(r"\\?\UNC\") {
+        return PathBuf::from(format!(r"\\{path}"));
+    }
+    if let Some(path) = raw.strip_prefix(r"\\?\") {
+        return PathBuf::from(path);
+    }
+    drop(raw);
+    path
+}
+
+#[cfg(not(windows))]
+fn strip_windows_verbatim_prefix(path: PathBuf) -> PathBuf {
+    path
+}

--- a/tools/runtime-baseline/build_support.rs
+++ b/tools/runtime-baseline/build_support.rs
@@ -55,16 +55,19 @@ pub struct GitMetadata {
 }
 
 impl BuildIdentity {
-    pub fn collect(source_root: &Path, explicit_git_sha: Option<&str>) -> Result<Self, String> {
+    pub fn collect(source_root: &Path, expected_git_sha: Option<&str>) -> Result<Self, String> {
         let metadata = GitMetadata::discover(source_root)?;
-        let git_sha = match explicit_git_sha {
-            Some(git_sha) => git_sha.to_owned(),
-            None => metadata
-                .git_output(source_root, &["rev-parse", "HEAD"])?
-                .trim()
-                .to_owned(),
-        };
-        validate_git_sha(&git_sha, "KIWI_BASELINE_BUILD_GIT_SHA")?;
+        let git_sha = metadata
+            .git_output(source_root, &["rev-parse", "HEAD"])?
+            .trim()
+            .to_owned();
+        validate_git_sha(&git_sha, "git rev-parse HEAD")?;
+        if let Some(expected_git_sha) = expected_git_sha {
+            validate_git_sha(expected_git_sha, "KIWI_BASELINE_BUILD_GIT_SHA")?;
+            if !expected_git_sha.eq_ignore_ascii_case(&git_sha) {
+                return Err("KIWI_BASELINE_BUILD_GIT_SHA does not match checkout HEAD".to_owned());
+            }
+        }
 
         let mut status_arguments = vec!["status", "--porcelain", "--untracked-files=all", "--"];
         status_arguments.extend(SOURCE_INPUTS);

--- a/tools/runtime-baseline/build_support.rs
+++ b/tools/runtime-baseline/build_support.rs
@@ -49,7 +49,6 @@ pub struct BuildIdentity {
 
 #[allow(dead_code)]
 pub struct GitMetadata {
-    pub dot_git: PathBuf,
     pub git_dir: PathBuf,
     pub common_dir: PathBuf,
     pub rerun_paths: BTreeSet<PathBuf>,
@@ -123,7 +122,6 @@ impl GitMetadata {
         }
 
         Ok(Self {
-            dot_git,
             git_dir,
             common_dir,
             rerun_paths,

--- a/tools/runtime-baseline/build_support.rs
+++ b/tools/runtime-baseline/build_support.rs
@@ -41,6 +41,13 @@ const SOURCE_EXCLUSIONS: &[&str] = &[
     ":(exclude,glob)**/results/**",
 ];
 
+pub fn source_status_arguments() -> Vec<&'static str> {
+    let mut arguments = vec!["status", "--porcelain", "--untracked-files=all", "--"];
+    arguments.extend(SOURCE_INPUTS);
+    arguments.extend(SOURCE_EXCLUSIONS);
+    arguments
+}
+
 pub struct BuildIdentity {
     pub compiled_git_sha: String,
     pub source_dirty: bool,
@@ -69,9 +76,7 @@ impl BuildIdentity {
             }
         }
 
-        let mut status_arguments = vec!["status", "--porcelain", "--untracked-files=all", "--"];
-        status_arguments.extend(SOURCE_INPUTS);
-        status_arguments.extend(SOURCE_EXCLUSIONS);
+        let status_arguments = source_status_arguments();
         let source_dirty = !metadata
             .git_output(source_root, &status_arguments)?
             .trim()

--- a/tools/runtime-baseline/build_support.rs
+++ b/tools/runtime-baseline/build_support.rs
@@ -140,12 +140,14 @@ pub fn git_dir_from_gitfile(
     source_root: &Path,
     contents: &str,
 ) -> Result<PathBuf, String> {
-    let git_dir = contents
+    let Some(git_dir) = contents
         .trim()
         .strip_prefix("gitdir:")
         .map(str::trim)
         .filter(|path| !path.is_empty())
-        .ok_or_else(|| format!("{} is not a valid Git gitfile", dot_git.display()))?;
+    else {
+        return Err(format!("{} is not a valid Git gitfile", dot_git.display()));
+    };
     Ok(accessible_path(Path::new(git_dir), source_root))
 }
 

--- a/tools/runtime-baseline/src/cli.rs
+++ b/tools/runtime-baseline/src/cli.rs
@@ -82,7 +82,7 @@ impl ServerArgs {
         let normalized_metrics_output =
             normalize_output_path("metrics-output", &self.metrics_output)?;
 
-        if normalized_startup_event == normalized_metrics_output {
+        if output_paths_may_alias(&normalized_startup_event, &normalized_metrics_output) {
             bail!("startup-event and metrics-output must be distinct paths");
         }
         if normalized_startup_event.starts_with(&normalized_data_dir)
@@ -115,6 +115,30 @@ impl ServerArgs {
     }
 }
 
+fn output_paths_may_alias(first: &Path, second: &Path) -> bool {
+    if first == second {
+        return true;
+    }
+
+    #[cfg(any(windows, target_os = "macos"))]
+    {
+        first.parent() == second.parent()
+            && first
+                .file_name()
+                .zip(second.file_name())
+                .is_some_and(|(first, second)| {
+                    first
+                        .as_encoded_bytes()
+                        .eq_ignore_ascii_case(second.as_encoded_bytes())
+                })
+    }
+
+    #[cfg(not(any(windows, target_os = "macos")))]
+    {
+        false
+    }
+}
+
 fn validate_loopback(name: &str, address: SocketAddr) -> Result<()> {
     if !address.ip().is_loopback() {
         bail!("{name} must use a loopback address");
@@ -143,6 +167,10 @@ fn normalize_output_path(name: &str, path: &Path) -> Result<PathBuf> {
     let file_name = path
         .file_name()
         .with_context(|| format!("{name} must name an output file"))?;
+    #[cfg(any(windows, target_os = "macos"))]
+    if !file_name.as_encoded_bytes().is_ascii() {
+        bail!("{name} file name must use ASCII characters on this platform");
+    }
     let parent = parent
         .canonicalize()
         .with_context(|| format!("cannot canonicalize {name} parent {}", parent.display()))?;

--- a/tools/runtime-baseline/src/cli.rs
+++ b/tools/runtime-baseline/src/cli.rs
@@ -1,0 +1,214 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::OsString;
+use std::net::SocketAddr;
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use clap::{ArgAction, Parser};
+
+/// Parameters accepted by the benchmark-only target.
+#[derive(Clone, Debug, Parser)]
+#[command(name = "kiwi-runtime-baseline")]
+pub struct ServerArgs {
+    #[arg(long, default_value = "127.0.0.1:0")]
+    pub listen: SocketAddr,
+    #[arg(long, default_value = "127.0.0.1:0")]
+    pub control_listen: SocketAddr,
+    #[arg(long)]
+    pub data_dir: PathBuf,
+    #[arg(long)]
+    pub startup_event: PathBuf,
+    #[arg(long)]
+    pub metrics_output: PathBuf,
+    #[arg(long)]
+    pub expected_git_sha: Option<String>,
+    #[arg(long, default_value_t = 1)]
+    pub network_threads: usize,
+    #[arg(long, default_value_t = 1)]
+    pub storage_threads: usize,
+    #[arg(long, default_value_t = 1024)]
+    pub channel_capacity: usize,
+    #[arg(long, default_value_t = 30_000)]
+    pub request_timeout_ms: u64,
+    #[arg(long, default_value_t = false, action = ArgAction::Set)]
+    pub batching: bool,
+    #[arg(long, default_value_t = 100)]
+    pub batch_size: usize,
+    #[arg(long, default_value_t = 10)]
+    pub batch_timeout_ms: u64,
+    #[arg(
+        long,
+        default_value = "off",
+        action = ArgAction::Set,
+        value_parser = parse_on_off
+    )]
+    pub instrumentation: bool,
+    #[arg(long, default_value_t = 8192)]
+    pub instrumentation_sample_capacity: usize,
+}
+
+fn parse_on_off(value: &str) -> std::result::Result<bool, String> {
+    match value {
+        "on" => Ok(true),
+        "off" => Ok(false),
+        _ => Err("must be one of: on, off".to_owned()),
+    }
+}
+
+impl ServerArgs {
+    /// Reject unsafe target parameters before opening a listener or data store.
+    pub fn validate(&self) -> Result<()> {
+        validate_loopback("listen", self.listen)?;
+        validate_loopback("control-listen", self.control_listen)?;
+        validate_absolute_path("data-dir", &self.data_dir)?;
+        let normalized_data_dir = normalize_data_dir(&self.data_dir)?;
+        let normalized_startup_event = normalize_output_path("startup-event", &self.startup_event)?;
+        let normalized_metrics_output =
+            normalize_output_path("metrics-output", &self.metrics_output)?;
+
+        if normalized_startup_event == normalized_metrics_output {
+            bail!("startup-event and metrics-output must be distinct paths");
+        }
+        if normalized_startup_event.starts_with(&normalized_data_dir)
+            || normalized_metrics_output.starts_with(&normalized_data_dir)
+        {
+            bail!("output paths must not be located under data-dir");
+        }
+        if normalized_data_dir.join("CURRENT").exists() {
+            bail!("data-dir already contains RocksDB CURRENT");
+        }
+        if self.data_dir.exists() && !self.data_dir.is_dir() {
+            bail!("data-dir must be a directory when it exists");
+        }
+        if let Some(expected_git_sha) = &self.expected_git_sha {
+            validate_git_sha("expected-git-sha", expected_git_sha)?;
+        }
+
+        validate_nonzero("network-threads", self.network_threads)?;
+        validate_nonzero("storage-threads", self.storage_threads)?;
+        validate_nonzero("channel-capacity", self.channel_capacity)?;
+        validate_nonzero("request-timeout-ms", self.request_timeout_ms)?;
+        validate_nonzero("batch-size", self.batch_size)?;
+        validate_nonzero("batch-timeout-ms", self.batch_timeout_ms)?;
+        validate_nonzero(
+            "instrumentation-sample-capacity",
+            self.instrumentation_sample_capacity,
+        )?;
+
+        Ok(())
+    }
+}
+
+fn validate_loopback(name: &str, address: SocketAddr) -> Result<()> {
+    if !address.ip().is_loopback() {
+        bail!("{name} must use a loopback address");
+    }
+    Ok(())
+}
+
+fn validate_absolute_path(name: &str, path: &Path) -> Result<()> {
+    if !path.is_absolute() {
+        bail!("{name} must be an absolute path");
+    }
+    Ok(())
+}
+
+fn normalize_output_path(name: &str, path: &Path) -> Result<PathBuf> {
+    validate_absolute_path(name, path)?;
+    let parent = path
+        .parent()
+        .context("absolute output path must have a parent directory")?;
+    if !parent.is_dir() {
+        bail!(
+            "{name} parent directory does not exist: {}",
+            parent.display()
+        );
+    }
+    let file_name = path
+        .file_name()
+        .with_context(|| format!("{name} must name an output file"))?;
+    let parent = parent
+        .canonicalize()
+        .with_context(|| format!("cannot canonicalize {name} parent {}", parent.display()))?;
+    Ok(parent.join(file_name))
+}
+
+fn normalize_data_dir(path: &Path) -> Result<PathBuf> {
+    let mut existing = path.to_path_buf();
+    let mut missing = Vec::new();
+
+    loop {
+        match existing.canonicalize() {
+            Ok(mut normalized) => {
+                for component in missing.into_iter().rev() {
+                    match component {
+                        MissingComponent::Normal(component) => normalized.push(component),
+                        MissingComponent::Parent => {
+                            normalized.pop();
+                        }
+                    }
+                }
+                return Ok(normalized);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let component = existing
+                    .components()
+                    .next_back()
+                    .context("data-dir must contain an existing absolute ancestor")?;
+                match component {
+                    Component::Normal(component) => {
+                        missing.push(MissingComponent::Normal(component.to_os_string()));
+                    }
+                    Component::ParentDir => missing.push(MissingComponent::Parent),
+                    Component::CurDir => {}
+                    Component::Prefix(_) | Component::RootDir => {
+                        return Err(error).context("cannot canonicalize data-dir");
+                    }
+                }
+                if !existing.pop() {
+                    return Err(error).context("cannot canonicalize data-dir");
+                }
+            }
+            Err(error) => return Err(error).context("cannot canonicalize data-dir"),
+        }
+    }
+}
+
+enum MissingComponent {
+    Normal(OsString),
+    Parent,
+}
+
+fn validate_nonzero<T>(name: &str, value: T) -> Result<()>
+where
+    T: TryInto<u128>,
+    T::Error: std::fmt::Debug,
+{
+    if value.try_into().expect("integer converts to u128") == 0 {
+        bail!("{name} must be greater than zero");
+    }
+    Ok(())
+}
+
+pub fn validate_git_sha(name: &str, git_sha: &str) -> Result<()> {
+    if git_sha.len() != 40 || !git_sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!("{name} must be a 40-character hexadecimal Git SHA");
+    }
+    Ok(())
+}

--- a/tools/runtime-baseline/src/lib.rs
+++ b/tools/runtime-baseline/src/lib.rs
@@ -1,0 +1,20 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod cli;
+pub mod schema;
+pub mod startup;

--- a/tools/runtime-baseline/src/main.rs
+++ b/tools/runtime-baseline/src/main.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::process::ExitCode;
+
+use clap::Parser;
+use runtime_baseline::cli::ServerArgs;
+use runtime_baseline::startup::ensure_expected_git_sha;
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("kiwi-runtime-baseline: {error:#}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> anyhow::Result<()> {
+    let args = ServerArgs::parse();
+    args.validate()?;
+    ensure_expected_git_sha(args.expected_git_sha.as_deref())?;
+    anyhow::bail!("harness not initialized")
+}

--- a/tools/runtime-baseline/src/schema.rs
+++ b/tools/runtime-baseline/src/schema.rs
@@ -1,0 +1,87 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+pub const STARTUP_SCHEMA_VERSION: u32 = 1;
+pub const COMPILED_GIT_SHA: &str = env!("KIWI_BASELINE_COMPILED_GIT_SHA");
+
+pub fn source_dirty() -> bool {
+    match env!("KIWI_BASELINE_SOURCE_DIRTY") {
+        "true" => true,
+        "false" => false,
+        value => panic!("KIWI_BASELINE_SOURCE_DIRTY must be true or false, got {value}"),
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum Publishability {
+    Publishable,
+    NonPublishable { reasons: Vec<String> },
+}
+
+impl Publishability {
+    pub fn from_source_dirty(source_dirty: bool) -> Self {
+        if source_dirty {
+            Self::NonPublishable {
+                reasons: vec!["dirty_source_tree".to_owned()],
+            }
+        } else {
+            Self::Publishable
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct StartupEvent {
+    pub schema_version: u32,
+    pub pid: u32,
+    pub redis_addr: SocketAddr,
+    pub control_addr: SocketAddr,
+    pub data_dir: PathBuf,
+    pub git_sha: String,
+    pub publishability: Publishability,
+}
+
+impl StartupEvent {
+    pub fn new(
+        pid: u32,
+        redis_addr: SocketAddr,
+        control_addr: SocketAddr,
+        data_dir: &Path,
+    ) -> Result<Self> {
+        let data_dir = data_dir.canonicalize().with_context(|| {
+            format!("cannot canonicalize data directory {}", data_dir.display())
+        })?;
+        let publishability = Publishability::from_source_dirty(source_dirty());
+
+        Ok(Self {
+            schema_version: STARTUP_SCHEMA_VERSION,
+            pid,
+            redis_addr,
+            control_addr,
+            data_dir,
+            git_sha: COMPILED_GIT_SHA.to_owned(),
+            publishability,
+        })
+    }
+}

--- a/tools/runtime-baseline/src/startup.rs
+++ b/tools/runtime-baseline/src/startup.rs
@@ -1,0 +1,98 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+use std::path::Path;
+
+#[cfg(unix)]
+use std::fs;
+
+use anyhow::{Context, Result, bail};
+use tempfile::NamedTempFile;
+
+use crate::cli::validate_git_sha;
+use crate::schema::{COMPILED_GIT_SHA, StartupEvent};
+
+/// Reject an identity mismatch before the future harness binds listeners.
+pub fn ensure_expected_git_sha(expected_git_sha: Option<&str>) -> Result<()> {
+    let Some(expected_git_sha) = expected_git_sha else {
+        return Ok(());
+    };
+    validate_git_sha("expected-git-sha", expected_git_sha)?;
+    if !expected_git_sha.eq_ignore_ascii_case(COMPILED_GIT_SHA) {
+        bail!("expected Git SHA does not match this binary's compiled identity");
+    }
+    Ok(())
+}
+
+/// Publish a complete startup event by atomically renaming a synced sibling file.
+pub fn write_startup_event_atomically(output: &Path, event: &StartupEvent) -> Result<()> {
+    let parent = output
+        .parent()
+        .context("startup event output must have a parent directory")?;
+    if !parent.is_dir() {
+        bail!(
+            "startup event parent directory does not exist: {}",
+            parent.display()
+        );
+    }
+    if output.exists() {
+        // This is only a friendly fast path; persist_noclobber below enforces no-clobber atomically.
+        bail!("startup event output already exists: {}", output.display());
+    }
+
+    let mut temporary = NamedTempFile::new_in(parent)
+        .with_context(|| format!("cannot create startup event beside {}", output.display()))?;
+    serde_json::to_writer(temporary.as_file_mut(), event)
+        .context("cannot serialize startup event JSON")?;
+    temporary
+        .as_file_mut()
+        .flush()
+        .context("cannot flush temporary startup event")?;
+    temporary
+        .as_file()
+        .sync_all()
+        .context("cannot sync temporary startup event")?;
+    temporary
+        .persist_noclobber(output)
+        .map_err(|error| error.error)
+        .with_context(|| {
+            format!(
+                "cannot atomically publish startup event at {}",
+                output.display()
+            )
+        })?;
+    sync_parent_directory(parent)?;
+    Ok(())
+}
+
+fn sync_parent_directory(parent: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        fs::File::open(parent)
+            .with_context(|| format!("cannot open startup event directory {}", parent.display()))?
+            .sync_all()
+            .with_context(|| format!("cannot sync startup event directory {}", parent.display()))?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = parent;
+    }
+
+    Ok(())
+}

--- a/tools/runtime-baseline/tests/build_identity_test.rs
+++ b/tools/runtime-baseline/tests/build_identity_test.rs
@@ -160,6 +160,36 @@ fn identity_marks_an_untracked_source_change_dirty_and_watches_it() {
 }
 
 #[test]
+fn explicit_build_sha_must_match_checkout_head() {
+    let repo = initialized_repository();
+    let actual_head = git_stdout(repo.path(), &["rev-parse", "HEAD"]);
+    let different_sha = if actual_head == "f".repeat(40) {
+        "e".repeat(40)
+    } else {
+        "f".repeat(40)
+    };
+
+    let error = match BuildIdentity::collect(repo.path(), Some(&different_sha)) {
+        Ok(_) => panic!("an explicit build SHA must identify the checked-out commit"),
+        Err(error) => error,
+    };
+
+    assert!(error.contains("does not match checkout HEAD"));
+}
+
+#[test]
+fn explicit_build_sha_accepts_uppercase_and_embeds_lowercase_head() {
+    let repo = initialized_repository();
+    let actual_head = git_stdout(repo.path(), &["rev-parse", "HEAD"]);
+    let uppercase_head = actual_head.to_ascii_uppercase();
+
+    let identity = BuildIdentity::collect(repo.path(), Some(&uppercase_head))
+        .expect("Git SHA comparison must be case insensitive");
+
+    assert_eq!(identity.compiled_git_sha, actual_head.to_ascii_lowercase());
+}
+
+#[test]
 fn cargo_rebuilds_the_real_build_script_after_a_tracked_source_edit() {
     let fixture = TempDir::new().expect("temporary Cargo fixture");
     create_cargo_fixture(fixture.path());

--- a/tools/runtime-baseline/tests/build_identity_test.rs
+++ b/tools/runtime-baseline/tests/build_identity_test.rs
@@ -1,0 +1,427 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[path = "../build_support.rs"]
+mod build_support;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use build_support::{BuildIdentity, GitMetadata};
+use runtime_baseline::schema::Publishability;
+use tempfile::TempDir;
+
+#[cfg(unix)]
+#[test]
+fn parses_a_windows_gitfile_path_for_wsl() {
+    let repository_root = Path::new("/repo");
+    let dot_git = repository_root.join(".git");
+    let git_dir = build_support::git_dir_from_gitfile(
+        &dot_git,
+        repository_root,
+        "gitdir: D:\\repo\\.git\\worktrees\\baseline\n",
+    )
+    .expect("Windows gitfile path");
+
+    assert_eq!(
+        git_dir,
+        PathBuf::from("/mnt/d/repo/.git/worktrees/baseline")
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn accessible_git_paths_do_not_use_the_windows_verbatim_prefix() {
+    let current_dir = std::env::current_dir().expect("current directory");
+    let accessible = build_support::accessible_path(&current_dir.join(".git"), &current_dir);
+
+    assert!(!accessible.to_string_lossy().starts_with(r"\\?\"));
+}
+
+#[test]
+fn discovers_linked_worktree_metadata_from_gitfile_and_commondir() {
+    let sandbox = TempDir::new().expect("temporary linked-worktree metadata");
+    let common_dir = sandbox.path().join("repository/.git");
+    let git_dir = common_dir.join("worktrees/baseline");
+    let worktree = sandbox.path().join("linked-worktree");
+    let branch_ref = common_dir.join("refs/heads/baseline");
+    fs::create_dir_all(&git_dir).expect("worktree Git directory");
+    fs::create_dir_all(branch_ref.parent().expect("branch ref parent"))
+        .expect("branch ref directory");
+    fs::create_dir(&worktree).expect("linked worktree directory");
+    fs::write(
+        worktree.join(".git"),
+        format!("gitdir: {}\n", git_dir.display()),
+    )
+    .expect("linked worktree gitfile");
+    fs::write(git_dir.join("commondir"), "../..\n").expect("commondir");
+    fs::write(git_dir.join("HEAD"), "ref: refs/heads/baseline\n").expect("HEAD");
+    fs::write(git_dir.join("index"), []).expect("index");
+    fs::write(&branch_ref, "0".repeat(40)).expect("branch ref");
+    fs::write(common_dir.join("packed-refs"), "# pack-refs with: peeled\n").expect("packed refs");
+
+    let metadata = GitMetadata::discover(&worktree).expect("linked worktree metadata");
+    assert_eq!(metadata.dot_git, worktree.join(".git"));
+    assert_eq!(metadata.git_dir, git_dir);
+    assert_eq!(metadata.common_dir, common_dir);
+    for path in [
+        worktree.join(".git"),
+        git_dir.join("HEAD"),
+        git_dir.join("index"),
+        git_dir.join("commondir"),
+        branch_ref.clone(),
+        branch_ref
+            .parent()
+            .expect("branch ref parent")
+            .to_path_buf(),
+        common_dir.join("packed-refs"),
+    ] {
+        assert!(
+            metadata.rerun_paths.contains(&path),
+            "missing {}",
+            path.display()
+        );
+    }
+}
+
+#[test]
+fn identity_ignores_generated_target_and_results_files() {
+    let repo = initialized_repository();
+    let clean = BuildIdentity::collect(repo.path(), None).expect("clean identity");
+    assert_eq!(clean.compiled_git_sha.len(), 40);
+    assert!(!clean.source_dirty);
+    assert!(clean.rerun_paths.contains(&repo.path().join("src")));
+    assert!(clean.rerun_paths.contains(&repo.path().join(".cargo")));
+
+    for excluded in ["src/results/output.json", "src/target/artifact"] {
+        let path = repo.path().join(excluded);
+        fs::create_dir_all(path.parent().expect("excluded path parent"))
+            .expect("excluded directory");
+        fs::write(&path, "generated\n").expect("excluded generated file");
+    }
+    let generated_outputs =
+        BuildIdentity::collect(repo.path(), None).expect("identity with generated outputs");
+    assert!(!generated_outputs.source_dirty);
+    assert!(
+        generated_outputs
+            .rerun_paths
+            .iter()
+            .all(|path| !path.ends_with("output.json") && !path.ends_with("artifact"))
+    );
+}
+
+#[test]
+fn identity_marks_a_tracked_source_change_dirty() {
+    let repo = initialized_repository();
+    fs::write(
+        repo.path().join("src/lib.rs"),
+        "pub const TRACKED: bool = true;\n",
+    )
+    .expect("tracked source edit");
+    let tracked_dirty = BuildIdentity::collect(repo.path(), None).expect("tracked dirty identity");
+    assert!(tracked_dirty.source_dirty);
+    assert_eq!(
+        Publishability::from_source_dirty(tracked_dirty.source_dirty),
+        Publishability::NonPublishable {
+            reasons: vec!["dirty_source_tree".to_string()],
+        }
+    );
+}
+
+#[test]
+fn identity_marks_an_untracked_source_change_dirty_and_watches_it() {
+    let repo = initialized_repository();
+    let untracked_source = repo.path().join("src/new_source.rs");
+    fs::write(&untracked_source, "pub const UNTRACKED: bool = true;\n")
+        .expect("untracked source edit");
+    let untracked_dirty =
+        BuildIdentity::collect(repo.path(), None).expect("untracked dirty identity");
+    assert!(untracked_dirty.source_dirty);
+    assert!(untracked_dirty.rerun_paths.contains(&untracked_source));
+    assert!(
+        untracked_dirty
+            .rerun_paths
+            .contains(&repo.path().join("src"))
+    );
+}
+
+#[test]
+fn cargo_rebuilds_the_real_build_script_after_a_tracked_source_edit() {
+    let fixture = TempDir::new().expect("temporary Cargo fixture");
+    create_cargo_fixture(fixture.path());
+    generate_fixture_lockfile(fixture.path());
+    git(fixture.path(), &["init"]);
+    git(
+        fixture.path(),
+        &["config", "user.email", "runtime-baseline@example.test"],
+    );
+    git(
+        fixture.path(),
+        &["config", "user.name", "Runtime Baseline Test"],
+    );
+    git(fixture.path(), &["add", "."]);
+    git(fixture.path(), &["commit", "-m", "clean fixture"]);
+
+    let clean = run_fixture_identity(fixture.path());
+    assert!(!clean.source_dirty);
+    assert!(clean.reasons.is_empty());
+    fs::write(
+        fixture.path().join("src/marker.rs"),
+        "pub const MARKER: bool = true;\n",
+    )
+    .expect("tracked source edit");
+    let dirty = run_fixture_identity(fixture.path());
+    assert!(dirty.source_dirty);
+    assert_eq!(dirty.reasons, ["dirty_source_tree"]);
+}
+
+#[test]
+fn cargo_rebuilds_the_real_build_script_when_a_linked_worktree_branch_ref_moves() {
+    let repository = TempDir::new().expect("temporary Cargo repository");
+    create_cargo_fixture(repository.path());
+    generate_fixture_lockfile(repository.path());
+    git(repository.path(), &["init"]);
+    git(
+        repository.path(),
+        &["config", "user.email", "runtime-baseline@example.test"],
+    );
+    git(
+        repository.path(),
+        &["config", "user.name", "Runtime Baseline Test"],
+    );
+    git(repository.path(), &["add", "."]);
+    git(repository.path(), &["commit", "-m", "fixture source"]);
+    let first_sha = git_stdout(repository.path(), &["rev-parse", "HEAD"]);
+    git(
+        repository.path(),
+        &["commit", "--allow-empty", "-m", "second identity"],
+    );
+    let second_sha = git_stdout(repository.path(), &["rev-parse", "HEAD"]);
+    assert_ne!(first_sha, second_sha);
+
+    let worktree = repository.path().join("linked-worktree");
+    git(
+        repository.path(),
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "baseline",
+            path_as_str(&worktree),
+            &first_sha,
+        ],
+    );
+    let first_identity = run_fixture_identity(&worktree);
+    assert_eq!(first_identity.compiled_git_sha, first_sha);
+    assert!(!first_identity.source_dirty);
+
+    let branch_ref = repository.path().join(".git/refs/heads/baseline");
+    let before = fs::read_to_string(&branch_ref).expect("branch ref before update");
+    git(
+        repository.path(),
+        &["update-ref", "refs/heads/baseline", &second_sha],
+    );
+    let after = fs::read_to_string(&branch_ref).expect("branch ref after update");
+    assert_ne!(before, after);
+
+    let second_identity = run_fixture_identity(&worktree);
+    assert_eq!(second_identity.compiled_git_sha, second_sha);
+    assert!(!second_identity.source_dirty);
+}
+
+fn initialized_repository() -> TempDir {
+    let repo = TempDir::new().expect("temporary repository");
+    git(repo.path(), &["init"]);
+    git(
+        repo.path(),
+        &["config", "user.email", "runtime-baseline@example.test"],
+    );
+    git(
+        repo.path(),
+        &["config", "user.name", "Runtime Baseline Test"],
+    );
+    fs::create_dir(repo.path().join("src")).expect("source directory");
+    fs::write(
+        repo.path().join("src/lib.rs"),
+        "pub const CLEAN: bool = true;\n",
+    )
+    .expect("tracked source");
+    git(repo.path(), &["add", "src/lib.rs"]);
+    git(repo.path(), &["commit", "-m", "initial source"]);
+    repo
+}
+
+fn git(directory: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(directory)
+        .output()
+        .expect("git command starts");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn path_as_str(path: &Path) -> &str {
+    path.to_str().expect("temporary path is UTF-8")
+}
+
+fn create_cargo_fixture(root: &Path) {
+    fs::create_dir_all(root.join("src")).expect("fixture source directory");
+    fs::write(
+        root.join("src/marker.rs"),
+        "pub const MARKER: bool = false;\n",
+    )
+    .expect("fixture tracked source");
+    fs::write(root.join(".gitignore"), "target/\n").expect("fixture Git ignore");
+    fs::write(
+        root.join("Cargo.toml"),
+        r#"[workspace]
+resolver = "2"
+members = ["tools/runtime-baseline"]
+
+[workspace.package]
+version = "0.1.0"
+description = "runtime baseline fixture"
+repository = "https://example.test/runtime-baseline"
+edition = "2021"
+
+[workspace.dependencies]
+anyhow = "1.0"
+clap = { version = "4.6", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tempfile = "3.27"
+
+[workspace.lints.clippy]
+dbg_macro = "warn"
+implicit_clone = "warn"
+
+[workspace.lints.rust]
+unknown_lints = "deny"
+"#,
+    )
+    .expect("fixture Cargo manifest");
+
+    let source_crate = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture_crate = root.join("tools/runtime-baseline");
+    fs::create_dir_all(fixture_crate.join("src/bin")).expect("fixture crate directory");
+    for file in ["Cargo.toml", "build.rs", "build_support.rs"] {
+        fs::copy(source_crate.join(file), fixture_crate.join(file)).expect("fixture build input");
+    }
+    for file in ["cli.rs", "lib.rs", "main.rs", "schema.rs", "startup.rs"] {
+        fs::copy(
+            source_crate.join("src").join(file),
+            fixture_crate.join("src").join(file),
+        )
+        .expect("fixture crate source");
+    }
+    fs::write(
+        fixture_crate.join("src/bin/identity.rs"),
+        r#"use runtime_baseline::schema::{Publishability, source_dirty};
+
+#[derive(serde::Serialize)]
+struct Identity<'a> {
+    compiled_git_sha: &'a str,
+    source_dirty: bool,
+    reasons: Vec<String>,
+}
+
+fn main() {
+    let source_dirty = source_dirty();
+    let reasons = match Publishability::from_source_dirty(source_dirty) {
+        Publishability::Publishable => Vec::new(),
+        Publishability::NonPublishable { reasons } => reasons,
+    };
+    println!(
+        "{}",
+        serde_json::to_string(&Identity {
+            compiled_git_sha: runtime_baseline::schema::COMPILED_GIT_SHA,
+            source_dirty,
+            reasons,
+        })
+        .expect("identity JSON")
+    );
+}
+"#,
+    )
+    .expect("fixture identity binary");
+}
+
+#[derive(serde::Deserialize)]
+struct FixtureIdentity {
+    compiled_git_sha: String,
+    source_dirty: bool,
+    reasons: Vec<String>,
+}
+
+fn run_fixture_identity(root: &Path) -> FixtureIdentity {
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "-p",
+            "runtime-baseline",
+            "--bin",
+            "identity",
+            "--quiet",
+        ])
+        .current_dir(root)
+        .env("CARGO_TARGET_DIR", root.join("target"))
+        .output()
+        .expect("fixture cargo starts");
+    assert!(
+        output.status.success(),
+        "fixture cargo failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("fixture identity output is JSON")
+}
+
+fn generate_fixture_lockfile(root: &Path) {
+    let output = Command::new("cargo")
+        .arg("generate-lockfile")
+        .current_dir(root)
+        .output()
+        .expect("fixture lockfile generation starts");
+    assert!(
+        output.status.success(),
+        "fixture lockfile generation failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_stdout(directory: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(directory)
+        .output()
+        .expect("git command starts");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("git stdout is UTF-8")
+        .trim()
+        .to_owned()
+}

--- a/tools/runtime-baseline/tests/build_identity_test.rs
+++ b/tools/runtime-baseline/tests/build_identity_test.rs
@@ -76,7 +76,6 @@ fn discovers_linked_worktree_metadata_from_gitfile_and_commondir() {
     fs::write(common_dir.join("packed-refs"), "# pack-refs with: peeled\n").expect("packed refs");
 
     let metadata = GitMetadata::discover(&worktree).expect("linked worktree metadata");
-    assert_eq!(metadata.dot_git, worktree.join(".git"));
     assert_eq!(metadata.git_dir, git_dir);
     assert_eq!(metadata.common_dir, common_dir);
     for path in [
@@ -292,9 +291,7 @@ fn create_cargo_fixture(root: &Path) {
     )
     .expect("fixture tracked source");
     fs::write(root.join(".gitignore"), "target/\n").expect("fixture Git ignore");
-    fs::write(
-        root.join("Cargo.toml"),
-        r#"[workspace]
+    let fixture_manifest = r#"[workspace]
 resolver = "2"
 members = ["tools/runtime-baseline"]
 
@@ -303,6 +300,7 @@ version = "0.1.0"
 description = "runtime baseline fixture"
 repository = "https://example.test/runtime-baseline"
 edition = "2021"
+rust-version = "__RUST_VERSION__"
 
 [workspace.dependencies]
 anyhow = "1.0"
@@ -317,9 +315,9 @@ implicit_clone = "warn"
 
 [workspace.lints.rust]
 unknown_lints = "deny"
-"#,
-    )
-    .expect("fixture Cargo manifest");
+"#
+    .replace("__RUST_VERSION__", env!("CARGO_PKG_RUST_VERSION"));
+    fs::write(root.join("Cargo.toml"), fixture_manifest).expect("fixture Cargo manifest");
 
     let source_crate = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let fixture_crate = root.join("tools/runtime-baseline");
@@ -374,7 +372,7 @@ struct FixtureIdentity {
 }
 
 fn run_fixture_identity(root: &Path) -> FixtureIdentity {
-    let output = Command::new("cargo")
+    let output = fixture_cargo(root)
         .args([
             "run",
             "-p",
@@ -383,7 +381,6 @@ fn run_fixture_identity(root: &Path) -> FixtureIdentity {
             "identity",
             "--quiet",
         ])
-        .current_dir(root)
         .env("CARGO_TARGET_DIR", root.join("target"))
         .output()
         .expect("fixture cargo starts");
@@ -396,9 +393,8 @@ fn run_fixture_identity(root: &Path) -> FixtureIdentity {
 }
 
 fn generate_fixture_lockfile(root: &Path) {
-    let output = Command::new("cargo")
+    let output = fixture_cargo(root)
         .arg("generate-lockfile")
-        .current_dir(root)
         .output()
         .expect("fixture lockfile generation starts");
     assert!(
@@ -406,6 +402,16 @@ fn generate_fixture_lockfile(root: &Path) {
         "fixture lockfile generation failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+fn fixture_cargo(root: &Path) -> Command {
+    let mut command = Command::new("cargo");
+    command
+        .current_dir(root)
+        .env_remove("RUSTFLAGS")
+        .env_remove("RUSTDOCFLAGS")
+        .env_remove("CARGO_ENCODED_RUSTFLAGS");
+    command
 }
 
 fn git_stdout(directory: &Path, args: &[&str]) -> String {

--- a/tools/runtime-baseline/tests/build_identity_test.rs
+++ b/tools/runtime-baseline/tests/build_identity_test.rs
@@ -76,19 +76,22 @@ fn discovers_linked_worktree_metadata_from_gitfile_and_commondir() {
     fs::write(common_dir.join("packed-refs"), "# pack-refs with: peeled\n").expect("packed refs");
 
     let metadata = GitMetadata::discover(&worktree).expect("linked worktree metadata");
-    assert_eq!(metadata.git_dir, git_dir);
-    assert_eq!(metadata.common_dir, common_dir);
+    let expected_git_dir = build_support::accessible_path(&git_dir, &worktree);
+    let expected_common_dir = build_support::accessible_path(&common_dir, &expected_git_dir);
+    assert_eq!(metadata.git_dir, expected_git_dir);
+    assert_eq!(metadata.common_dir, expected_common_dir);
     for path in [
         worktree.join(".git"),
-        git_dir.join("HEAD"),
-        git_dir.join("index"),
-        git_dir.join("commondir"),
-        branch_ref.clone(),
-        branch_ref
+        expected_git_dir.join("HEAD"),
+        expected_git_dir.join("index"),
+        expected_git_dir.join("commondir"),
+        expected_common_dir.join("refs/heads/baseline"),
+        expected_common_dir
+            .join("refs/heads/baseline")
             .parent()
             .expect("branch ref parent")
             .to_path_buf(),
-        common_dir.join("packed-refs"),
+        expected_common_dir.join("packed-refs"),
     ] {
         assert!(
             metadata.rerun_paths.contains(&path),
@@ -99,7 +102,7 @@ fn discovers_linked_worktree_metadata_from_gitfile_and_commondir() {
 }
 
 #[test]
-fn identity_ignores_generated_target_and_results_files() {
+fn identity_ignores_unrelated_docs_and_generated_artifacts() {
     let repo = initialized_repository();
     let clean = BuildIdentity::collect(repo.path(), None).expect("clean identity");
     assert_eq!(clean.compiled_git_sha.len(), 40);
@@ -107,7 +110,13 @@ fn identity_ignores_generated_target_and_results_files() {
     assert!(clean.rerun_paths.contains(&repo.path().join("src")));
     assert!(clean.rerun_paths.contains(&repo.path().join(".cargo")));
 
-    for excluded in ["src/results/output.json", "src/target/artifact"] {
+    for excluded in [
+        "docs/unrelated.md",
+        "target/artifact",
+        "tools/runtime-baseline/results/output.json",
+        "src/results/output.json",
+        "src/target/artifact",
+    ] {
         let path = repo.path().join(excluded);
         fs::create_dir_all(path.parent().expect("excluded path parent"))
             .expect("excluded directory");
@@ -157,6 +166,31 @@ fn identity_marks_an_untracked_source_change_dirty_and_watches_it() {
             .rerun_paths
             .contains(&repo.path().join("src"))
     );
+}
+
+#[test]
+fn identity_marks_each_canonical_source_area_dirty() {
+    for source_input in [
+        "Cargo.toml",
+        ".cargo/config.toml",
+        "tools/runtime-baseline/build_support.rs",
+        "tools/runtime-baseline/src/lib.rs",
+        "tools/runtime-baseline/tests/contract.rs",
+    ] {
+        let repo = initialized_repository();
+        let path = repo.path().join(source_input);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("canonical source parent");
+        }
+        fs::write(&path, "canonical source input\n").expect("canonical source input");
+
+        let identity = BuildIdentity::collect(repo.path(), None)
+            .expect("identity with canonical source input");
+        assert!(
+            identity.source_dirty,
+            "canonical source input was ignored: {source_input}"
+        );
+    }
 }
 
 #[test]

--- a/tools/runtime-baseline/tests/ci_contract_test.rs
+++ b/tools/runtime-baseline/tests/ci_contract_test.rs
@@ -1,0 +1,225 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+const STABLE_PLATFORMS: [&str; 3] = ["ubuntu-latest", "macos-latest", "windows-latest"];
+
+#[derive(Deserialize)]
+struct Workflow {
+    jobs: BTreeMap<String, Job>,
+}
+
+#[derive(Deserialize)]
+struct Job {
+    strategy: Option<Strategy>,
+    #[serde(default)]
+    steps: Vec<Step>,
+    #[serde(rename = "runs-on")]
+    runs_on: Option<String>,
+    #[serde(rename = "if")]
+    condition: Option<yaml_serde::Value>,
+    #[serde(rename = "continue-on-error")]
+    continue_on_error: Option<yaml_serde::Value>,
+}
+
+#[derive(Deserialize)]
+struct Strategy {
+    matrix: Matrix,
+}
+
+#[derive(Deserialize)]
+struct Matrix {
+    #[serde(default)]
+    include: Vec<MatrixEntry>,
+}
+
+#[derive(Deserialize)]
+struct MatrixEntry {
+    os: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Step {
+    run: Option<String>,
+    #[serde(rename = "if")]
+    condition: Option<yaml_serde::Value>,
+    #[serde(rename = "continue-on-error")]
+    continue_on_error: Option<yaml_serde::Value>,
+}
+
+#[test]
+fn stable_platform_matrix_verifies_runtime_baseline_explicitly() {
+    let workflow = read_workspace_file(".github/workflows/ci.yml");
+    validate_ci_contract(&workflow).expect("stable CI must verify the runtime baseline tool");
+}
+
+#[test]
+fn benchmark_check_compiles_the_runtime_baseline_binary() {
+    let workflow = read_workspace_file(".github/workflows/benchmark.yml");
+    validate_benchmark_contract(&workflow)
+        .expect("Compile Benchmarks must link the runtime baseline binary explicitly");
+}
+
+#[test]
+fn ci_contract_rejects_commented_commands_and_missing_platforms() {
+    let workflow = read_workspace_file(".github/workflows/ci.yml");
+    let commented_build = workflow.replace(
+        "run: cargo build -p runtime-baseline --bin kiwi-runtime-baseline",
+        "run: '# cargo build -p runtime-baseline --bin kiwi-runtime-baseline'",
+    );
+    assert!(validate_ci_contract(&commented_build).is_err());
+
+    let missing_windows = workflow.replace("          - os: windows-latest\n", "");
+    assert!(validate_ci_contract(&missing_windows).is_err());
+
+    let conditional_test = workflow.replace(
+        "      - name: Test runtime baseline tool\n        run:",
+        "      - name: Test runtime baseline tool\n        if: false\n        run:",
+    );
+    assert!(validate_ci_contract(&conditional_test).is_err());
+
+    let ignored_test_failure = workflow.replace(
+        "      - name: Test runtime baseline tool\n        run:",
+        "      - name: Test runtime baseline tool\n        continue-on-error: true\n        run:",
+    );
+    assert!(validate_ci_contract(&ignored_test_failure).is_err());
+
+    let pinned_runner = workflow.replace("runs-on: ${{ matrix.os }}", "runs-on: ubuntu-latest");
+    assert!(validate_ci_contract(&pinned_runner).is_err());
+}
+
+#[test]
+fn benchmark_contract_rejects_a_commented_build() {
+    let workflow = read_workspace_file(".github/workflows/benchmark.yml");
+    let commented = workflow.replace(
+        "          cargo build --release -p runtime-baseline --bin kiwi-runtime-baseline",
+        "          # cargo build --release -p runtime-baseline --bin kiwi-runtime-baseline",
+    );
+    assert!(validate_benchmark_contract(&commented).is_err());
+}
+
+fn read_workspace_file(path: &str) -> String {
+    fs::read_to_string(workspace_root().join(path))
+        .expect("workflow file must be readable")
+        .replace("\r\n", "\n")
+}
+
+fn validate_ci_contract(contents: &str) -> Result<(), String> {
+    let workflow = parse_workflow(contents)?;
+    let build_job = required_job(&workflow, "build-and-test")?;
+    let clippy_job = required_job(&workflow, "cargo-clippy")?;
+    require_stable_platforms(build_job, "build-and-test")?;
+    require_stable_platforms(clippy_job, "cargo-clippy")?;
+    require_matrix_runner(build_job, "build-and-test")?;
+    require_matrix_runner(clippy_job, "cargo-clippy")?;
+    require_unconditional_command(
+        build_job,
+        "cargo build -p runtime-baseline --bin kiwi-runtime-baseline",
+    )?;
+    require_unconditional_command(build_job, "cargo test -p runtime-baseline --all-targets")?;
+    require_unconditional_command(
+        clippy_job,
+        "cargo clippy -p runtime-baseline --all-targets -- -D warnings -D clippy::unwrap_used",
+    )
+}
+
+fn validate_benchmark_contract(contents: &str) -> Result<(), String> {
+    let workflow = parse_workflow(contents)?;
+    let benchmark_job = required_job(&workflow, "benchmark")?;
+    require_unconditional_command(
+        benchmark_job,
+        "cargo build --release -p runtime-baseline --bin kiwi-runtime-baseline",
+    )
+}
+
+fn parse_workflow(contents: &str) -> Result<Workflow, String> {
+    yaml_serde::from_str(contents).map_err(|error| format!("invalid workflow YAML: {error}"))
+}
+
+fn required_job<'a>(workflow: &'a Workflow, name: &str) -> Result<&'a Job, String> {
+    let job = workflow
+        .jobs
+        .get(name)
+        .ok_or_else(|| format!("workflow is missing `{name}` job"))?;
+    if job.condition.is_some() || job.continue_on_error.is_some() {
+        Err(format!("`{name}` job must be unconditional and blocking"))
+    } else {
+        Ok(job)
+    }
+}
+
+fn require_stable_platforms(job: &Job, name: &str) -> Result<(), String> {
+    let actual = job
+        .strategy
+        .as_ref()
+        .ok_or_else(|| format!("`{name}` job has no strategy"))?
+        .matrix
+        .include
+        .iter()
+        .filter_map(|entry| entry.os.as_deref())
+        .collect::<BTreeSet<_>>();
+    let missing = STABLE_PLATFORMS
+        .iter()
+        .copied()
+        .filter(|platform| !actual.contains(platform))
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("`{name}` job is missing platforms: {missing:?}"))
+    }
+}
+
+fn require_matrix_runner(job: &Job, name: &str) -> Result<(), String> {
+    if job.runs_on.as_deref() == Some("${{ matrix.os }}") {
+        Ok(())
+    } else {
+        Err(format!("`{name}` job must run on `${{{{ matrix.os }}}}`"))
+    }
+}
+
+fn require_unconditional_command(job: &Job, command: &str) -> Result<(), String> {
+    let step = job
+        .steps
+        .iter()
+        .find(|step| {
+            step.run
+                .as_deref()
+                .is_some_and(|run| run.lines().map(str::trim).any(|line| line == command))
+        })
+        .ok_or_else(|| format!("job is missing active command `{command}`"))?;
+    if step.condition.is_some() || step.continue_on_error.is_some() {
+        Err(format!(
+            "command `{command}` must be unconditional and blocking"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("runtime-baseline must be nested under the workspace root")
+        .to_path_buf()
+}

--- a/tools/runtime-baseline/tests/ci_contract_test.rs
+++ b/tools/runtime-baseline/tests/ci_contract_test.rs
@@ -141,6 +141,15 @@ fn benchmark_contract_rejects_a_weakened_or_misordered_clean_check() {
     let ignored_failure = workflow.replace("            exit 1\n", "            exit 0\n");
     assert!(validate_benchmark_contract(&ignored_failure).is_err());
 
+    let cleared_status = workflow.replace(&clean, &format!("{clean}\n          dirty=\"\""));
+    assert!(validate_benchmark_contract(&cleared_status).is_err());
+
+    let unreachable_failure = workflow.replace(
+        "            exit 1\n",
+        "            if false; then\n              exit 1\n            fi\n",
+    );
+    assert!(validate_benchmark_contract(&unreachable_failure).is_err());
+
     let conditional = workflow.replace(
         "      - name: Verify runtime baseline source inputs are clean\n        shell: bash",
         "      - name: Verify runtime baseline source inputs are clean\n        if: false\n        shell: bash",
@@ -185,12 +194,47 @@ fn runtime_baseline_docs_define_separate_run_and_verify_commands() {
                 "{path} is missing documented controller contract `{required}`"
             );
         }
+        for command in ["run_baseline.py run", "run_baseline.py verify"] {
+            assert_definition_precedes_command_in_same_shell_block(
+                &contents,
+                path,
+                command,
+                "TMPDIR=\"${TMPDIR:-${RUNNER_TEMP:-/tmp}}\"",
+            );
+            assert_definition_precedes_command_in_same_shell_block(
+                &contents,
+                path,
+                command,
+                "RESULTS_ROOT=\"$TMPDIR/runtime-baseline-results\"",
+            );
+        }
         assert_eq!(
             contents.matches("--results-root \"$RESULTS_ROOT\"").count(),
             2,
             "{path} must use the same explicit results root for run and verify"
         );
     }
+}
+
+fn assert_definition_precedes_command_in_same_shell_block(
+    contents: &str,
+    path: &str,
+    command: &str,
+    definition: &str,
+) {
+    let command_index = contents
+        .find(command)
+        .unwrap_or_else(|| panic!("{path} is missing `{command}`"));
+    let shell_block_index = contents[..command_index]
+        .rfind("```bash")
+        .unwrap_or_else(|| panic!("{path} does not place `{command}` in a bash block"));
+    let definition_index = contents[..command_index]
+        .rfind(definition)
+        .unwrap_or_else(|| panic!("{path} does not define `{definition}` before `{command}`"));
+    assert!(
+        definition_index > shell_block_index,
+        "{path} must define `{definition}` in the same bash block before `{command}`"
+    );
 }
 
 fn read_workspace_file(path: &str) -> String {
@@ -248,35 +292,23 @@ fn require_fail_closed_clean_gate(job: &Job) -> Result<(usize, usize), String> {
         .expect("command step has a run body")
         .lines()
         .map(str::trim)
+        .filter(|line| !line.is_empty())
         .collect::<Vec<_>>();
-    let strict_index = lines
-        .iter()
-        .position(|line| *line == "set -Eeuo pipefail")
-        .ok_or_else(|| {
-            "runtime baseline source clean gate must enable strict shell mode".to_string()
-        })?;
-    let condition_index = lines
-        .iter()
-        .position(|line| *line == "if [[ -n \"$dirty\" ]]; then")
-        .ok_or_else(|| {
-            "runtime baseline source clean gate must reject non-empty status".to_string()
-        })?;
-    let exit_index = lines
-        .iter()
-        .position(|line| *line == "exit 1")
-        .ok_or_else(|| "runtime baseline source clean gate must fail the job".to_string())?;
-    let fi_index = lines
-        .iter()
-        .position(|line| *line == "fi")
-        .ok_or_else(|| "runtime baseline source clean gate condition is incomplete".to_string())?;
-    if strict_index < assignment_index
-        && assignment_index < condition_index
-        && condition_index < exit_index
-        && exit_index < fi_index
-    {
+    let expected = [
+        "set -Eeuo pipefail",
+        assignment.as_str(),
+        "if [[ -n \"$dirty\" ]]; then",
+        "printf '%s\\n' \"$dirty\" >&2",
+        "exit 1",
+        "fi",
+    ];
+    if lines == expected {
         Ok((step_index, assignment_index))
     } else {
-        Err("runtime baseline source clean gate commands are out of order".to_string())
+        Err(
+            "runtime baseline source clean gate must match the fail-closed body exactly"
+                .to_string(),
+        )
     }
 }
 

--- a/tools/runtime-baseline/tests/ci_contract_test.rs
+++ b/tools/runtime-baseline/tests/ci_contract_test.rs
@@ -21,6 +21,10 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
+#[allow(dead_code)]
+#[path = "../build_support.rs"]
+mod build_support;
+
 const STABLE_PLATFORMS: [&str; 3] = ["ubuntu-latest", "macos-latest", "windows-latest"];
 
 #[derive(Deserialize)]
@@ -117,6 +121,78 @@ fn benchmark_contract_rejects_a_commented_build() {
     assert!(validate_benchmark_contract(&commented).is_err());
 }
 
+#[test]
+fn benchmark_contract_rejects_a_weakened_or_misordered_clean_check() {
+    let workflow = read_workspace_file(".github/workflows/benchmark.yml");
+    let clean = source_clean_assignment();
+
+    let commented = workflow.replace(&clean, &format!("# {clean}"));
+    assert!(validate_benchmark_contract(&commented).is_err());
+
+    let unbounded = workflow.replace(&clean, "dirty=\"$(git status --porcelain)\"");
+    assert!(validate_benchmark_contract(&unbounded).is_err());
+
+    let missing_condition = workflow.replace("          if [[ -n \"$dirty\" ]]; then\n", "");
+    assert!(validate_benchmark_contract(&missing_condition).is_err());
+
+    let missing_failure = workflow.replace("            exit 1\n", "");
+    assert!(validate_benchmark_contract(&missing_failure).is_err());
+
+    let ignored_failure = workflow.replace("            exit 1\n", "            exit 0\n");
+    assert!(validate_benchmark_contract(&ignored_failure).is_err());
+
+    let conditional = workflow.replace(
+        "      - name: Verify runtime baseline source inputs are clean\n        shell: bash",
+        "      - name: Verify runtime baseline source inputs are clean\n        if: false\n        shell: bash",
+    );
+    assert!(validate_benchmark_contract(&conditional).is_err());
+
+    let after_build = workflow
+        .replace(&clean, "true")
+        .replace(
+            "          cargo build --release -p runtime-baseline --bin kiwi-runtime-baseline",
+            &format!(
+                "          cargo build --release -p runtime-baseline --bin kiwi-runtime-baseline\n          {clean}"
+            ),
+        );
+    assert!(validate_benchmark_contract(&after_build).is_err());
+}
+
+#[test]
+fn runtime_baseline_docs_define_separate_run_and_verify_commands() {
+    for path in [
+        "docs/superpowers/specs/2026-07-24-storage-runtime-baseline-design.md",
+        "docs/superpowers/plans/2026-07-24-storage-runtime-baseline-harness.md",
+    ] {
+        let contents = read_workspace_file(path);
+        assert!(
+            !contents.contains("run_baseline.py \\\n  --smoke"),
+            "{path} still documents the removed top-level --smoke form"
+        );
+        for required in [
+            "MEMTIER_PREFIX=\"${MEMTIER_PREFIX:?set MEMTIER_PREFIX to the memtier install prefix}\"",
+            "TMPDIR=\"${TMPDIR:-${RUNNER_TEMP:-/tmp}}\"",
+            "RESULTS_ROOT=\"$TMPDIR/runtime-baseline-results\"",
+            "run_baseline.py run",
+            "run_baseline.py verify",
+            "--suite smoke",
+            "--cases tools/runtime-baseline/cases/cases.yaml",
+            "--results-root \"$RESULTS_ROOT\"",
+            "--expected-git-sha \"$(git rev-parse HEAD)\"",
+        ] {
+            assert!(
+                contents.contains(required),
+                "{path} is missing documented controller contract `{required}`"
+            );
+        }
+        assert_eq!(
+            contents.matches("--results-root \"$RESULTS_ROOT\"").count(),
+            2,
+            "{path} must use the same explicit results root for run and verify"
+        );
+    }
+}
+
 fn read_workspace_file(path: &str) -> String {
     fs::read_to_string(workspace_root().join(path))
         .expect("workflow file must be readable")
@@ -145,10 +221,63 @@ fn validate_ci_contract(contents: &str) -> Result<(), String> {
 fn validate_benchmark_contract(contents: &str) -> Result<(), String> {
     let workflow = parse_workflow(contents)?;
     let benchmark_job = required_job(&workflow, "benchmark")?;
-    require_unconditional_command(
+    let clean = require_fail_closed_clean_gate(benchmark_job)?;
+    let build = require_unconditional_command_location(
         benchmark_job,
         "cargo build --release -p runtime-baseline --bin kiwi-runtime-baseline",
-    )
+    )?;
+    if clean < build {
+        Ok(())
+    } else {
+        Err("runtime baseline source clean check must run before the release build".to_string())
+    }
+}
+
+fn require_fail_closed_clean_gate(job: &Job) -> Result<(usize, usize), String> {
+    let assignment = source_clean_assignment();
+    let (step_index, step, assignment_index) = find_command(job, &assignment)?;
+    if step.condition.is_some() || step.continue_on_error.is_some() {
+        return Err(
+            "runtime baseline source clean gate must be unconditional and blocking".to_string(),
+        );
+    }
+
+    let lines = step
+        .run
+        .as_deref()
+        .expect("command step has a run body")
+        .lines()
+        .map(str::trim)
+        .collect::<Vec<_>>();
+    let strict_index = lines
+        .iter()
+        .position(|line| *line == "set -Eeuo pipefail")
+        .ok_or_else(|| {
+            "runtime baseline source clean gate must enable strict shell mode".to_string()
+        })?;
+    let condition_index = lines
+        .iter()
+        .position(|line| *line == "if [[ -n \"$dirty\" ]]; then")
+        .ok_or_else(|| {
+            "runtime baseline source clean gate must reject non-empty status".to_string()
+        })?;
+    let exit_index = lines
+        .iter()
+        .position(|line| *line == "exit 1")
+        .ok_or_else(|| "runtime baseline source clean gate must fail the job".to_string())?;
+    let fi_index = lines
+        .iter()
+        .position(|line| *line == "fi")
+        .ok_or_else(|| "runtime baseline source clean gate condition is incomplete".to_string())?;
+    if strict_index < assignment_index
+        && assignment_index < condition_index
+        && condition_index < exit_index
+        && exit_index < fi_index
+    {
+        Ok((step_index, assignment_index))
+    } else {
+        Err("runtime baseline source clean gate commands are out of order".to_string())
+    }
 }
 
 fn parse_workflow(contents: &str) -> Result<Workflow, String> {
@@ -198,22 +327,45 @@ fn require_matrix_runner(job: &Job, name: &str) -> Result<(), String> {
 }
 
 fn require_unconditional_command(job: &Job, command: &str) -> Result<(), String> {
-    let step = job
-        .steps
-        .iter()
-        .find(|step| {
-            step.run
-                .as_deref()
-                .is_some_and(|run| run.lines().map(str::trim).any(|line| line == command))
-        })
-        .ok_or_else(|| format!("job is missing active command `{command}`"))?;
+    require_unconditional_command_location(job, command).map(|_| ())
+}
+
+fn require_unconditional_command_location(
+    job: &Job,
+    command: &str,
+) -> Result<(usize, usize), String> {
+    let (step_index, step, line_index) = find_command(job, command)?;
     if step.condition.is_some() || step.continue_on_error.is_some() {
         Err(format!(
             "command `{command}` must be unconditional and blocking"
         ))
     } else {
-        Ok(())
+        Ok((step_index, line_index))
     }
+}
+
+fn find_command<'a>(job: &'a Job, command: &str) -> Result<(usize, &'a Step, usize), String> {
+    job.steps
+        .iter()
+        .enumerate()
+        .find_map(|(step_index, step)| {
+            step.run.as_deref().and_then(|run| {
+                run.lines()
+                    .map(str::trim)
+                    .position(|line| line == command)
+                    .map(|line_index| (step_index, step, line_index))
+            })
+        })
+        .ok_or_else(|| format!("job is missing active command `{command}`"))
+}
+
+fn source_clean_assignment() -> String {
+    let arguments = build_support::source_status_arguments()
+        .into_iter()
+        .map(|argument| format!("'{argument}'"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!("dirty=\"$(git {arguments})\"")
 }
 
 fn workspace_root() -> PathBuf {

--- a/tools/runtime-baseline/tests/cli_test.rs
+++ b/tools/runtime-baseline/tests/cli_test.rs
@@ -1,0 +1,333 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs;
+use std::net::SocketAddr;
+use std::path::Path;
+
+#[cfg(windows)]
+use std::process::Command;
+
+use clap::Parser;
+use runtime_baseline::cli::ServerArgs;
+use tempfile::TempDir;
+
+fn absolute_path(dir: &TempDir, name: &str) -> std::path::PathBuf {
+    dir.path().join(name)
+}
+
+fn valid_args(dir: &TempDir) -> ServerArgs {
+    ServerArgs {
+        listen: "127.0.0.1:0"
+            .parse::<SocketAddr>()
+            .expect("valid listen address"),
+        control_listen: "127.0.0.1:0"
+            .parse::<SocketAddr>()
+            .expect("valid control address"),
+        data_dir: absolute_path(dir, "data"),
+        startup_event: absolute_path(dir, "startup.json"),
+        metrics_output: absolute_path(dir, "metrics.json"),
+        expected_git_sha: None,
+        network_threads: 1,
+        storage_threads: 1,
+        channel_capacity: 1,
+        request_timeout_ms: 1,
+        batching: false,
+        batch_size: 1,
+        batch_timeout_ms: 1,
+        instrumentation: false,
+        instrumentation_sample_capacity: 1,
+    }
+}
+
+#[test]
+fn rejects_relative_data_directory() {
+    let dir = TempDir::new().expect("temp directory");
+    let mut args = valid_args(&dir);
+    args.data_dir = Path::new("relative-data").to_path_buf();
+
+    assert!(args.validate().is_err());
+}
+
+#[test]
+fn rejects_non_loopback_listeners() {
+    let dir = TempDir::new().expect("temp directory");
+    let mut args = valid_args(&dir);
+    args.listen = "0.0.0.0:0".parse().expect("valid socket address");
+
+    assert!(args.validate().is_err());
+
+    args.listen = "127.0.0.1:0".parse().expect("valid socket address");
+    args.control_listen = "192.168.1.10:0".parse().expect("valid socket address");
+
+    assert!(args.validate().is_err());
+}
+
+#[test]
+fn rejects_existing_rocksdb_data_directory() {
+    let dir = TempDir::new().expect("temp directory");
+    let args = valid_args(&dir);
+    std::fs::create_dir(&args.data_dir).expect("data directory");
+    std::fs::write(args.data_dir.join("CURRENT"), b"MANIFEST-000001\n").expect("rocksdb marker");
+
+    assert!(args.validate().is_err());
+}
+
+#[test]
+fn rejects_any_existing_current_marker() {
+    let dir = TempDir::new().expect("temp directory");
+    let args = valid_args(&dir);
+    std::fs::create_dir(&args.data_dir).expect("data directory");
+    std::fs::create_dir(args.data_dir.join("CURRENT")).expect("rocksdb marker directory");
+
+    assert!(args.validate().is_err());
+}
+
+#[test]
+fn rejects_relative_event_and_metrics_paths() {
+    let dir = TempDir::new().expect("temp directory");
+    let mut args = valid_args(&dir);
+    args.startup_event = Path::new("startup.json").to_path_buf();
+
+    assert!(args.validate().is_err());
+
+    args.startup_event = absolute_path(&dir, "startup.json");
+    args.metrics_output = Path::new("metrics.json").to_path_buf();
+
+    assert!(args.validate().is_err());
+}
+
+#[test]
+fn rejects_output_paths_that_normalize_to_the_same_target() {
+    let dir = TempDir::new().expect("temp directory");
+    let alias = dir.path().join("alias");
+    fs::create_dir(&alias).expect("alias directory");
+    let mut args = valid_args(&dir);
+    args.startup_event = alias.join("..").join("shared.json");
+    args.metrics_output = dir.path().join("shared.json");
+
+    let error = args
+        .validate()
+        .expect_err("aliases must resolve to one target");
+    assert!(error.to_string().contains("must be distinct"));
+}
+
+#[test]
+fn rejects_an_output_parent_alias_that_resolves_inside_the_data_directory() {
+    let dir = TempDir::new().expect("temp directory");
+    let mut args = valid_args(&dir);
+    fs::create_dir(&args.data_dir).expect("data directory");
+    let alias = dir.path().join("data-alias");
+    create_directory_alias(&args.data_dir, &alias);
+    args.startup_event = alias.join("startup.json");
+
+    let error = args
+        .validate()
+        .expect_err("output aliases must not enter data-dir");
+    assert!(
+        error
+            .to_string()
+            .contains("must not be located under data-dir")
+    );
+}
+
+#[test]
+fn normalizes_a_missing_data_directory_from_its_existing_aliased_ancestor() {
+    let dir = TempDir::new().expect("temp directory");
+    let actual_parent = dir.path().join("actual-parent");
+    fs::create_dir(&actual_parent).expect("actual parent directory");
+    let alias = dir.path().join("parent-alias");
+    create_directory_alias(&actual_parent, &alias);
+    let mut args = valid_args(&dir);
+    args.data_dir = alias.join("future-data");
+    args.startup_event = actual_parent.join("future-data");
+    assert!(!args.data_dir.exists());
+
+    let error = args
+        .validate()
+        .expect_err("missing data-dir aliases must normalize from their existing ancestor");
+    assert!(
+        error
+            .to_string()
+            .contains("must not be located under data-dir")
+    );
+}
+
+#[test]
+fn parses_every_planned_argument() {
+    let dir = TempDir::new().expect("temp directory");
+    let arguments = valid_command_line(&dir);
+    let parsed = ServerArgs::try_parse_from(&arguments).expect("all planned arguments parse");
+    assert_eq!(
+        parsed.listen,
+        "127.0.0.1:0".parse().expect("listen address")
+    );
+    assert_eq!(
+        parsed.control_listen,
+        "127.0.0.1:0".parse().expect("control address")
+    );
+    assert_eq!(parsed.data_dir, absolute_path(&dir, "parsed-data"));
+    assert_eq!(
+        parsed.startup_event,
+        absolute_path(&dir, "parsed-startup.json")
+    );
+    assert_eq!(
+        parsed.metrics_output,
+        absolute_path(&dir, "parsed-metrics.json")
+    );
+    assert_eq!(
+        parsed.expected_git_sha.as_deref(),
+        Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    );
+    assert_eq!(parsed.network_threads, 2);
+    assert_eq!(parsed.storage_threads, 3);
+    assert_eq!(parsed.channel_capacity, 4);
+    assert_eq!(parsed.request_timeout_ms, 5);
+    assert!(parsed.batching);
+    assert_eq!(parsed.batch_size, 6);
+    assert_eq!(parsed.batch_timeout_ms, 7);
+    assert!(parsed.instrumentation);
+    assert_eq!(parsed.instrumentation_sample_capacity, 8);
+    assert!(parsed.validate().is_ok());
+}
+
+#[test]
+fn rejects_zero_for_each_numeric_parameter() {
+    let dir = TempDir::new().expect("temp directory");
+    for flag in [
+        "--network-threads",
+        "--storage-threads",
+        "--channel-capacity",
+        "--request-timeout-ms",
+        "--batch-size",
+        "--batch-timeout-ms",
+        "--instrumentation-sample-capacity",
+    ] {
+        let mut zero_arguments = valid_command_line(&dir);
+        let value_index = zero_arguments
+            .iter()
+            .position(|argument| argument == flag)
+            .expect("planned option is present")
+            + 1;
+        zero_arguments[value_index] = "0".to_string();
+        let parsed = ServerArgs::try_parse_from(&zero_arguments).expect("zero still parses");
+        assert!(parsed.validate().is_err(), "{flag} must reject zero");
+    }
+}
+
+#[test]
+fn instrumentation_uses_the_documented_on_off_values() {
+    let dir = TempDir::new().expect("temp directory");
+
+    let enabled =
+        ServerArgs::try_parse_from(valid_command_line(&dir)).expect("instrumentation=on parses");
+    assert!(enabled.instrumentation);
+
+    let mut disabled_arguments = valid_command_line(&dir);
+    replace_option_value(&mut disabled_arguments, "--instrumentation", "off");
+    let disabled =
+        ServerArgs::try_parse_from(disabled_arguments).expect("instrumentation=off parses");
+    assert!(!disabled.instrumentation);
+
+    let mut boolean_arguments = valid_command_line(&dir);
+    replace_option_value(&mut boolean_arguments, "--instrumentation", "true");
+    assert!(ServerArgs::try_parse_from(boolean_arguments).is_err());
+}
+
+#[test]
+fn rejects_invalid_expected_git_sha_from_the_real_argument_parser() {
+    let dir = TempDir::new().expect("temp directory");
+    for git_sha in ["abc".to_string(), "g".repeat(40), "a".repeat(41)] {
+        let mut arguments = valid_command_line(&dir);
+        let value_index = arguments
+            .iter()
+            .position(|argument| argument == "--expected-git-sha")
+            .expect("expected SHA is present")
+            + 1;
+        arguments[value_index] = git_sha;
+        let parsed = ServerArgs::try_parse_from(&arguments).expect("invalid SHA syntax parses");
+        assert!(parsed.validate().is_err());
+    }
+}
+
+fn valid_command_line(dir: &TempDir) -> Vec<String> {
+    vec![
+        "kiwi-runtime-baseline".to_string(),
+        "--listen".to_string(),
+        "127.0.0.1:0".to_string(),
+        "--control-listen".to_string(),
+        "127.0.0.1:0".to_string(),
+        "--data-dir".to_string(),
+        absolute_path(dir, "parsed-data").display().to_string(),
+        "--startup-event".to_string(),
+        absolute_path(dir, "parsed-startup.json")
+            .display()
+            .to_string(),
+        "--metrics-output".to_string(),
+        absolute_path(dir, "parsed-metrics.json")
+            .display()
+            .to_string(),
+        "--expected-git-sha".to_string(),
+        "a".repeat(40),
+        "--network-threads".to_string(),
+        "2".to_string(),
+        "--storage-threads".to_string(),
+        "3".to_string(),
+        "--channel-capacity".to_string(),
+        "4".to_string(),
+        "--request-timeout-ms".to_string(),
+        "5".to_string(),
+        "--batching=true".to_string(),
+        "--batch-size".to_string(),
+        "6".to_string(),
+        "--batch-timeout-ms".to_string(),
+        "7".to_string(),
+        "--instrumentation".to_string(),
+        "on".to_string(),
+        "--instrumentation-sample-capacity".to_string(),
+        "8".to_string(),
+    ]
+}
+
+fn replace_option_value(arguments: &mut [String], flag: &str, value: &str) {
+    let value_index = arguments
+        .iter()
+        .position(|argument| argument == flag)
+        .expect("planned option is present")
+        + 1;
+    arguments[value_index] = value.to_string();
+}
+
+#[cfg(unix)]
+fn create_directory_alias(target: &Path, alias: &Path) {
+    std::os::unix::fs::symlink(target, alias).expect("directory symlink");
+}
+
+#[cfg(windows)]
+fn create_directory_alias(target: &Path, alias: &Path) {
+    let output = Command::new("cmd")
+        .args(["/C", "mklink", "/J"])
+        .arg(alias)
+        .arg(target)
+        .output()
+        .expect("junction command starts");
+    assert!(
+        output.status.success(),
+        "cannot create directory junction: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/tools/runtime-baseline/tests/cli_test.rs
+++ b/tools/runtime-baseline/tests/cli_test.rs
@@ -126,6 +126,33 @@ fn rejects_output_paths_that_normalize_to_the_same_target() {
     assert!(error.to_string().contains("must be distinct"));
 }
 
+#[cfg(any(windows, target_os = "macos"))]
+#[test]
+fn rejects_output_paths_that_differ_only_by_case() {
+    let dir = TempDir::new().expect("temp directory");
+    let mut args = valid_args(&dir);
+    args.startup_event = dir.path().join("Startup.json");
+    args.metrics_output = dir.path().join("STARTUP.JSON");
+
+    let error = args
+        .validate()
+        .expect_err("case-insensitive platforms must reject one output target");
+    assert!(error.to_string().contains("must be distinct"));
+}
+
+#[cfg(any(windows, target_os = "macos"))]
+#[test]
+fn rejects_non_ascii_output_file_names_on_case_insensitive_platforms() {
+    let dir = TempDir::new().expect("temp directory");
+    let mut args = valid_args(&dir);
+    args.startup_event = dir.path().join("Σ.json");
+
+    let error = args
+        .validate()
+        .expect_err("non-ASCII output names must fail closed on this platform");
+    assert!(error.to_string().contains("must use ASCII"));
+}
+
 #[test]
 fn rejects_an_output_parent_alias_that_resolves_inside_the_data_directory() {
     let dir = TempDir::new().expect("temp directory");

--- a/tools/runtime-baseline/tests/startup_test.rs
+++ b/tools/runtime-baseline/tests/startup_test.rs
@@ -1,0 +1,278 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs;
+use std::net::SocketAddr;
+use std::process::Command;
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+use runtime_baseline::schema::{
+    COMPILED_GIT_SHA, Publishability, STARTUP_SCHEMA_VERSION, StartupEvent, source_dirty,
+};
+use runtime_baseline::startup::{ensure_expected_git_sha, write_startup_event_atomically};
+use tempfile::TempDir;
+
+#[test]
+fn startup_event_is_complete_atomic_and_uses_compiled_identity() {
+    let dir = TempDir::new().expect("temp directory");
+    let data_dir = dir.path().join("data");
+    let output_dir = dir.path().join("events");
+    let output = output_dir.join("startup.json");
+    fs::create_dir(&data_dir).expect("data directory");
+    fs::create_dir(&output_dir).expect("output directory");
+
+    let redis_addr = "127.0.0.1:41001"
+        .parse::<SocketAddr>()
+        .expect("redis loopback address");
+    let control_addr = "127.0.0.1:41002"
+        .parse::<SocketAddr>()
+        .expect("control loopback address");
+    let event =
+        StartupEvent::new(4242, redis_addr, control_addr, &data_dir).expect("valid startup event");
+
+    write_startup_event_atomically(&output, &event).expect("atomic startup event");
+
+    let parsed: StartupEvent = serde_json::from_slice(
+        &fs::read(&output).expect("startup event is present after atomic rename"),
+    )
+    .expect("startup event is complete JSON");
+    assert_eq!(parsed.schema_version, STARTUP_SCHEMA_VERSION);
+    assert_eq!(parsed.pid, 4242);
+    assert_eq!(parsed.redis_addr, redis_addr);
+    assert_eq!(parsed.control_addr, control_addr);
+    assert_eq!(
+        parsed.data_dir,
+        fs::canonicalize(&data_dir).expect("canonical data dir")
+    );
+    assert_eq!(parsed.git_sha, COMPILED_GIT_SHA);
+    assert_eq!(parsed.publishability, event.publishability);
+
+    let output_names = fs::read_dir(&output_dir)
+        .expect("output directory")
+        .map(|entry| entry.expect("directory entry").file_name())
+        .collect::<Vec<_>>();
+    assert_eq!(output_names, vec!["startup.json"]);
+}
+
+#[test]
+fn existing_startup_event_is_not_overwritten() {
+    let dir = TempDir::new().expect("temp directory");
+    let data_dir = dir.path().join("data");
+    let output_dir = dir.path().join("events");
+    let output = output_dir.join("startup.json");
+    fs::create_dir(&data_dir).expect("data directory");
+    fs::create_dir(&output_dir).expect("output directory");
+    fs::write(&output, b"existing startup event\n").expect("existing startup event");
+    let event = startup_event(&data_dir, 4242);
+
+    write_startup_event_atomically(&output, &event).expect_err("must not replace existing output");
+
+    assert_eq!(
+        fs::read(&output).expect("existing output remains readable"),
+        b"existing startup event\n"
+    );
+    assert_eq!(directory_entry_names(&output_dir), ["startup.json"]);
+}
+
+#[test]
+fn concurrent_startup_event_writers_publish_at_most_one_complete_file() {
+    let dir = TempDir::new().expect("temp directory");
+    let data_dir = dir.path().join("data");
+    let output_dir = dir.path().join("events");
+    let output = output_dir.join("startup.json");
+    fs::create_dir(&data_dir).expect("data directory");
+    fs::create_dir(&output_dir).expect("output directory");
+    let events = [4242, 4343]
+        .into_iter()
+        .enumerate()
+        .map(|(index, pid)| {
+            let mut event = startup_event(&data_dir, pid);
+            event.publishability = Publishability::NonPublishable {
+                reasons: vec![(if index == 0 { "a" } else { "b" }).repeat(4 * 1024 * 1024)],
+            };
+            Arc::new(event)
+        })
+        .collect::<Vec<_>>();
+    let output = Arc::new(output);
+    let barrier = Arc::new(Barrier::new(2));
+
+    let writers = events
+        .iter()
+        .map(|event| {
+            let event = Arc::clone(event);
+            let output = Arc::clone(&output);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                write_startup_event_atomically(&output, &event)
+            })
+        })
+        .collect::<Vec<_>>();
+    let results = writers
+        .into_iter()
+        .map(|writer| writer.join().expect("startup writer does not panic"))
+        .collect::<Vec<_>>();
+
+    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+    let parsed: StartupEvent = serde_json::from_slice(
+        &fs::read(output.as_ref()).expect("published startup event is present"),
+    )
+    .expect("published startup event is complete JSON");
+    assert!(events.iter().any(|event| &parsed == event.as_ref()));
+    assert_eq!(directory_entry_names(&output_dir), ["startup.json"]);
+}
+
+#[test]
+fn publishability_reflects_embedded_source_cleanliness() {
+    let dir = TempDir::new().expect("temp directory");
+    let data_dir = dir.path().join("data");
+    fs::create_dir(&data_dir).expect("data directory");
+    let event = StartupEvent::new(
+        1,
+        "127.0.0.1:0".parse().expect("redis loopback address"),
+        "127.0.0.1:0".parse().expect("control loopback address"),
+        &data_dir,
+    )
+    .expect("startup event");
+
+    if source_dirty() {
+        assert_eq!(
+            event.publishability,
+            Publishability::NonPublishable {
+                reasons: vec!["dirty_source_tree".to_string()],
+            }
+        );
+    } else {
+        assert_eq!(event.publishability, Publishability::Publishable);
+    }
+}
+
+#[test]
+fn expected_sha_mismatch_fails_without_echoing_the_caller_value() {
+    let caller_value = "ffffffffffffffffffffffffffffffffffffffff";
+    assert_ne!(COMPILED_GIT_SHA, caller_value);
+
+    let error = ensure_expected_git_sha(Some(caller_value)).expect_err("must reject mismatch");
+    assert!(!error.to_string().contains(caller_value));
+}
+
+#[test]
+fn binary_rejects_mismatched_identity_before_reaching_the_harness_exit() {
+    let dir = TempDir::new().expect("temp directory");
+    let data_dir = dir.path().join("data");
+    let startup_event = dir.path().join("startup.json");
+    let metrics_output = dir.path().join("metrics.json");
+    let caller_sha = "f".repeat(40);
+    assert_ne!(caller_sha, COMPILED_GIT_SHA);
+
+    let mismatch = run_binary(&data_dir, &startup_event, &metrics_output, &caller_sha);
+    assert!(!mismatch.status.success());
+    let mismatch_stderr = String::from_utf8(mismatch.stderr).expect("UTF-8 stderr");
+    assert!(
+        mismatch_stderr.contains("expected Git SHA does not match this binary's compiled identity")
+    );
+    assert!(!mismatch_stderr.contains(&caller_sha));
+    assert!(!mismatch_stderr.contains("harness not initialized"));
+    assert!(!startup_event.exists());
+    assert!(!metrics_output.exists());
+}
+
+#[test]
+fn binary_with_matching_identity_reaches_the_harness_exit_without_outputs() {
+    let dir = TempDir::new().expect("temp directory");
+    let data_dir = dir.path().join("data");
+    let startup_event = dir.path().join("startup.json");
+    let metrics_output = dir.path().join("metrics.json");
+    let matching = run_binary(&data_dir, &startup_event, &metrics_output, COMPILED_GIT_SHA);
+    assert!(!matching.status.success());
+    let matching_stderr = String::from_utf8(matching.stderr).expect("UTF-8 stderr");
+    assert!(matching_stderr.contains("harness not initialized"));
+    assert!(!startup_event.exists());
+    assert!(!metrics_output.exists());
+}
+
+fn run_binary(
+    data_dir: &std::path::Path,
+    startup_event: &std::path::Path,
+    metrics_output: &std::path::Path,
+    expected_sha: &str,
+) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_kiwi-runtime-baseline"))
+        .args([
+            "--listen",
+            "127.0.0.1:0",
+            "--control-listen",
+            "127.0.0.1:0",
+            "--data-dir",
+            data_dir.to_str().expect("temporary path is UTF-8"),
+            "--startup-event",
+            startup_event.to_str().expect("temporary path is UTF-8"),
+            "--metrics-output",
+            metrics_output.to_str().expect("temporary path is UTF-8"),
+            "--expected-git-sha",
+            expected_sha,
+            "--network-threads",
+            "2",
+            "--storage-threads",
+            "3",
+            "--channel-capacity",
+            "4",
+            "--request-timeout-ms",
+            "5",
+            "--batching=false",
+            "--batch-size",
+            "6",
+            "--batch-timeout-ms",
+            "7",
+            "--instrumentation",
+            "off",
+            "--instrumentation-sample-capacity",
+            "8",
+        ])
+        .output()
+        .expect("runtime baseline binary starts")
+}
+
+fn startup_event(data_dir: &std::path::Path, pid: u32) -> StartupEvent {
+    StartupEvent::new(
+        pid,
+        "127.0.0.1:41001"
+            .parse::<SocketAddr>()
+            .expect("redis loopback address"),
+        "127.0.0.1:41002"
+            .parse::<SocketAddr>()
+            .expect("control loopback address"),
+        data_dir,
+    )
+    .expect("valid startup event")
+}
+
+fn directory_entry_names(directory: &std::path::Path) -> Vec<String> {
+    let mut names = fs::read_dir(directory)
+        .expect("output directory")
+        .map(|entry| {
+            entry
+                .expect("directory entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect::<Vec<_>>();
+    names.sort();
+    names
+}


### PR DESCRIPTION
## Summary

This PR establishes the foundation for Issue #350 Plan C without changing the storage scheduling model or publishing performance results.

- add the versioned design and implementation plan for the storage runtime baseline;
- add an opt-in `runtime-baseline` workspace tool skeleton with strict loopback/path validation, compiled Git identity, dirty-source publishability, and atomic no-clobber startup-event publishing;
- allow `StorageServer` to compose custom batching configuration with the same pause controller and access gate;
- add an owned, cancellable and awaitable `NetworkServer` lifecycle that reaps connection tasks, joins pool cleanup, clears idle pooled resources, and observes cancellation at safe socket-read boundaries;
- add an explicit, idempotent `RuntimeManager` storage-request sender close point for ordered harness shutdown;
- add a feature-gated runtime baseline observer contract, logical and physical request identity, lifecycle attempt tokens, ordered state transitions, and fail-closed panic/reentrancy handling;
- bind instrumented `StorageRequest` identity to its baseline attempt and cover final-drop, pre-accept, timeout/execution overlap, and observer-failure races.

## Delivery boundary

This PR covers Plan C foundation Tasks 1-5 only.

The baseline binary intentionally exits with `harness not initialized`. The following work remains for follow-up PRs:

- MessageChannel, StorageClient, retry, timeout, and response-event wiring;
- StorageServer dequeue, batching, gate, running, and terminal-event wiring;
- concrete metrics, conservation checks, control protocol, and real harness orchestration;
- Python controller, memtier provenance/bootstrap, and the four-case GET/SET smoke matrix;
- benchmark CI workflow and auditable smoke artifacts;
- full baseline results and frozen thresholds for #351.

This PR does not close #350.

## Validation

Fresh WSL/Linux validation at `06e24302ec446f884632a78d2459b6401bdebb91`:

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features -- --test-threads=1`
- `make lint`
- `git diff --check origin/main...HEAD`

All commands exited successfully. The workspace test includes runtime baseline tests, Runtime 159/159, Net lifecycle and storage-command E2E tests, Raft, Storage, the runtime-baseline tool tests, and doctests.

## Draft / integration status

This PR is intentionally opened as Draft because two integration items must be resolved before it is ready to merge:

1. the committed design currently describes the first stage as one complete harness/smoke PR; it must be reconciled with the new Tasks 1-5 foundation split;
2. latest `main` includes #369 and #370. The synthetic merge must validate Rust 1.97.1, rust-rocksdb v0.51.0-arana.2, the combined lockfile, and the new tool crate's workspace `rust-version` inheritance.

No rebase or force-push was performed against the already verified commit history.

Refs #350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the initial `runtime-baseline` command-line tool with strict pre-flight validation, build identity checks, and atomic startup metadata publishing.
  * Added a feature-gated storage “baseline attempt” lifecycle with observable state transitions.
  * Improved cancellation-aware server shutdown and added network server lifecycle statistics visibility.
* **CI & Testing**
  * Expanded CI/clippy/test coverage for the runtime-baseline package, plus benchmark workflow cleanliness verification and a two-step benchmark build/run flow.
  * Added workflow contract checks for the baseline harness.
* **Documentation**
  * Added detailed plans/specs for a reproducible storage runtime baseline harness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->