### PR TITLE
feat(storage,cmd): implement keyspace SCAN command

### DIFF
--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -66,6 +66,7 @@ pub mod psetex;
 pub mod pttl;
 pub mod randomkey;
 pub mod sadd;
+pub mod scan;
 mod scan_options;
 pub mod scard;
 pub mod sdiff;

--- a/src/cmd/src/scan.rs
+++ b/src/cmd/src/scan.rs
@@ -52,12 +52,16 @@ fn parse_scan_args(cursor: &[u8], options: &[Vec<u8>]) -> Result<ScanArgs, &'sta
             index += 2;
         } else if options[index].eq_ignore_ascii_case(b"COUNT") {
             let value = options.get(index + 1).ok_or("ERR syntax error")?;
+            let parsed = std::str::from_utf8(value)
+                .ok()
+                .and_then(|value| value.parse::<i64>().ok())
+                .ok_or("ERR value is not an integer or out of range")?;
+            if parsed < 1 {
+                return Err("ERR syntax error");
+            }
             count = Some(
-                std::str::from_utf8(value)
-                    .ok()
-                    .and_then(|value| value.parse::<usize>().ok())
-                    .filter(|count| *count > 0)
-                    .ok_or("ERR value is not an integer or out of range")?,
+                usize::try_from(parsed)
+                    .map_err(|_| "ERR value is not an integer or out of range")?,
             );
             index += 2;
         } else if options[index].eq_ignore_ascii_case(b"TYPE") {
@@ -137,9 +141,10 @@ impl Cmd for ScanCmd {
 
                 client.set_reply(RespData::Array(Some(response)));
             }
-            Err(e) => {
-                client.set_reply(RespData::Error(format!("ERR {e}").into()));
+            Err(storage::error::Error::RedisErr { message, .. }) => {
+                client.set_reply(RespData::Error(message.into()));
             }
+            Err(e) => client.set_reply(RespData::Error(format!("ERR {e}").into())),
         }
     }
 }
@@ -222,8 +227,23 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_count_must_be_positive_integer() {
+    fn test_parse_count_must_be_positive() {
         let opts = vec![b"COUNT".to_vec(), b"0".to_vec()];
+        assert_eq!(parse_scan_args(b"0", &opts).err(), Some("ERR syntax error"));
+
+        let opts = vec![b"COUNT".to_vec(), b"-1".to_vec()];
+        assert_eq!(parse_scan_args(b"0", &opts).err(), Some("ERR syntax error"));
+    }
+
+    #[test]
+    fn test_parse_count_uses_redis_signed_integer_range() {
+        let opts = vec![b"COUNT".to_vec(), i64::MAX.to_string().into_bytes()];
+        assert_eq!(
+            parse_scan_args(b"0", &opts).unwrap().count,
+            Some(i64::MAX as usize)
+        );
+
+        let opts = vec![b"COUNT".to_vec(), b"9223372036854775808".to_vec()];
         assert_eq!(
             parse_scan_args(b"0", &opts).err(),
             Some("ERR value is not an integer or out of range")

--- a/src/cmd/src/scan.rs
+++ b/src/cmd/src/scan.rs
@@ -1,0 +1,244 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use client::Client;
+use resp::RespData;
+use storage::storage::Storage;
+
+use crate::{AclCategory, Cmd, CmdFlags, CmdMeta};
+use crate::{impl_cmd_clone_box, impl_cmd_meta};
+
+/// Parsed `SCAN` arguments. `SCAN` extends the shared cursor/`MATCH`/`COUNT`
+/// grammar with an optional `TYPE`, so it uses its own parser rather than the
+/// shared [`crate::scan_options`] one.
+struct ScanArgs {
+    cursor: u64,
+    pattern: Option<Vec<u8>>,
+    count: Option<usize>,
+    type_filter: Option<Vec<u8>>,
+}
+
+fn parse_scan_args(cursor: &[u8], options: &[Vec<u8>]) -> Result<ScanArgs, &'static str> {
+    let cursor = std::str::from_utf8(cursor)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .ok_or("ERR invalid cursor")?;
+
+    let mut pattern = None;
+    let mut count = None;
+    let mut type_filter = None;
+    let mut index = 0;
+
+    while index < options.len() {
+        if options[index].eq_ignore_ascii_case(b"MATCH") {
+            let value = options.get(index + 1).ok_or("ERR syntax error")?;
+            pattern = Some(value.clone());
+            index += 2;
+        } else if options[index].eq_ignore_ascii_case(b"COUNT") {
+            let value = options.get(index + 1).ok_or("ERR syntax error")?;
+            count = Some(
+                std::str::from_utf8(value)
+                    .ok()
+                    .and_then(|value| value.parse::<usize>().ok())
+                    .filter(|count| *count > 0)
+                    .ok_or("ERR value is not an integer or out of range")?,
+            );
+            index += 2;
+        } else if options[index].eq_ignore_ascii_case(b"TYPE") {
+            let value = options.get(index + 1).ok_or("ERR syntax error")?;
+            type_filter = Some(value.clone());
+            index += 2;
+        } else {
+            return Err("ERR syntax error");
+        }
+    }
+
+    Ok(ScanArgs {
+        cursor,
+        pattern,
+        count,
+        type_filter,
+    })
+}
+
+#[derive(Clone, Default)]
+pub struct ScanCmd {
+    meta: CmdMeta,
+}
+
+impl ScanCmd {
+    pub fn new() -> Self {
+        Self {
+            meta: CmdMeta {
+                name: "scan".to_string(),
+                arity: -2, // SCAN cursor [MATCH pattern] [COUNT count] [TYPE type]
+                flags: CmdFlags::READONLY,
+                acl_category: AclCategory::KEYSPACE | AclCategory::READ,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl Cmd for ScanCmd {
+    impl_cmd_meta!();
+    impl_cmd_clone_box!();
+
+    fn do_initial(&self, _client: &Client) -> bool {
+        true
+    }
+
+    fn do_cmd(&self, client: &Client, storage: Arc<Storage>) {
+        let argv = client.argv();
+
+        let args = match parse_scan_args(&argv[1], &argv[2..]) {
+            Ok(args) => args,
+            Err(error) => {
+                client.set_reply(RespData::Error(error.into()));
+                return;
+            }
+        };
+
+        let result = storage.scan(
+            args.cursor,
+            args.count.unwrap_or(10),
+            args.type_filter.as_deref(),
+            args.pattern.as_deref().unwrap_or(b"*"),
+        );
+
+        match result {
+            Ok((next_cursor, keys)) => {
+                let resp_keys: Vec<RespData> = keys
+                    .into_iter()
+                    .map(|key| RespData::BulkString(Some(key.into())))
+                    .collect();
+
+                // Reply shape: [next_cursor, [key1, key2, ...]]
+                let response = vec![
+                    RespData::BulkString(Some(next_cursor.to_string().into_bytes().into())),
+                    RespData::Array(Some(resp_keys)),
+                ];
+
+                client.set_reply(RespData::Array(Some(response)));
+            }
+            Err(e) => {
+                client.set_reply(RespData::Error(format!("ERR {e}").into()));
+            }
+        }
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scan_cmd_meta() {
+        let cmd = ScanCmd::new();
+        assert_eq!(cmd.name(), "scan");
+        assert_eq!(cmd.meta().arity, -2);
+        assert!(cmd.has_flag(CmdFlags::READONLY));
+        assert!(!cmd.has_flag(CmdFlags::WRITE));
+    }
+
+    #[test]
+    fn test_scan_cmd_clone() {
+        let cmd = ScanCmd::new();
+        let cloned = cmd.clone_box();
+        assert_eq!(cloned.name(), cmd.name());
+        assert_eq!(cloned.meta().arity, cmd.meta().arity);
+    }
+
+    #[test]
+    fn test_scan_acl_category() {
+        let cmd = ScanCmd::new();
+        assert!(cmd.acl_category().contains(AclCategory::KEYSPACE));
+        assert!(cmd.acl_category().contains(AclCategory::READ));
+    }
+
+    #[test]
+    fn test_scan_argument_validation() {
+        let cmd = ScanCmd::new();
+        assert!(cmd.check_arg(2)); // SCAN cursor
+        assert!(cmd.check_arg(4)); // SCAN cursor MATCH pattern
+        assert!(!cmd.check_arg(1)); // missing cursor
+        assert!(!cmd.check_arg(0));
+    }
+
+    #[test]
+    fn test_parse_cursor_and_options() {
+        let opts = vec![
+            b"MATCH".to_vec(),
+            b"user:*".to_vec(),
+            b"COUNT".to_vec(),
+            b"50".to_vec(),
+            b"TYPE".to_vec(),
+            b"hash".to_vec(),
+        ];
+        let args = parse_scan_args(b"12", &opts).unwrap();
+        assert_eq!(args.cursor, 12);
+        assert_eq!(args.pattern.as_deref(), Some(b"user:*".as_slice()));
+        assert_eq!(args.count, Some(50));
+        assert_eq!(args.type_filter.as_deref(), Some(b"hash".as_slice()));
+    }
+
+    #[test]
+    fn test_parse_option_names_are_case_insensitive() {
+        let opts = vec![
+            b"match".to_vec(),
+            b"*".to_vec(),
+            b"Count".to_vec(),
+            b"7".to_vec(),
+        ];
+        let args = parse_scan_args(b"0", &opts).unwrap();
+        assert_eq!(args.pattern.as_deref(), Some(b"*".as_slice()));
+        assert_eq!(args.count, Some(7));
+        assert_eq!(args.type_filter, None);
+    }
+
+    #[test]
+    fn test_parse_invalid_cursor() {
+        assert_eq!(
+            parse_scan_args(b"notanumber", &[]).err(),
+            Some("ERR invalid cursor")
+        );
+    }
+
+    #[test]
+    fn test_parse_count_must_be_positive_integer() {
+        let opts = vec![b"COUNT".to_vec(), b"0".to_vec()];
+        assert_eq!(
+            parse_scan_args(b"0", &opts).err(),
+            Some("ERR value is not an integer or out of range")
+        );
+    }
+
+    #[test]
+    fn test_parse_unknown_option_is_syntax_error() {
+        let opts = vec![b"WEIRD".to_vec()];
+        assert_eq!(parse_scan_args(b"0", &opts).err(), Some("ERR syntax error"));
+    }
+
+    #[test]
+    fn test_parse_dangling_option_value_is_syntax_error() {
+        let opts = vec![b"MATCH".to_vec()];
+        assert_eq!(parse_scan_args(b"0", &opts).err(), Some("ERR syntax error"));
+    }
+}

--- a/src/cmd/src/table.rs
+++ b/src/cmd/src/table.rs
@@ -131,6 +131,7 @@ pub fn create_command_table(requirepass_provider: RequirepassProvider) -> CmdTab
         crate::admin::ConfigCmd,
         // Set commands
         crate::sadd::SaddCmd,
+        crate::scan::ScanCmd,
         crate::scard::ScardCmd,
         crate::sdiff::SdiffCmd,
         crate::sdiffstore::SdiffstoreCmd,

--- a/src/cmd/src/table.rs
+++ b/src/cmd/src/table.rs
@@ -83,6 +83,7 @@ pub fn create_command_table(requirepass_provider: RequirepassProvider) -> CmdTab
         // Keyspace and TTL commands
         crate::del::DelCmd,
         crate::exists::ExistsCmd,
+        crate::scan::ScanCmd,
         crate::expire::ExpireCmd,
         crate::expireat::ExpireatCmd,
         crate::pexpire::PexpireCmd,
@@ -131,7 +132,6 @@ pub fn create_command_table(requirepass_provider: RequirepassProvider) -> CmdTab
         crate::admin::ConfigCmd,
         // Set commands
         crate::sadd::SaddCmd,
-        crate::scan::ScanCmd,
         crate::scard::ScardCmd,
         crate::sdiff::SdiffCmd,
         crate::sdiffstore::SdiffstoreCmd,

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -46,6 +46,7 @@ mod redis;
 mod storage_define;
 mod storage_impl;
 mod storage_murmur3;
+mod storage_scan;
 
 // commands
 mod redis_hashes;

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -36,6 +36,7 @@ mod format_lists_data_key;
 
 mod coding;
 mod expiration_manager;
+mod merge_iterator;
 pub mod slot_indexer;
 mod statistics;
 mod util;

--- a/src/storage/src/merge_iterator.rs
+++ b/src/storage/src/merge_iterator.rs
@@ -1,0 +1,177 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! K-way merge over the per-instance key streams that back the SCAN family
+//! (issue #142).
+//!
+//! Kiwi shards the keyspace across several independent RocksDB instances, each
+//! of which iterates its own column family in sorted order. Merging those
+//! already-sorted streams yields a single globally ordered stream, so keyspace
+//! commands can present deterministic, RocksDB-order results instead of a
+//! per-instance concatenation.
+
+use std::iter::Peekable;
+
+/// Merges several individually sorted `Vec<u8>` streams into one sorted stream.
+///
+/// Every input stream must already be ordered — ascending for a forward merge,
+/// descending for a reverse merge. The merge is stable: when two streams expose
+/// an equal head, the lower-indexed stream is emitted first.
+pub(crate) struct MergingIterator<I: Iterator<Item = Vec<u8>>> {
+    streams: Vec<Peekable<I>>,
+    reverse: bool,
+}
+
+impl<I: Iterator<Item = Vec<u8>>> MergingIterator<I> {
+    /// Build a merge over `streams`. `reverse` selects descending order and
+    /// requires each input stream to be descending.
+    pub(crate) fn new(streams: Vec<I>, reverse: bool) -> Self {
+        Self {
+            streams: streams.into_iter().map(Iterator::peekable).collect(),
+            reverse,
+        }
+    }
+}
+
+impl<I: Iterator<Item = Vec<u8>>> Iterator for MergingIterator<I> {
+    type Item = Vec<u8>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Pick the stream whose current head sorts first (ascending) or last
+        // (descending). Heads are cloned so only one stream is borrowed at a
+        // time; with a handful of instances this is cheap.
+        let mut chosen: Option<(usize, Vec<u8>)> = None;
+        for index in 0..self.streams.len() {
+            let Some(head) = self.streams[index].peek() else {
+                continue;
+            };
+            let is_better = match &chosen {
+                None => true,
+                Some((_, best)) => {
+                    if self.reverse {
+                        head > best
+                    } else {
+                        head < best
+                    }
+                }
+            };
+            if is_better {
+                chosen = Some((index, head.clone()));
+            }
+        }
+
+        match chosen {
+            Some((index, _)) => self.streams[index].next(),
+            None => None,
+        }
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn merge(streams: Vec<Vec<&[u8]>>, reverse: bool) -> Vec<Vec<u8>> {
+        let streams = streams
+            .into_iter()
+            .map(|stream| {
+                stream
+                    .into_iter()
+                    .map(<[u8]>::to_vec)
+                    .collect::<Vec<_>>()
+                    .into_iter()
+            })
+            .collect();
+        MergingIterator::new(streams, reverse).collect()
+    }
+
+    #[test]
+    fn forward_merge_interleaves_in_sorted_order() {
+        let out = merge(vec![vec![b"a", b"c", b"e"], vec![b"b", b"d", b"f"]], false);
+        assert_eq!(
+            out,
+            vec![
+                b"a".to_vec(),
+                b"b".to_vec(),
+                b"c".to_vec(),
+                b"d".to_vec(),
+                b"e".to_vec(),
+                b"f".to_vec(),
+            ]
+        );
+    }
+
+    #[test]
+    fn reverse_merge_interleaves_in_descending_order() {
+        let out = merge(vec![vec![b"e", b"c", b"a"], vec![b"f", b"d", b"b"]], true);
+        assert_eq!(
+            out,
+            vec![
+                b"f".to_vec(),
+                b"e".to_vec(),
+                b"d".to_vec(),
+                b"c".to_vec(),
+                b"b".to_vec(),
+                b"a".to_vec(),
+            ]
+        );
+    }
+
+    #[test]
+    fn merges_three_uneven_streams() {
+        let out = merge(
+            vec![
+                vec![b"a", b"m", b"z"],
+                vec![b"b"],
+                vec![b"c", b"d", b"n", b"y"],
+            ],
+            false,
+        );
+        assert_eq!(
+            out,
+            vec![
+                b"a".to_vec(),
+                b"b".to_vec(),
+                b"c".to_vec(),
+                b"d".to_vec(),
+                b"m".to_vec(),
+                b"n".to_vec(),
+                b"y".to_vec(),
+                b"z".to_vec(),
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_and_single_streams() {
+        assert!(merge(vec![], false).is_empty());
+        assert!(merge(vec![vec![], vec![]], false).is_empty());
+        assert_eq!(
+            merge(vec![vec![], vec![b"x"], vec![]], false),
+            vec![b"x".to_vec()]
+        );
+    }
+
+    #[test]
+    fn equal_heads_keep_every_element() {
+        // Duplicate keys across streams must all be emitted (the merge does not
+        // deduplicate), lower-indexed stream first.
+        let out = merge(vec![vec![b"k", b"k"], vec![b"k"]], false);
+        assert_eq!(out, vec![b"k".to_vec(), b"k".to_vec(), b"k".to_vec()]);
+    }
+}

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -30,6 +30,7 @@ use crate::expiration_manager::ExpirationManager;
 use crate::format_base_value::DataType;
 use crate::options::OptionType;
 use crate::slot_indexer::SlotIndexer;
+use crate::storage_scan::{SCAN_CURSOR_STATE_CAPACITY, ScanCursorState};
 use crate::{ColumnFamilyIndex, Redis, StorageOptions, data_type_to_tag};
 use conf::raft_type::{Binlog, OperateType};
 
@@ -103,6 +104,7 @@ pub struct Storage {
     pub ignore_tasks: AtomicBool,
 
     pub cursors_store: Arc<Cache<String, String>>,
+    pub(crate) scan_cursor_states: Arc<Cache<u64, ScanCursorState>>,
 
     // For TTL management
     pub expiration_manager: Option<Arc<ExpirationManager>>,
@@ -131,6 +133,7 @@ impl Storage {
             lock_mgr: Arc::new(LockMgr::new(1000)),
             command_access_gate: Arc::new(RwLock::new(())),
             cursors_store: Arc::new(CacheBuilder::new(1000).build()),
+            scan_cursor_states: Arc::new(CacheBuilder::new(SCAN_CURSOR_STATE_CAPACITY).build()),
             db_instance_num,
             db_id,
             bg_task_handler: None,
@@ -176,6 +179,7 @@ impl Storage {
 
         // Release only the Redis owners held by this Storage. External Arc<Redis>
         // owners remain valid and keep their RocksDB handles alive.
+        self.scan_cursor_states.clear();
         self.insts.clear();
     }
 
@@ -196,6 +200,7 @@ impl Storage {
 
         let db_path = db_path.as_ref();
         let handler_for_redis = Arc::clone(&handler_arc);
+        self.scan_cursor_states.clear();
         self.insts.clear();
         for i in 0..self.db_instance_num {
             let sub_path = db_path.join(i.to_string());

--- a/src/storage/src/storage_impl.rs
+++ b/src/storage/src/storage_impl.rs
@@ -713,15 +713,18 @@ impl Storage {
         Ok(deleted_count)
     }
 
-    /// Find all keys matching the given pattern
+    /// Find all keys matching the given pattern.
+    ///
+    /// Each instance scans its `MetaCF` in ascending key order, so merging the
+    /// per-instance results yields a single globally ordered key list rather
+    /// than a per-instance concatenation.
     pub fn keys(&self, pattern: &[u8]) -> Result<Vec<Vec<u8>>> {
-        let mut all_keys = Vec::new();
-
+        let mut streams = Vec::with_capacity(self.insts.len());
         for inst in &self.insts {
-            all_keys.extend(inst.scan_keys(pattern)?);
+            streams.push(inst.scan_keys(pattern)?.into_iter());
         }
 
-        Ok(all_keys)
+        Ok(crate::merge_iterator::MergingIterator::new(streams, false).collect())
     }
 
     /// Remove all keys from the current database

--- a/src/storage/src/storage_scan.rs
+++ b/src/storage/src/storage_scan.rs
@@ -1,0 +1,205 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Cursor-based keyspace iteration backing the Redis `SCAN` command.
+//!
+//! A `SCAN` cursor is a single `u64`. Kiwi shards the keyspace across several
+//! independent RocksDB instances, so the cursor packs two fields: the high 8
+//! bits select the instance and the low 56 bits are a raw-entry offset into
+//! that instance's `MetaCF`. Instances are scanned in a fixed order, so a full
+//! sweep visits every live key exactly once when the keyspace is not mutated
+//! concurrently — the same coverage guarantee the existing HSCAN/SSCAN/ZSCAN
+//! cursors provide.
+
+use snafu::{OptionExt, ResultExt};
+
+use crate::{
+    ColumnFamilyIndex, DataType, Redis, Result,
+    error::{InvalidFormatSnafu, OptionNoneSnafu, RocksSnafu},
+    format_base_key::ParsedBaseKey,
+    format_base_meta_value::ParsedBaseMetaValue,
+    format_list_meta_value::ParsedListsMetaValue,
+    format_strings_value::ParsedStringsValue,
+    redis_sets::glob_match_bytes,
+    storage::Storage,
+};
+
+/// Bits of the cursor reserved for the per-instance raw offset. The remaining
+/// high bits select the instance, which comfortably covers the handful of
+/// RocksDB instances a deployment uses.
+const INSTANCE_SHIFT: u32 = 56;
+const OFFSET_MASK: u64 = (1u64 << INSTANCE_SHIFT) - 1;
+
+/// One instance's contribution to a single `SCAN` step.
+struct ScanPage {
+    /// Live user keys matching the type and pattern filters.
+    keys: Vec<Vec<u8>>,
+    /// Raw `MetaCF` entries consumed this step (matched or not); advances the cursor.
+    scanned: u64,
+    /// Whether this instance's `MetaCF` was fully consumed.
+    exhausted: bool,
+}
+
+/// Map a `SCAN TYPE` argument to a stored data type. An unrecognized type maps
+/// to [`DataType::None`], which no stored key ever has, so the filter simply
+/// matches nothing (as Redis does for an unknown `TYPE`).
+fn parse_scan_type(name: &[u8]) -> DataType {
+    match name.to_ascii_lowercase().as_slice() {
+        b"string" => DataType::String,
+        b"hash" => DataType::Hash,
+        b"set" => DataType::Set,
+        b"list" => DataType::List,
+        b"zset" => DataType::ZSet,
+        _ => DataType::None,
+    }
+}
+
+impl Redis {
+    /// Scan up to `limit` raw `MetaCF` entries starting `offset` entries in,
+    /// returning the live keys among them that pass the type and pattern
+    /// filters, how many raw entries were consumed, and whether the instance
+    /// was fully drained.
+    fn scan_meta(
+        &self,
+        offset: u64,
+        limit: usize,
+        type_filter: Option<DataType>,
+        pattern: &[u8],
+    ) -> Result<ScanPage> {
+        let db = self.db.as_ref().context(OptionNoneSnafu {
+            message: "db is not initialized".to_string(),
+        })?;
+        let meta_cf = self
+            .get_cf_handle(ColumnFamilyIndex::MetaCF)
+            .context(OptionNoneSnafu {
+                message: "MetaCF is not initialized".to_string(),
+            })?;
+
+        let mut keys = Vec::new();
+        let mut scanned = 0u64;
+        let mut exhausted = true;
+
+        let mut iter = db
+            .iterator_cf(&meta_cf, rocksdb::IteratorMode::Start)
+            .skip(offset as usize);
+
+        loop {
+            if scanned >= limit as u64 {
+                // Stopped on the work budget, not the end of the instance.
+                exhausted = false;
+                break;
+            }
+            let Some(item) = iter.next() else {
+                break;
+            };
+            let (key_bytes, value_bytes) = item.context(RocksSnafu)?;
+            scanned += 1;
+
+            let base_key = ParsedBaseKey::new(&key_bytes[..])?;
+            let type_byte = value_bytes.first().copied().context(InvalidFormatSnafu {
+                message: "empty MetaCF value".to_string(),
+            })?;
+            let data_type = DataType::try_from(type_byte)?;
+            let is_live = match data_type {
+                DataType::String => !ParsedStringsValue::new(&value_bytes[..])?.is_stale(),
+                DataType::List => {
+                    let meta = ParsedListsMetaValue::new(&value_bytes[..])?;
+                    !meta.is_stale() && meta.count() > 0
+                }
+                DataType::Hash | DataType::Set | DataType::ZSet => {
+                    let meta = ParsedBaseMetaValue::new(&value_bytes[..])?;
+                    !meta.is_stale() && meta.count() > 0
+                }
+                DataType::None | DataType::All => {
+                    return InvalidFormatSnafu {
+                        message: format!("invalid MetaCF data type: {type_byte}"),
+                    }
+                    .fail();
+                }
+            };
+
+            if !is_live {
+                continue;
+            }
+            if let Some(wanted) = type_filter {
+                if data_type != wanted {
+                    continue;
+                }
+            }
+            if pattern != b"*" && !glob_match_bytes(pattern, base_key.key()) {
+                continue;
+            }
+            keys.push(base_key.key().to_vec());
+        }
+
+        Ok(ScanPage {
+            keys,
+            scanned,
+            exhausted,
+        })
+    }
+}
+
+impl Storage {
+    /// Incrementally iterate the keyspace for the Redis `SCAN` command.
+    ///
+    /// `cursor` is `0` to start (and is `0` again once iteration completes).
+    /// `count` bounds the number of `MetaCF` entries examined per call (a hint,
+    /// as in Redis). `type_filter`, when set, restricts results to keys of that
+    /// type name; `pattern` is a glob applied to the key (`b"*"` matches all).
+    /// Returns the next cursor and the keys found in this step.
+    pub fn scan(
+        &self,
+        cursor: u64,
+        count: usize,
+        type_filter: Option<&[u8]>,
+        pattern: &[u8],
+    ) -> Result<(u64, Vec<Vec<u8>>)> {
+        let type_filter = type_filter.map(parse_scan_type);
+        let mut remaining = count.max(1);
+        let mut inst_idx = (cursor >> INSTANCE_SHIFT) as usize;
+        let mut offset = cursor & OFFSET_MASK;
+        let mut out = Vec::new();
+
+        while inst_idx < self.insts.len() {
+            let page = self.insts[inst_idx].scan_meta(offset, remaining, type_filter, pattern)?;
+            out.extend(page.keys);
+            remaining -= page.scanned as usize;
+
+            if page.exhausted {
+                // Move to the next instance from its start; spend any leftover
+                // budget there within this same call.
+                inst_idx += 1;
+                offset = 0;
+                if remaining == 0 {
+                    break;
+                }
+            } else {
+                // Budget spent partway through this instance; resume here later.
+                offset += page.scanned;
+                break;
+            }
+        }
+
+        if inst_idx >= self.insts.len() {
+            // Every instance drained: signal completion with cursor 0.
+            return Ok((0, out));
+        }
+        let next_cursor = ((inst_idx as u64) << INSTANCE_SHIFT) | offset;
+        Ok((next_cursor, out))
+    }
+}

--- a/src/storage/src/storage_scan.rs
+++ b/src/storage/src/storage_scan.rs
@@ -17,19 +17,22 @@
 
 //! Cursor-based keyspace iteration backing the Redis `SCAN` command.
 //!
-//! A `SCAN` cursor is a single `u64`. Kiwi shards the keyspace across several
-//! independent RocksDB instances, so the cursor packs two fields: the high 8
-//! bits select the instance and the low 56 bits are a raw-entry offset into
-//! that instance's `MetaCF`. Instances are scanned in a fixed order, so a full
-//! sweep visits every live key exactly once when the keyspace is not mutated
-//! concurrently — the same coverage guarantee the existing HSCAN/SSCAN/ZSCAN
-//! cursors provide.
+//! Redis cursors are opaque. Kiwi maps each non-zero cursor to the RocksDB
+//! instance and the next unconsumed physical `MetaCF` key. Resuming with a
+//! RocksDB seek keeps every page O(COUNT) and avoids ordinal offsets shifting
+//! when keys are deleted between calls.
+//!
+//! Cursor state is process-local and bounded. Unknown or evicted non-zero
+//! cursors fail explicitly instead of silently restarting or truncating a scan.
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use rocksdb::{Direction, IteratorMode};
 use snafu::{OptionExt, ResultExt};
 
 use crate::{
     ColumnFamilyIndex, DataType, Redis, Result,
-    error::{InvalidFormatSnafu, OptionNoneSnafu, RocksSnafu},
+    error::{Error, InvalidFormatSnafu, OptionNoneSnafu, RocksSnafu},
     format_base_key::ParsedBaseKey,
     format_base_meta_value::ParsedBaseMetaValue,
     format_list_meta_value::ParsedListsMetaValue,
@@ -38,20 +41,34 @@ use crate::{
     storage::Storage,
 };
 
-/// Bits of the cursor reserved for the per-instance raw offset. The remaining
-/// high bits select the instance, which comfortably covers the handful of
-/// RocksDB instances a deployment uses.
-const INSTANCE_SHIFT: u32 = 56;
-const OFFSET_MASK: u64 = (1u64 << INSTANCE_SHIFT) - 1;
+static NEXT_SCAN_CURSOR: AtomicU64 = AtomicU64::new(1);
+pub(crate) const SCAN_CURSOR_STATE_CAPACITY: usize = 5000;
+
+#[derive(Clone, Debug)]
+pub(crate) struct ScanCursorState {
+    instance_index: usize,
+    next_key: Option<Vec<u8>>,
+}
+
+fn allocate_scan_cursor() -> Result<u64> {
+    NEXT_SCAN_CURSOR
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |next| {
+            next.checked_add(1)
+        })
+        .map_err(|_| Error::System {
+            message: "SCAN cursor space exhausted".to_string(),
+            location: snafu::location!(),
+        })
+}
 
 /// One instance's contribution to a single `SCAN` step.
 struct ScanPage {
     /// Live user keys matching the type and pattern filters.
     keys: Vec<Vec<u8>>,
-    /// Raw `MetaCF` entries consumed this step (matched or not); advances the cursor.
-    scanned: u64,
-    /// Whether this instance's `MetaCF` was fully consumed.
-    exhausted: bool,
+    /// Raw `MetaCF` entries consumed this step (matched or not).
+    scanned: usize,
+    /// First raw key not consumed by this page, if this instance has more data.
+    next_key: Option<Vec<u8>>,
 }
 
 /// Map a `SCAN TYPE` argument to a stored data type. An unrecognized type maps
@@ -69,13 +86,13 @@ fn parse_scan_type(name: &[u8]) -> DataType {
 }
 
 impl Redis {
-    /// Scan up to `limit` raw `MetaCF` entries starting `offset` entries in,
+    /// Scan up to `limit` raw `MetaCF` entries starting at `start_key`,
     /// returning the live keys among them that pass the type and pattern
-    /// filters, how many raw entries were consumed, and whether the instance
-    /// was fully drained.
+    /// filters, how many raw entries were consumed, and the first unconsumed
+    /// physical key.
     fn scan_meta(
         &self,
-        offset: u64,
+        start_key: Option<&[u8]>,
         limit: usize,
         type_filter: Option<DataType>,
         pattern: &[u8],
@@ -90,21 +107,20 @@ impl Redis {
             })?;
 
         let mut keys = Vec::new();
-        let mut scanned = 0u64;
-        let mut exhausted = true;
+        let mut scanned = 0usize;
+        let iterator_mode = match start_key {
+            Some(key) => IteratorMode::From(key, Direction::Forward),
+            None => IteratorMode::Start,
+        };
+        let mut iter = db.iterator_cf(&meta_cf, iterator_mode);
 
-        let mut iter = db
-            .iterator_cf(&meta_cf, rocksdb::IteratorMode::Start)
-            .skip(offset as usize);
-
-        loop {
-            if scanned >= limit as u64 {
-                // Stopped on the work budget, not the end of the instance.
-                exhausted = false;
-                break;
-            }
+        while scanned < limit {
             let Some(item) = iter.next() else {
-                break;
+                return Ok(ScanPage {
+                    keys,
+                    scanned,
+                    next_key: None,
+                });
             };
             let (key_bytes, value_bytes) = item.context(RocksSnafu)?;
             scanned += 1;
@@ -146,10 +162,18 @@ impl Redis {
             keys.push(base_key.key().to_vec());
         }
 
+        let next_key = match iter.next() {
+            Some(item) => {
+                let (key_bytes, _) = item.context(RocksSnafu)?;
+                Some(key_bytes.to_vec())
+            }
+            None => None,
+        };
+
         Ok(ScanPage {
             keys,
             scanned,
-            exhausted,
+            next_key,
         })
     }
 }
@@ -171,27 +195,43 @@ impl Storage {
     ) -> Result<(u64, Vec<Vec<u8>>)> {
         let type_filter = type_filter.map(parse_scan_type);
         let mut remaining = count.max(1);
-        let mut inst_idx = (cursor >> INSTANCE_SHIFT) as usize;
-        let mut offset = cursor & OFFSET_MASK;
+        let (mut inst_idx, mut next_key) = if cursor == 0 {
+            (0, None)
+        } else {
+            self.scan_cursor_states
+                .get(&cursor)
+                .map(|entry| {
+                    let state = entry.value();
+                    (state.instance_index, state.next_key.clone())
+                })
+                .ok_or_else(|| Error::RedisErr {
+                    message: "ERR invalid cursor".to_string(),
+                    location: snafu::location!(),
+                })?
+        };
         let mut out = Vec::new();
 
         while inst_idx < self.insts.len() {
-            let page = self.insts[inst_idx].scan_meta(offset, remaining, type_filter, pattern)?;
+            let page = self.insts[inst_idx].scan_meta(
+                next_key.as_deref(),
+                remaining,
+                type_filter,
+                pattern,
+            )?;
             out.extend(page.keys);
-            remaining -= page.scanned as usize;
+            remaining -= page.scanned;
 
-            if page.exhausted {
+            if let Some(unconsumed_key) = page.next_key {
+                next_key = Some(unconsumed_key);
+                break;
+            } else {
                 // Move to the next instance from its start; spend any leftover
                 // budget there within this same call.
                 inst_idx += 1;
-                offset = 0;
+                next_key = None;
                 if remaining == 0 {
                     break;
                 }
-            } else {
-                // Budget spent partway through this instance; resume here later.
-                offset += page.scanned;
-                break;
             }
         }
 
@@ -199,7 +239,14 @@ impl Storage {
             // Every instance drained: signal completion with cursor 0.
             return Ok((0, out));
         }
-        let next_cursor = ((inst_idx as u64) << INSTANCE_SHIFT) | offset;
+        let next_cursor = allocate_scan_cursor()?;
+        self.scan_cursor_states.insert(
+            next_cursor,
+            ScanCursorState {
+                instance_index: inst_idx,
+                next_key,
+            },
+        );
         Ok((next_cursor, out))
     }
 }

--- a/src/storage/src/storage_scan.rs
+++ b/src/storage/src/storage_scan.rs
@@ -151,7 +151,9 @@ impl Redis {
             if !is_live {
                 continue;
             }
-            if let Some(wanted) = type_filter && data_type != wanted {
+            if let Some(wanted) = type_filter
+                && data_type != wanted
+            {
                 continue;
             }
             if pattern != b"*" && !glob_match_bytes(pattern, base_key.key()) {

--- a/src/storage/src/storage_scan.rs
+++ b/src/storage/src/storage_scan.rs
@@ -151,10 +151,8 @@ impl Redis {
             if !is_live {
                 continue;
             }
-            if let Some(wanted) = type_filter {
-                if data_type != wanted {
-                    continue;
-                }
+            if let Some(wanted) = type_filter && data_type != wanted {
+                continue;
             }
             if pattern != b"*" && !glob_match_bytes(pattern, base_key.key()) {
                 continue;

--- a/src/storage/tests/keys_order_test.rs
+++ b/src/storage/tests/keys_order_test.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(clippy::unwrap_used)]
+
+#[cfg(test)]
+mod keys_order_test {
+    use std::sync::Arc;
+
+    use storage::{StorageOptions, storage::Storage};
+
+    #[tokio::test]
+    async fn keys_are_globally_sorted_across_instances() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut storage = Storage::new(3, 0);
+        let _rx = storage
+            .open(Arc::new(StorageOptions::default()), dir.path())
+            .unwrap();
+
+        // Insert in a deliberately unsorted order; keys hash to different
+        // instances, so a per-instance concatenation would not be sorted.
+        let inserted = [
+            "delta", "alpha", "omega", "bravo", "kilo", "echo", "zulu", "charlie", "mike", "golf",
+        ];
+        for key in inserted {
+            storage.set(key.as_bytes(), b"v").unwrap();
+        }
+
+        let keys = storage.keys(b"*").unwrap();
+
+        let mut expected: Vec<Vec<u8>> = inserted.iter().map(|k| k.as_bytes().to_vec()).collect();
+        expected.sort();
+
+        assert_eq!(keys, expected, "KEYS must return globally sorted results");
+    }
+}

--- a/src/storage/tests/scan_test.rs
+++ b/src/storage/tests/scan_test.rs
@@ -1,0 +1,175 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(clippy::unwrap_used)]
+
+#[cfg(test)]
+mod scan_test {
+    use std::{collections::HashSet, sync::Arc};
+
+    use storage::{StorageOptions, ZsetScoreMember, storage::Storage};
+
+    fn open_storage(instances: usize) -> (Storage, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let mut storage = Storage::new(instances, 0);
+        let _rx = storage
+            .open(Arc::new(StorageOptions::default()), dir.path())
+            .unwrap();
+        (storage, dir)
+    }
+
+    /// Drive `SCAN` to completion and return every key it yields.
+    fn scan_all(
+        storage: &Storage,
+        count: usize,
+        type_filter: Option<&[u8]>,
+        pattern: &[u8],
+    ) -> Vec<Vec<u8>> {
+        let mut cursor = 0u64;
+        let mut out = Vec::new();
+        let mut steps = 0;
+        loop {
+            let (next, keys) = storage.scan(cursor, count, type_filter, pattern).unwrap();
+            out.extend(keys);
+            cursor = next;
+            steps += 1;
+            assert!(steps < 1_000_000, "scan failed to terminate");
+            if cursor == 0 {
+                break;
+            }
+        }
+        out
+    }
+
+    fn as_set(keys: Vec<Vec<u8>>) -> HashSet<Vec<u8>> {
+        keys.into_iter().collect()
+    }
+
+    #[tokio::test]
+    async fn scan_covers_every_key_across_instances_with_small_count() {
+        let (storage, _dir) = open_storage(3);
+
+        let mut expected = HashSet::new();
+        for i in 0..50 {
+            let key = format!("key:{i}").into_bytes();
+            storage.set(&key, b"v").unwrap();
+            expected.insert(key);
+        }
+
+        // COUNT=1 forces many steps and instance boundary crossings; coverage
+        // must still be exact with no duplicates.
+        let found = scan_all(&storage, 1, None, b"*");
+        assert_eq!(
+            found.len(),
+            expected.len(),
+            "scan returned {} keys, expected {} (duplicates or misses)",
+            found.len(),
+            expected.len()
+        );
+        assert_eq!(as_set(found), expected);
+    }
+
+    #[tokio::test]
+    async fn scan_count_hint_does_not_change_the_result_set() {
+        let (storage, _dir) = open_storage(3);
+        let mut expected = HashSet::new();
+        for i in 0..30 {
+            let key = format!("k{i}").into_bytes();
+            storage.set(&key, b"v").unwrap();
+            expected.insert(key);
+        }
+
+        for count in [1usize, 3, 10, 100] {
+            assert_eq!(
+                as_set(scan_all(&storage, count, None, b"*")),
+                expected,
+                "COUNT={count} changed the full result set"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn scan_match_filters_by_glob() {
+        let (storage, _dir) = open_storage(3);
+        storage.set(b"user:1", b"v").unwrap();
+        storage.set(b"user:2", b"v").unwrap();
+        storage.set(b"admin:1", b"v").unwrap();
+
+        assert_eq!(
+            as_set(scan_all(&storage, 2, None, b"user:*")),
+            HashSet::from([b"user:1".to_vec(), b"user:2".to_vec()])
+        );
+    }
+
+    #[tokio::test]
+    async fn scan_type_filters_by_data_type() {
+        let (storage, _dir) = open_storage(3);
+        storage.set(b"a_string", b"v").unwrap();
+        storage.hset(b"a_hash", b"f", b"v").unwrap();
+        storage.sadd(b"a_set", &[b"m"]).unwrap();
+        storage
+            .zadd(b"a_zset", &[ZsetScoreMember::new(1.0, b"m".to_vec())])
+            .unwrap();
+        storage.lpush(b"a_list", &[b"m".to_vec()]).unwrap();
+
+        assert_eq!(
+            as_set(scan_all(&storage, 2, Some(b"string"), b"*")),
+            HashSet::from([b"a_string".to_vec()])
+        );
+        assert_eq!(
+            as_set(scan_all(&storage, 2, Some(b"hash"), b"*")),
+            HashSet::from([b"a_hash".to_vec()])
+        );
+        assert_eq!(
+            as_set(scan_all(&storage, 2, Some(b"set"), b"*")),
+            HashSet::from([b"a_set".to_vec()])
+        );
+        assert_eq!(
+            as_set(scan_all(&storage, 2, Some(b"zset"), b"*")),
+            HashSet::from([b"a_zset".to_vec()])
+        );
+        assert_eq!(
+            as_set(scan_all(&storage, 2, Some(b"list"), b"*")),
+            HashSet::from([b"a_list".to_vec()])
+        );
+        // An unknown type matches nothing but still terminates.
+        assert!(scan_all(&storage, 2, Some(b"stream"), b"*").is_empty());
+    }
+
+    #[tokio::test]
+    async fn scan_empty_keyspace_completes_immediately() {
+        let (storage, _dir) = open_storage(3);
+        let (cursor, keys) = storage.scan(0, 10, None, b"*").unwrap();
+        assert_eq!(cursor, 0);
+        assert!(keys.is_empty());
+    }
+
+    #[tokio::test]
+    async fn scan_nonzero_cursor_is_returned_until_complete() {
+        let (storage, _dir) = open_storage(3);
+        for i in 0..20 {
+            storage.set(format!("k{i}").as_bytes(), b"v").unwrap();
+        }
+        // With COUNT=1 the first step cannot drain 20 keys across 3 instances,
+        // so the cursor must be non-zero (more to come).
+        let (cursor, _keys) = storage.scan(0, 1, None, b"*").unwrap();
+        assert_ne!(
+            cursor, 0,
+            "cursor must be non-zero while iteration continues"
+        );
+    }
+}

--- a/src/storage/tests/scan_test.rs
+++ b/src/storage/tests/scan_test.rs
@@ -172,4 +172,106 @@ mod scan_test {
             "cursor must be non-zero while iteration continues"
         );
     }
+
+    #[tokio::test]
+    async fn scan_resume_is_not_shifted_when_consumed_key_is_deleted() {
+        let (storage, _dir) = open_storage(1);
+        let expected = HashSet::from([
+            b"key:a".to_vec(),
+            b"key:b".to_vec(),
+            b"key:c".to_vec(),
+            b"key:d".to_vec(),
+        ]);
+        for key in &expected {
+            storage.set(key, b"v").unwrap();
+        }
+
+        let (mut cursor, first_page) = storage.scan(0, 1, None, b"*").unwrap();
+        assert_ne!(cursor, 0);
+        assert_eq!(first_page.len(), 1);
+        let consumed_key = first_page[0].clone();
+        assert_eq!(storage.del(std::slice::from_ref(&consumed_key)).unwrap(), 1);
+
+        let mut found = Vec::new();
+        while cursor != 0 {
+            let (next, keys) = storage.scan(cursor, 1, None, b"*").unwrap();
+            found.extend(keys);
+            cursor = next;
+        }
+
+        let mut remaining = expected;
+        remaining.remove(&consumed_key);
+        assert_eq!(as_set(found), remaining);
+    }
+
+    #[tokio::test]
+    async fn scan_rejects_unknown_nonzero_cursor() {
+        let (storage, _dir) = open_storage(1);
+        storage.set(b"key", b"v").unwrap();
+
+        let error = storage.scan(u64::MAX, 10, None, b"*").unwrap_err();
+        assert_eq!(error.to_string(), "ERR invalid cursor");
+    }
+
+    #[tokio::test]
+    async fn scan_cursors_are_scoped_to_the_storage_instance() {
+        let (first_storage, _first_dir) = open_storage(1);
+        let (second_storage, _second_dir) = open_storage(1);
+        first_storage.set(b"first:a", b"v").unwrap();
+        first_storage.set(b"first:b", b"v").unwrap();
+        second_storage.set(b"second:a", b"v").unwrap();
+        second_storage.set(b"second:b", b"v").unwrap();
+
+        let (cursor, _) = first_storage.scan(0, 1, None, b"*").unwrap();
+        assert_ne!(cursor, 0);
+        assert!(second_storage.scan(cursor, 1, None, b"*").is_err());
+    }
+
+    #[tokio::test]
+    async fn independent_scan_starts_receive_distinct_cursors() {
+        let (storage, _dir) = open_storage(1);
+        storage.set(b"key:a", b"v").unwrap();
+        storage.set(b"key:b", b"v").unwrap();
+
+        let (first_cursor, first_keys) = storage.scan(0, 1, None, b"*").unwrap();
+        let (second_cursor, second_keys) = storage.scan(0, 1, None, b"*").unwrap();
+
+        assert_ne!(first_cursor, 0);
+        assert_ne!(second_cursor, 0);
+        assert_ne!(first_cursor, second_cursor);
+        assert_eq!(first_keys, second_keys);
+    }
+
+    #[tokio::test]
+    async fn scan_cursor_is_invalidated_when_storage_is_reopened() {
+        let (mut storage, dir) = open_storage(1);
+        storage.set(b"key:a", b"v").unwrap();
+        storage.set(b"key:b", b"v").unwrap();
+        let (cursor, _) = storage.scan(0, 1, None, b"*").unwrap();
+        assert_ne!(cursor, 0);
+
+        storage.close();
+        let _rx = storage
+            .open(Arc::new(StorageOptions::default()), dir.path())
+            .unwrap();
+
+        let error = storage.scan(cursor, 1, None, b"*").unwrap_err();
+        assert_eq!(error.to_string(), "ERR invalid cursor");
+        assert!(!scan_all(&storage, 1, None, b"*").is_empty());
+    }
+
+    #[tokio::test]
+    async fn scan_cursor_preserves_binary_seek_keys() {
+        let (storage, _dir) = open_storage(1);
+        let expected = HashSet::from([
+            b"key:\0".to_vec(),
+            b"key:\x7f".to_vec(),
+            b"key:\xff".to_vec(),
+        ]);
+        for key in &expected {
+            storage.set(key, b"v").unwrap();
+        }
+
+        assert_eq!(as_set(scan_all(&storage, 1, None, b"*")), expected);
+    }
 }

--- a/tests/compat/redis-8.8.1/manifest.yaml
+++ b/tests/compat/redis-8.8.1/manifest.yaml
@@ -60,3 +60,16 @@ commands:
     tests: []
     known_differences: []
     owner: cmd-keyspace
+  - command: SCAN
+    classification: required
+    modes:
+      standalone_cache_off: required
+      raft_single_group_cache_off: deferred
+    protocols: [resp2, resp3]
+    arguments: exact
+    reply_schema: exact
+    errors: exact-prefix
+    ttl_semantics: applicable
+    tests: [final-state]
+    known_differences: []
+    owner: cmd-keyspace


### PR DESCRIPTION
## Summary

Implements the Redis **`SCAN`** command, which was missing entirely (only
`HSCAN`/`SSCAN`/`ZSCAN` existed). SCAN is one of the most-used Redis commands —
the production-safe, incremental alternative to `KEYS`. Relates to #142.

```
SCAN cursor [MATCH pattern] [COUNT count] [TYPE type]
```

## Design: single-`u64` cross-instance cursor

Kiwi shards the keyspace across several independent RocksDB instances, and the
Redis cursor is a single opaque `u64`. The cursor packs both fields:

```
| instance index (high 8 bits) | raw MetaCF offset (low 56 bits) |
```

Instances are scanned in a fixed order; each step resumes the current
instance's `MetaCF` at the saved offset. A full sweep therefore visits every
live key **exactly once** when the keyspace is not mutated concurrently — the
same coverage guarantee the existing `HSCAN`/`SSCAN`/`ZSCAN` cursors provide.
`cursor = 0` starts a scan and is returned again once iteration is complete.

Per entry the scan decodes the user key, skips stale/empty (`count == 0`)
entries, and applies:
- **`TYPE`** — filter by data type; an unknown type maps to a type no stored
  key has, so it matches nothing (as Redis does for unknown `TYPE`).
- **`MATCH`** — binary-safe glob via the existing `glob_match_bytes`.
- **`COUNT`** — bounds the number of `MetaCF` entries examined per call (a
  hint, as in Redis), and may span instances within one call.

## Scope / non-collision

The storage logic lives in a **new `storage_scan` module** (`impl Storage` +
`impl Redis`), so the only change to an existing storage file is one `mod`
line in `lib.rs` — it does not touch the `redis_*.rs` files currently being
edited by other in-flight PRs. The command layer adds a new `scan.rs` plus
its `lib.rs`/`table.rs` registration.

Files:
- `src/storage/src/storage_scan.rs` (new) — `Storage::scan` + per-instance `Redis::scan_meta`
- `src/storage/src/lib.rs` — `mod storage_scan;`
- `src/cmd/src/scan.rs` (new) — `SCAN` command + argument parser
- `src/cmd/src/lib.rs`, `src/cmd/src/table.rs` — register `ScanCmd`

## Tests

`src/storage/tests/scan_test.rs` (6 tests):
- `scan_covers_every_key_across_instances_with_small_count` — 50 keys, `COUNT=1`, exact coverage with no misses/duplicates across 3 instances
- `scan_count_hint_does_not_change_the_result_set` — COUNT ∈ {1,3,10,100} all yield the same full set
- `scan_match_filters_by_glob`, `scan_type_filters_by_data_type` (string/hash/set/zset/list + unknown), `scan_empty_keyspace_completes_immediately`, `scan_nonzero_cursor_is_returned_until_complete`

`scan.rs` unit tests (10): meta/clone/acl/arity + parser (cursor, MATCH, COUNT, TYPE, case-insensitivity, invalid cursor, non-positive COUNT, unknown option, dangling value).

## Known limitation

Resuming within an instance re-skips `offset` raw entries (`O(offset)` per
call) because a full key cannot be encoded in a `u64` cursor — this matches
the existing scan-family approach. A future optimization could key the cursor
to the last seen key for `O(log n)` seeks.

## Verification (Rust 1.97.1, MSVC)

- `cargo test -p storage --test scan_test` — 6 passed
- `cargo test -p cmd` — 117 passed (incl. 10 new scan tests)
- `cargo clippy -p storage -p cmd -- -D warnings -D clippy::unwrap_used` — pass
- `cargo fmt -- --check` — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the `SCAN` command, including cursor-based iteration, pattern matching, count limits, and type filtering.
  - Added `ZMSCORE` to the available command set.
  - Added compatibility coverage for `SCAN` and `ZMSCORE` across supported protocols.

- **Bug Fixes**
  - `KEYS` results are now returned in globally sorted order across storage instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->