### PR TITLE
refactor(storage): add MergingIterator and order KEYS across instances

### DIFF
--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -36,6 +36,7 @@ mod format_lists_data_key;
 
 mod coding;
 mod expiration_manager;
+mod merge_iterator;
 pub mod slot_indexer;
 mod statistics;
 mod util;

--- a/src/storage/src/merge_iterator.rs
+++ b/src/storage/src/merge_iterator.rs
@@ -1,0 +1,177 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! K-way merge over the per-instance key streams that back the SCAN family
+//! (issue #142).
+//!
+//! Kiwi shards the keyspace across several independent RocksDB instances, each
+//! of which iterates its own column family in sorted order. Merging those
+//! already-sorted streams yields a single globally ordered stream, so keyspace
+//! commands can present deterministic, RocksDB-order results instead of a
+//! per-instance concatenation.
+
+use std::iter::Peekable;
+
+/// Merges several individually sorted `Vec<u8>` streams into one sorted stream.
+///
+/// Every input stream must already be ordered — ascending for a forward merge,
+/// descending for a reverse merge. The merge is stable: when two streams expose
+/// an equal head, the lower-indexed stream is emitted first.
+pub(crate) struct MergingIterator<I: Iterator<Item = Vec<u8>>> {
+    streams: Vec<Peekable<I>>,
+    reverse: bool,
+}
+
+impl<I: Iterator<Item = Vec<u8>>> MergingIterator<I> {
+    /// Build a merge over `streams`. `reverse` selects descending order and
+    /// requires each input stream to be descending.
+    pub(crate) fn new(streams: Vec<I>, reverse: bool) -> Self {
+        Self {
+            streams: streams.into_iter().map(Iterator::peekable).collect(),
+            reverse,
+        }
+    }
+}
+
+impl<I: Iterator<Item = Vec<u8>>> Iterator for MergingIterator<I> {
+    type Item = Vec<u8>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Pick the stream whose current head sorts first (ascending) or last
+        // (descending). Heads are cloned so only one stream is borrowed at a
+        // time; with a handful of instances this is cheap.
+        let mut chosen: Option<(usize, Vec<u8>)> = None;
+        for index in 0..self.streams.len() {
+            let Some(head) = self.streams[index].peek() else {
+                continue;
+            };
+            let is_better = match &chosen {
+                None => true,
+                Some((_, best)) => {
+                    if self.reverse {
+                        head > best
+                    } else {
+                        head < best
+                    }
+                }
+            };
+            if is_better {
+                chosen = Some((index, head.clone()));
+            }
+        }
+
+        match chosen {
+            Some((index, _)) => self.streams[index].next(),
+            None => None,
+        }
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn merge(streams: Vec<Vec<&[u8]>>, reverse: bool) -> Vec<Vec<u8>> {
+        let streams = streams
+            .into_iter()
+            .map(|stream| {
+                stream
+                    .into_iter()
+                    .map(<[u8]>::to_vec)
+                    .collect::<Vec<_>>()
+                    .into_iter()
+            })
+            .collect();
+        MergingIterator::new(streams, reverse).collect()
+    }
+
+    #[test]
+    fn forward_merge_interleaves_in_sorted_order() {
+        let out = merge(vec![vec![b"a", b"c", b"e"], vec![b"b", b"d", b"f"]], false);
+        assert_eq!(
+            out,
+            vec![
+                b"a".to_vec(),
+                b"b".to_vec(),
+                b"c".to_vec(),
+                b"d".to_vec(),
+                b"e".to_vec(),
+                b"f".to_vec(),
+            ]
+        );
+    }
+
+    #[test]
+    fn reverse_merge_interleaves_in_descending_order() {
+        let out = merge(vec![vec![b"e", b"c", b"a"], vec![b"f", b"d", b"b"]], true);
+        assert_eq!(
+            out,
+            vec![
+                b"f".to_vec(),
+                b"e".to_vec(),
+                b"d".to_vec(),
+                b"c".to_vec(),
+                b"b".to_vec(),
+                b"a".to_vec(),
+            ]
+        );
+    }
+
+    #[test]
+    fn merges_three_uneven_streams() {
+        let out = merge(
+            vec![
+                vec![b"a", b"m", b"z"],
+                vec![b"b"],
+                vec![b"c", b"d", b"n", b"y"],
+            ],
+            false,
+        );
+        assert_eq!(
+            out,
+            vec![
+                b"a".to_vec(),
+                b"b".to_vec(),
+                b"c".to_vec(),
+                b"d".to_vec(),
+                b"m".to_vec(),
+                b"n".to_vec(),
+                b"y".to_vec(),
+                b"z".to_vec(),
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_and_single_streams() {
+        assert!(merge(vec![], false).is_empty());
+        assert!(merge(vec![vec![], vec![]], false).is_empty());
+        assert_eq!(
+            merge(vec![vec![], vec![b"x"], vec![]], false),
+            vec![b"x".to_vec()]
+        );
+    }
+
+    #[test]
+    fn equal_heads_keep_every_element() {
+        // Duplicate keys across streams must all be emitted (the merge does not
+        // deduplicate), lower-indexed stream first.
+        let out = merge(vec![vec![b"k", b"k"], vec![b"k"]], false);
+        assert_eq!(out, vec![b"k".to_vec(), b"k".to_vec(), b"k".to_vec()]);
+    }
+}

--- a/src/storage/src/storage_impl.rs
+++ b/src/storage/src/storage_impl.rs
@@ -713,15 +713,18 @@ impl Storage {
         Ok(deleted_count)
     }
 
-    /// Find all keys matching the given pattern
+    /// Find all keys matching the given pattern.
+    ///
+    /// Each instance scans its `MetaCF` in ascending key order, so merging the
+    /// per-instance results yields a single globally ordered key list rather
+    /// than a per-instance concatenation.
     pub fn keys(&self, pattern: &[u8]) -> Result<Vec<Vec<u8>>> {
-        let mut all_keys = Vec::new();
-
+        let mut streams = Vec::with_capacity(self.insts.len());
         for inst in &self.insts {
-            all_keys.extend(inst.scan_keys(pattern)?);
+            streams.push(inst.scan_keys(pattern)?.into_iter());
         }
 
-        Ok(all_keys)
+        Ok(crate::merge_iterator::MergingIterator::new(streams, false).collect())
     }
 
     /// Remove all keys from the current database

--- a/src/storage/tests/keys_order_test.rs
+++ b/src/storage/tests/keys_order_test.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(clippy::unwrap_used)]
+
+#[cfg(test)]
+mod keys_order_test {
+    use std::sync::Arc;
+
+    use storage::{StorageOptions, storage::Storage};
+
+    #[tokio::test]
+    async fn keys_are_globally_sorted_across_instances() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut storage = Storage::new(3, 0);
+        let _rx = storage
+            .open(Arc::new(StorageOptions::default()), dir.path())
+            .unwrap();
+
+        // Insert in a deliberately unsorted order; keys hash to different
+        // instances, so a per-instance concatenation would not be sorted.
+        let inserted = [
+            "delta", "alpha", "omega", "bravo", "kilo", "echo", "zulu", "charlie", "mike", "golf",
+        ];
+        for key in inserted {
+            storage.set(key.as_bytes(), b"v").unwrap();
+        }
+
+        let keys = storage.keys(b"*").unwrap();
+
+        let mut expected: Vec<Vec<u8>> = inserted.iter().map(|k| k.as_bytes().to_vec()).collect();
+        expected.sort();
+
+        assert_eq!(keys, expected, "KEYS must return globally sorted results");
+    }
+}


### PR DESCRIPTION
## Summary

First refactor step toward #142's centralized scan iterators: adds a reusable
**`MergingIterator`** and uses it to give `KEYS` deterministic, globally ordered
output across RocksDB instances.

> **Stacked on #379** (keyspace `SCAN`). Base this PR's review on #379; the diff
> here is only the iterator work.

## What #142 asks for, and what this delivers

#142 calls for a `MergingIterator` for forward/reverse merge across the several
independent RocksDB instances Kiwi shards the keyspace over. Each instance
already iterates its column family in sorted order, so merging those streams
yields one globally ordered stream.

- New `merge_iterator.rs`: `MergingIterator`, a stable k-way merge over
  individually sorted `Vec<u8>` streams (ascending or descending). Generic over
  `Iterator<Item = Vec<u8>>`, so it is unit-tested with in-memory fixtures — no
  RocksDB needed for the merge logic.
- `Storage::keys()` now merges each instance's `scan_keys` result through it,
  returning a single globally ordered key list instead of a per-instance
  concatenation. `KEYS` order is unspecified in Redis; existing tests are
  set-based and unaffected.

## Scope / deferral

Wiring the per-type `HSCAN`/`SSCAN`/`ZSCAN` paths onto a shared streaming
`TypeIterator` (the other half of #142) is intentionally deferred: those
methods live in `redis_hashes.rs` / `redis_sets.rs` / `redis_zsets.rs`, which
are being actively edited by other open PRs, so refactoring them now would
collide. This PR lands the reusable merge primitive and its first consumer.

Files:
- `src/storage/src/merge_iterator.rs` (new)
- `src/storage/src/lib.rs` — `mod merge_iterator;`
- `src/storage/src/storage_impl.rs` — `keys()` merges per-instance streams
- `src/storage/tests/keys_order_test.rs` (new)

## Tests

- `merge_iterator` unit tests (5): forward and reverse ordering, three uneven
  streams, empty/single streams, and duplicate-preserving equal heads.
- `keys_order_test`: `KEYS` returns globally sorted results across 3 instances.

## Verification (Rust 1.97.1, MSVC)

- `cargo test -p storage --lib merge_iterator` — 5 passed
- `cargo test -p storage --test keys_order_test` — 1 passed
- `cargo test -p storage --test scan_test` — 6 passed (regression)
- `cargo test -p storage --test redis_string_test` — 28 passed (KEYS regression)
- `cargo clippy -p storage -- -D warnings -D clippy::unwrap_used` — pass
- `cargo fmt -- --check` — pass