### PR TITLE
build: migrate Kiwi to Rust 2024 edition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,7 @@ make -C tests test-python
 - Normal development, CI, and release builds use Rust 1.97.1 stable. The root
   `rust-toolchain.toml` selects the exact toolchain automatically; verify it with
   `rustup show active-toolchain` and `rustc --version --verbose`.
-- The source remains on Rust 2021 Edition. Rust 2024 Edition migration is a
-  separate follow-up change; do not treat it as part of the baseline update.
+- All Kiwi workspace crates use Rust 2024 Edition.
 - Dated nightly toolchains are reserved for specialized checks such as
   Sanitizers and do not define the normal development baseline.
 - The first build compiles `librocksdb-sys` from source and can take ~18 minutes. Incremental builds with `sccache` are typically 30 seconds–2 minutes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,7 @@ rustup show active-toolchain
 rustc --version --verbose
 ```
 
-The source currently remains on Rust 2021 Edition. Migrating to Rust 2024 Edition
-is a separate follow-up change and is not part of the toolchain baseline update.
+All Kiwi workspace crates use Rust 2024 Edition.
 Dated nightly toolchains are limited to specialized checks such as Sanitizers.
 
 `protoc` is required. Windows builds use the Rust MSVC target and the Visual

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.1.0"
 description = "An enhanced Redis server implemented in Rust"
 readme = "README.md"
 repository = "https://github.com/arana-db/kiwi"
-edition = "2021"
+edition = "2024"
 rust-version = "1.97.1"
 
 [workspace.lints.clippy]

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ Client → TCP accept [network runtime] → RESP parse → Command lookup
 
 Kiwi's normal development, CI, and release baseline is Rust 1.97.1 stable. After
 you clone the repository, `rust-toolchain.toml` makes rustup select that exact
-toolchain automatically. The source remains on Rust 2021 Edition; the Rust 2024
-Edition migration is a separate follow-up change.
+toolchain automatically. All Kiwi workspace crates use Rust 2024 Edition.
 
 `protoc` and the native C/C++ tools needed to build RocksDB are also required.
 On Windows, use the Rust MSVC target and install the Visual Studio C++ build
 tools. On Linux and macOS, install the platform C/C++ build dependencies used by
-the project in addition to `protoc`.
+the project in addition to `protoc`. See the platform-specific commands in the
+[development guide](docs/development.md#prerequisites).
 
 ```bash
 # Install rustup; rust-toolchain.toml selects Rust 1.97.1 stable in this repo

--- a/README_CN.md
+++ b/README_CN.md
@@ -62,23 +62,29 @@ Client → TCP accept [网络运行时] → RESP 解析 → 命令查找
 ### 环境要求
 
 Kiwi 的普通开发、CI 和发布基线是精确固定的 Rust 1.97.1 stable。克隆仓库后，
-`rust-toolchain.toml` 会让 rustup 自动选择该工具链。当前源码仍使用 Rust 2021
-Edition；Rust 2024 Edition 迁移将在后续独立变更中完成。
+`rust-toolchain.toml` 会让 rustup 自动选择该工具链。所有 Kiwi workspace crate
+均使用 Rust 2024 Edition。
 
 项目还必须安装 `protoc`，以及编译 RocksDB 所需的原生 C/C++ 工具。Windows
 使用 Rust MSVC target，并安装 Visual Studio C++ 构建工具；Linux 和 macOS 除
-`protoc` 外，还需安装项目在对应平台使用的 C/C++ 构建依赖。
+`protoc` 外，还需安装项目在对应平台使用的 C/C++ 构建依赖。完整的平台安装
+命令见[开发指南](docs/development.md#prerequisites)。
 
 ```bash
 # 安装 rustup；进入本仓库后由 rust-toolchain.toml 选择 Rust 1.97.1 stable
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
-# protobuf 编译器 (macOS)
-brew install protobuf
+# macOS 原生 C/C++ 工具、protobuf 编译器和构建依赖
+xcode-select --install
+brew install protobuf cmake
 
-# protobuf 编译器 (Linux)
-apt install protobuf-compiler
+# Debian/Ubuntu Linux 原生 C/C++ 工具、protobuf 编译器和构建依赖
+sudo apt install clang cmake libclang-dev llvm-dev pkg-config protobuf-compiler
 ```
+
+Windows 使用与 CI 一致的官方 Protobuf 27.1。请在 PowerShell 中下载并解压
+`protoc-27.1-win64.zip`，将解压目录下的 `bin` 加入 `PATH`，然后运行
+`protoc --version`；可直接使用[开发指南中的 PowerShell 命令](docs/development.md#prerequisites)。
 
 固定日期的 nightly 只用于 Sanitizer 等专项检查，不定义普通开发或发布基线。
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,8 +5,7 @@
 Normal development, CI, and release builds use the exact Rust 1.97.1 stable
 toolchain pinned in the repository root. After rustup is installed,
 `rust-toolchain.toml` selects it automatically whenever commands run inside this
-repository. The source currently uses Rust 2021 Edition. Rust 2024 Edition is a
-separate follow-up migration, not part of this toolchain baseline.
+repository. All Kiwi workspace crates use Rust 2024 Edition.
 
 Kiwi also requires `protoc` and a native C/C++ toolchain because RocksDB is built
 from source:
@@ -30,11 +29,47 @@ brew install protobuf cmake
 sudo apt install clang cmake libclang-dev llvm-dev pkg-config protobuf-compiler
 ```
 
+On Windows, install the Visual Studio Build Tools C++ workload first, then run
+the following commands in PowerShell to install the same official Protobuf 27.1
+release used by CI and add it to both the current process and the user `PATH`:
+
+```powershell
+$protocVersion = "27.1"
+$protocZip = "protoc-$protocVersion-win64.zip"
+$protocUrl = "https://github.com/protocolbuffers/protobuf/releases/download/v$protocVersion/$protocZip"
+$protocArchive = Join-Path $env:TEMP $protocZip
+$protocRoot = Join-Path $env:LOCALAPPDATA "Programs\protoc-$protocVersion"
+
+Invoke-WebRequest -Uri $protocUrl -OutFile $protocArchive
+Expand-Archive -Path $protocArchive -DestinationPath $protocRoot -Force
+
+$protocBin = Join-Path $protocRoot "bin"
+$processPath = $env:Path
+if ([string]::IsNullOrWhiteSpace($processPath)) {
+    $env:Path = $protocBin
+} elseif (($processPath -split ";") -notcontains $protocBin) {
+    $env:Path = "$protocBin;$processPath"
+}
+
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ([string]::IsNullOrWhiteSpace($userPath)) {
+    [Environment]::SetEnvironmentVariable("Path", $protocBin, "User")
+} elseif (($userPath -split ";") -notcontains $protocBin) {
+    [Environment]::SetEnvironmentVariable("Path", "$protocBin;$userPath", "User")
+}
+
+protoc --version
+```
+
+The final command must report `libprotoc 27.1`. New terminals pick up the user
+`PATH` automatically.
+
 Verify the compiler selected for the current checkout:
 
 ```bash
 rustup show active-toolchain
 rustc --version --verbose
+protoc --version
 ```
 
 Dated nightly toolchains are used only by specialized checks such as

--- a/docs/superpowers/plans/2026-07-25-rust-2024-edition.md
+++ b/docs/superpowers/plans/2026-07-25-rust-2024-edition.md
@@ -10,13 +10,13 @@
 
 ---
 
-### 任务 1：从 PR 1 的已验证 Head 建立 stacked 分支
+## 任务 1：从 PR 1 的已验证 Head 建立 stacked 分支
 
 - [ ] 确认 PR 1 工作树干净、记录确切 Head，从该 Head 创建 `codex/rust-2024-edition` 隔离 worktree。
 - [ ] 运行 `rustup show active-toolchain` 和 `rustc --version --verbose`，确认 stacked checkout 仍使用 PR 1 固定的 Rust 1.97.1 stable。
 - [ ] 运行 `cargo metadata --locked --format-version 1 --no-deps` 和 `cargo fmt --all -- --check`，确认初始状态为 Edition 2021 / Rust 1.97.1。
 
-### 任务 2：生成并审计保守迁移 Diff
+## 任务 2：生成并审计保守迁移 Diff
 
 **文件：**
 - 可能修改：`src/**/*.rs`
@@ -25,7 +25,7 @@
 - [ ] 分文件审查 `git diff -- src`，重点检查 unsafe/FFI、宏 fragment、临时值/drop 顺序、环境变量 API 和 Prelude 方法解析。
 - [ ] 在 Edition 2021 下重跑 fmt、check 和严格 Clippy，通过后提交 `refactor: prepare code for Rust 2024`；如无源码变更，不创建空提交。
 
-### 任务 3：切换 workspace 到 Edition 2024
+## 任务 3：切换 workspace 到 Edition 2024
 
 **文件：**
 - 修改：`Cargo.toml`
@@ -40,7 +40,7 @@
 - [ ] 更新生效文档，删除 Edition 2021 过渡表述，保留工具链和 Nightly 边界。
 - [ ] 扫描生效配置和开发文档中的 Edition 2021 残留，提交 `build: migrate Kiwi to Rust 2024 edition`。
 
-### 任务 4：完整验证 PR 2
+## 任务 4：完整验证 PR 2
 
 - [ ] Windows MSVC + Protoc 27.1 执行 fmt、workspace check、严格 Clippy 和 workspace tests。
 - [ ] WSL/Linux 使用独立 target 重复 check、Clippy 和 tests。

--- a/docs/superpowers/plans/2026-07-25-rust-toolchain-baseline.md
+++ b/docs/superpowers/plans/2026-07-25-rust-toolchain-baseline.md
@@ -10,7 +10,7 @@
 
 ---
 
-### 任务 1：统一 Cargo workspace 和本地工具链
+## 任务 1：统一 Cargo workspace 和本地工具链
 
 **文件：**
 - 修改：`rust-toolchain.toml`
@@ -24,7 +24,7 @@
 - [ ] 运行 `cargo fmt --all -- --check` 和 `cargo check --workspace --all-features --locked`。
 - [ ] 只提交工具链和 manifest：`build: pin Rust 1.97.1 toolchain`。
 
-### 任务 2：统一 CI、Sanitizer 和 Docker
+## 任务 2：统一 CI、Sanitizer 和 Docker
 
 **文件：**
 - 修改：`.github/workflows/ci.yml`
@@ -40,7 +40,7 @@
 - [ ] 运行 GitHub Actions YAML 语法检查，并人工审查全部 setup-rust-toolchain 和 Cargo override 行。
 - [ ] 提交：`ci: align builds with pinned Rust toolchain`。
 
-### 任务 3：更新开发者合同文档
+## 任务 3：更新开发者合同文档
 
 **文件：**
 - 修改：`README.md`
@@ -55,7 +55,7 @@
 - [ ] 删除生效文档中 `nightly-2025-08-20` 和浮动 stable 是标准的表述；历史 plan 证据不改写。
 - [ ] 运行 `rg` 残留扫描、`git diff --check`，并提交：`docs: define the Kiwi Rust baseline`。
 
-### 任务 4：完整验证 PR 1
+## 任务 4：完整验证 PR 1
 
 - [ ] 运行 `rustup show active-toolchain` 和 `rustc --version --verbose`，确认当前 checkout 使用 Rust 1.97.1 stable。
 - [ ] Windows 验证必须在 Visual Studio Developer Command Prompt 或已加载等价 VS C++ 环境的终端中执行；`rustc --version --verbose` 必须严格包含 `host: x86_64-pc-windows-msvc`，且 `where cl`（PowerShell 使用 `where.exe cl`）必须解析到可执行的 MSVC `cl.exe`。任一条件不满足时立即停止，不得把后续结果记为 Windows MSVC 验证。

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -68,12 +68,16 @@ impl Client {
 
     pub async fn read(&self, buf: &mut [u8]) -> Result<usize, std::io::Error> {
         let mut stream = self.stream.lock().await;
-        stream.read(buf).await
+        let result = stream.read(buf).await;
+        drop(stream);
+        result
     }
 
     pub async fn write(&self, data: &[u8]) -> Result<usize, std::io::Error> {
         let mut stream = self.stream.lock().await;
-        stream.write(data).await
+        let result = stream.write(data).await;
+        drop(stream);
+        result
     }
 
     pub fn set_argv(&self, argv: &[Vec<u8>]) {

--- a/src/cmd/src/hello.rs
+++ b/src/cmd/src/hello.rs
@@ -101,12 +101,13 @@ impl Cmd for HelloCmd {
             }
         };
 
-        match client.handle_hello(
+        let hello_result = client.handle_hello(
             &command,
             client.is_authenticated(),
             authentication_required,
             &mut authenticate,
-        ) {
+        );
+        match hello_result {
             Ok((response, _)) => {
                 // handle_hello only succeeds when the client is already
                 // authenticated or the HELLO included an AUTH clause that

--- a/src/cmd/src/table.rs
+++ b/src/cmd/src/table.rs
@@ -25,7 +25,7 @@ pub type CmdTable = HashMap<String, Arc<dyn Cmd>>;
 
 #[macro_export]
 macro_rules! register_cmd {
-    ($cmd_table:expr, $($cmd_struct:ty),+ $(,)?) => {
+    ($cmd_table:expr_2021, $($cmd_struct:ty),+ $(,)?) => {
         $(
             {
                 let cmd = <$cmd_struct>::new();
@@ -39,7 +39,7 @@ macro_rules! register_cmd {
 
 #[macro_export]
 macro_rules! register_group_cmd {
-    ($cmd_table:expr, $($constructor:path),+ $(,)?) => {
+    ($cmd_table:expr_2021, $($constructor:path),+ $(,)?) => {
         $(
             {
                 let group_cmd = $constructor();

--- a/src/common/runtime/error_logging.rs
+++ b/src/common/runtime/error_logging.rs
@@ -546,14 +546,14 @@ pub fn get_global_error_logger() -> Option<Arc<ErrorLogger>> {
 /// Convenience macro for logging errors with the global logger
 #[macro_export]
 macro_rules! log_dual_runtime_error {
-    ($error:expr, $runtime:expr) => {
+    ($error:expr_2021, $runtime:expr_2021) => {
         if let Some(logger) = $crate::runtime::error_logging::get_global_error_logger() {
             tokio::spawn(async move {
                 logger.log_simple_error($error, $runtime).await;
             });
         }
     };
-    ($error:expr, $runtime:expr, $correlation_id:expr) => {
+    ($error:expr_2021, $runtime:expr_2021, $correlation_id:expr_2021) => {
         if let Some(logger) = $crate::runtime::error_logging::get_global_error_logger() {
             tokio::spawn(async move {
                 logger

--- a/src/common/runtime/message.rs
+++ b/src/common/runtime/message.rs
@@ -901,10 +901,10 @@ impl StorageClient {
             }
             let remaining_timeout = timeout - elapsed;
 
-            match self
+            let attempt_result = self
                 .try_send_request(command.clone(), remaining_timeout, priority)
-                .await
-            {
+                .await;
+            match attempt_result {
                 Ok(data) => {
                     // Success - record in circuit breaker and recovery manager
                     {
@@ -1175,10 +1175,10 @@ impl StorageClient {
         let degraded_retries = self.retry_config.max_retries.min(2);
 
         for attempt in 0..=degraded_retries {
-            match self
+            let attempt_result = self
                 .try_send_request(command.clone(), degraded_timeout, priority)
-                .await
-            {
+                .await;
+            match attempt_result {
                 Ok(data) => {
                     // Success in degraded mode
                     let mut recovery_manager = self.recovery_manager.lock().await;

--- a/src/common/runtime/metrics.rs
+++ b/src/common/runtime/metrics.rs
@@ -396,20 +396,20 @@ impl MetricsCollector {
                 *last_metrics.write().expect("lock poisoned") = Some(runtime_metrics.clone());
 
                 // Log key metrics periodically
-                if let Ok(elapsed) = SystemTime::now().duration_since(UNIX_EPOCH) {
-                    if elapsed.as_secs() % 60 == 0 {
-                        // Log every minute
-                        info!(
-                            "Runtime Metrics - Network RPS: {:.2}, Storage OPS: {:.2}, Channel Util: {:.1}%, Health: {:?}",
-                            runtime_metrics.network_metrics.requests_per_second,
-                            runtime_metrics.storage_metrics.operations_per_second,
-                            runtime_metrics
-                                .channel_metrics
-                                .buffer_metrics
-                                .buffer_utilization_percent,
-                            runtime_metrics.health_status.overall_health
-                        );
-                    }
+                if let Ok(elapsed) = SystemTime::now().duration_since(UNIX_EPOCH)
+                    && elapsed.as_secs() % 60 == 0
+                {
+                    // Log every minute
+                    info!(
+                        "Runtime Metrics - Network RPS: {:.2}, Storage OPS: {:.2}, Channel Util: {:.1}%, Health: {:?}",
+                        runtime_metrics.network_metrics.requests_per_second,
+                        runtime_metrics.storage_metrics.operations_per_second,
+                        runtime_metrics
+                            .channel_metrics
+                            .buffer_metrics
+                            .buffer_utilization_percent,
+                        runtime_metrics.health_status.overall_health
+                    );
                 }
             }
         });

--- a/src/common/runtime/storage_server.rs
+++ b/src/common/runtime/storage_server.rs
@@ -741,9 +741,7 @@ impl BatchProcessor {
         });
 
         let batch_size = self.max_batch_size.min(state.requests.len());
-        let batch = state.requests.drain(0..batch_size).collect();
-
-        batch
+        state.requests.drain(0..batch_size).collect()
     }
 
     /// Wait for batch condition to be met (size or efficiency threshold)
@@ -1070,31 +1068,31 @@ impl BackgroundTaskManager {
                         config.compaction_trigger_threshold,
                     )
                     .await;
-                    if let Ok(needs_compaction) = compaction_check {
-                        if needs_compaction {
-                            info!("Triggering background compaction");
+                    if let Ok(needs_compaction) = compaction_check
+                        && needs_compaction
+                    {
+                        info!("Triggering background compaction");
 
-                            // Record compaction started
+                        // Record compaction started
+                        if let Some(ref _tracker) = metrics_tracker {
+                            // TODO: Fix type annotation issue
+                            // tracker.record_compaction_started().await;
+                        }
+
+                        let compaction_start = Instant::now();
+                        if let Err(e) = storage.compact_all(false).await {
+                            warn!("Failed to trigger background compaction: {}", e);
+                        } else {
+                            let _compaction_duration = compaction_start.elapsed();
+
+                            // Update statistics
+                            let mut stats_guard = stats.lock().await;
+                            stats_guard.compactions_triggered += 1;
+
+                            // Record compaction completed
                             if let Some(ref _tracker) = metrics_tracker {
                                 // TODO: Fix type annotation issue
-                                // tracker.record_compaction_started().await;
-                            }
-
-                            let compaction_start = Instant::now();
-                            if let Err(e) = storage.compact_all(false).await {
-                                warn!("Failed to trigger background compaction: {}", e);
-                            } else {
-                                let _compaction_duration = compaction_start.elapsed();
-
-                                // Update statistics
-                                let mut stats_guard = stats.lock().await;
-                                stats_guard.compactions_triggered += 1;
-
-                                // Record compaction completed
-                                if let Some(ref _tracker) = metrics_tracker {
-                                    // TODO: Fix type annotation issue
-                                    // tracker.record_compaction_completed(0, compaction_duration).await; // TODO: Get actual bytes compacted
-                                }
+                                // tracker.record_compaction_completed(0, compaction_duration).await; // TODO: Get actual bytes compacted
                             }
                         }
                     }
@@ -1144,25 +1142,25 @@ impl BackgroundTaskManager {
 
                     // Check flush status for each storage instance
                     for (i, instance) in storage.insts.iter().enumerate() {
-                        if let Ok(flush_pending) = Self::check_flush_status(instance).await {
-                            if flush_pending {
-                                debug!("Flush pending detected on storage instance {}", i);
+                        if let Ok(flush_pending) = Self::check_flush_status(instance).await
+                            && flush_pending
+                        {
+                            debug!("Flush pending detected on storage instance {}", i);
 
-                                // Record flush started
-                                if let Some(ref _tracker) = metrics_tracker {
-                                    // TODO: Fix type annotation issue
-                                    // tracker.record_flush_started().await;
-                                }
+                            // Record flush started
+                            if let Some(ref _tracker) = metrics_tracker {
+                                // TODO: Fix type annotation issue
+                                // tracker.record_flush_started().await;
+                            }
 
-                                // Update statistics
-                                let mut stats_guard = stats.lock().await;
-                                stats_guard.flushes_detected += 1;
+                            // Update statistics
+                            let mut stats_guard = stats.lock().await;
+                            stats_guard.flushes_detected += 1;
 
-                                // Record flush completed (simulated)
-                                if let Some(ref _tracker) = metrics_tracker {
-                                    // TODO: Fix type annotation issue
-                                    // tracker.record_flush_completed(0, Duration::from_millis(10)).await; // TODO: Get actual flush metrics
-                                }
+                            // Record flush completed (simulated)
+                            if let Some(ref _tracker) = metrics_tracker {
+                                // TODO: Fix type annotation issue
+                                // tracker.record_flush_completed(0, Duration::from_millis(10)).await; // TODO: Get actual flush metrics
                             }
                         }
                     }
@@ -1256,17 +1254,17 @@ impl BackgroundTaskManager {
         // Check each storage instance
         for instance in &storage.insts {
             // Get number of SST files (placeholder - would use actual RocksDB property)
-            if let Ok(sst_count) = instance.get_property("rocksdb.num-files-at-level0") {
-                if sst_count as usize > threshold {
-                    return Ok(true);
-                }
+            if let Ok(sst_count) = instance.get_property("rocksdb.num-files-at-level0")
+                && sst_count as usize > threshold
+            {
+                return Ok(true);
             }
 
             // Check for write stalls
-            if let Ok(write_stall) = instance.get_property("rocksdb.actual-delayed-write-rate") {
-                if write_stall > 0 {
-                    return Ok(true);
-                }
+            if let Ok(write_stall) = instance.get_property("rocksdb.actual-delayed-write-rate")
+                && write_stall > 0
+            {
+                return Ok(true);
             }
         }
 
@@ -1306,24 +1304,24 @@ impl BackgroundTaskManager {
             }
 
             // Check compaction status
-            if let Ok(compaction) = instance.get_property("rocksdb.compaction-pending") {
-                if compaction > 0 {
-                    stats.compaction_pending = true;
-                }
+            if let Ok(compaction) = instance.get_property("rocksdb.compaction-pending")
+                && compaction > 0
+            {
+                stats.compaction_pending = true;
             }
 
             // Check flush status
-            if let Ok(flush) = instance.get_property("rocksdb.mem-table-flush-pending") {
-                if flush > 0 {
-                    stats.flush_pending = true;
-                }
+            if let Ok(flush) = instance.get_property("rocksdb.mem-table-flush-pending")
+                && flush > 0
+            {
+                stats.flush_pending = true;
             }
 
             // Check write stall status
-            if let Ok(stall) = instance.get_property("rocksdb.actual-delayed-write-rate") {
-                if stall > 0 {
-                    stats.write_stall_active = true;
-                }
+            if let Ok(stall) = instance.get_property("rocksdb.actual-delayed-write-rate")
+                && stall > 0
+            {
+                stats.write_stall_active = true;
             }
         }
 

--- a/src/common/runtime/storage_server.rs
+++ b/src/common/runtime/storage_server.rs
@@ -460,7 +460,11 @@ impl StorageServer {
     ) -> Result<(), DualRuntimeError> {
         info!("Storage server running without batching");
 
-        while let Some(request) = request_receiver.recv().await {
+        loop {
+            let received = request_receiver.recv().await;
+            let Some(request) = received else {
+                break;
+            };
             debug!("Received storage request: {:?}", request.id);
 
             let access_guard = self.access_gate.enter().await;
@@ -504,7 +508,8 @@ impl StorageServer {
 
         // Wait for all requests in the batch to complete
         for handle in handles {
-            if let Err(e) = handle.await {
+            let join_result = handle.await;
+            if let Err(e) = join_result {
                 error!("Failed to process request in batch: {}", e);
             }
         }
@@ -999,7 +1004,8 @@ impl BackgroundTaskManager {
             _ = async {
                 // Wait for any task to complete (which would indicate an error)
                 for (name, handle) in handles {
-                    if let Err(e) = handle.await {
+                    let join_result = handle.await;
+                    if let Err(e) = join_result {
                         error!("Background task '{}' failed: {}", name, e);
                         return;
                     }
@@ -1059,7 +1065,12 @@ impl BackgroundTaskManager {
                     }
 
                     // Check if compaction is needed
-                    if let Ok(needs_compaction) = Self::check_compaction_needed(&storage, config.compaction_trigger_threshold).await {
+                    let compaction_check = Self::check_compaction_needed(
+                        &storage,
+                        config.compaction_trigger_threshold,
+                    )
+                    .await;
+                    if let Ok(needs_compaction) = compaction_check {
                         if needs_compaction {
                             info!("Triggering background compaction");
 

--- a/src/common/runtime/stress_tests.rs
+++ b/src/common/runtime/stress_tests.rs
@@ -132,7 +132,7 @@ impl ChaosTestFramework {
     }
 
     fn should_inject_failure(&mut self) -> bool {
-        self.rng.gen::<f64>() < self.failure_rate
+        self.rng.r#gen::<f64>() < self.failure_rate
     }
 
     fn random_failure_type(&mut self) -> ChaosFailureType {
@@ -290,7 +290,8 @@ mod memory_pressure_tests {
         let mut channel_error_count = 0;
 
         for handle in handles {
-            match handle.await.unwrap() {
+            let request_result = handle.await.unwrap();
+            match request_result {
                 Ok(_) => _success_count += 1,
                 Err(DualRuntimeError::Timeout { .. }) => timeout_count += 1,
                 Err(DualRuntimeError::Channel(_)) => channel_error_count += 1,

--- a/src/common/runtime/tests.rs
+++ b/src/common/runtime/tests.rs
@@ -760,7 +760,8 @@ mod integration_tests {
         let mut error_count = 0;
 
         for handle in handles {
-            match handle.await.unwrap() {
+            let request_result = handle.await.unwrap();
+            match request_result {
                 Ok(_) => _success_count += 1,
                 Err(_) => error_count += 1,
             }
@@ -1054,7 +1055,8 @@ mod integration_tests {
         let mut error_count = 0;
 
         for handle in handles {
-            match handle.await.unwrap() {
+            let request_result = handle.await.unwrap();
+            match request_result {
                 Ok(_) => success_count += 1,
                 Err(_) => error_count += 1,
             }

--- a/src/executor/src/executor.rs
+++ b/src/executor/src/executor.rs
@@ -526,7 +526,8 @@ mod tests {
             Ok(mut executor) => executor.close().await,
             Err(_) => panic!("all exclusive executor owners should be released"),
         }
-        match Arc::try_unwrap(shared_executor) {
+        let shared_executor = Arc::try_unwrap(shared_executor);
+        match shared_executor {
             Ok(mut executor) => executor.close().await,
             Err(_) => panic!("all shared executor owners should be released"),
         }

--- a/src/net/src/async_resp_parser.rs
+++ b/src/net/src/async_resp_parser.rs
@@ -181,23 +181,23 @@ impl CommandBatch {
         let mut max_priority = BatchPriority::Normal;
 
         for command in commands {
-            if let RespData::Array(Some(params)) = command {
-                if let Some(RespData::BulkString(Some(cmd_name))) = params.first() {
-                    let cmd_str = String::from_utf8_lossy(cmd_name).to_lowercase();
-                    let cmd_priority = match cmd_str.as_str() {
-                        // Critical commands
-                        "auth" | "hello" | "quit" => BatchPriority::Critical,
-                        // High priority commands
-                        "ping" | "echo" => BatchPriority::High,
-                        // Low priority commands
-                        "info" | "keys" | "scan" => BatchPriority::Low,
-                        // Normal priority for everything else
-                        _ => BatchPriority::Normal,
-                    };
+            if let RespData::Array(Some(params)) = command
+                && let Some(RespData::BulkString(Some(cmd_name))) = params.first()
+            {
+                let cmd_str = String::from_utf8_lossy(cmd_name).to_lowercase();
+                let cmd_priority = match cmd_str.as_str() {
+                    // Critical commands
+                    "auth" | "hello" | "quit" => BatchPriority::Critical,
+                    // High priority commands
+                    "ping" | "echo" => BatchPriority::High,
+                    // Low priority commands
+                    "info" | "keys" | "scan" => BatchPriority::Low,
+                    // Normal priority for everything else
+                    _ => BatchPriority::Normal,
+                };
 
-                    if cmd_priority > max_priority {
-                        max_priority = cmd_priority;
-                    }
+                if cmd_priority > max_priority {
+                    max_priority = cmd_priority;
                 }
             }
         }

--- a/src/net/src/buffer.rs
+++ b/src/net/src/buffer.rs
@@ -165,7 +165,11 @@ impl BufferManager {
         let mut stats = self.stats.lock().await;
 
         // Try to get an existing buffer from pool
-        while let Some(mut buffer) = pool.pop_front() {
+        loop {
+            let next_buffer = pool.pop_front();
+            let Some(mut buffer) = next_buffer else {
+                break;
+            };
             // Check if buffer is still good to use
             if !buffer.should_replace(self.config.max_buffer_size) {
                 buffer.reset();
@@ -279,7 +283,11 @@ impl BufferManager {
                 // Keep only non-idle buffers, but maintain minimum pool size
                 let mut kept_buffers = VecDeque::new();
 
-                while let Some(buffer) = pool_guard.pop_front() {
+                loop {
+                    let next_buffer = pool_guard.pop_front();
+                    let Some(buffer) = next_buffer else {
+                        break;
+                    };
                     if buffer.is_idle(config.max_idle_time)
                         && (kept_buffers.len() + pool_guard.len()) > config.min_pool_size
                     {

--- a/src/net/src/executor_ext.rs
+++ b/src/net/src/executor_ext.rs
@@ -62,18 +62,19 @@ impl CmdExecutorNetworkExt for CmdExecutor {
 
             // Cluster-mode leader gate: reject writes on non-leaders before any
             // command-specific setup runs.
-            if let Some(gate) = exec.leader_gate.as_ref() {
-                if exec.cmd.has_flag(CmdFlags::WRITE) && !gate.is_leader() {
-                    // Simplified redirect: Kiwi returns "MOVED <addr>" (no hash slot,
-                    // unlike Redis Cluster's "MOVED <slot> <ip:port>"). Clients are
-                    // expected to reconnect to the returned leader address directly.
-                    let reply = match gate.leader_resp_addr() {
-                        Some(addr) => format!("MOVED {addr}"),
-                        None => "ERR not leader".to_string(),
-                    };
-                    exec.client.set_reply(RespData::Error(reply.into()));
-                    return Ok(());
-                }
+            if let Some(gate) = exec.leader_gate.as_ref()
+                && exec.cmd.has_flag(CmdFlags::WRITE)
+                && !gate.is_leader()
+            {
+                // Simplified redirect: Kiwi returns "MOVED <addr>" (no hash slot,
+                // unlike Redis Cluster's "MOVED <slot> <ip:port>"). Clients are
+                // expected to reconnect to the returned leader address directly.
+                let reply = match gate.leader_resp_addr() {
+                    Some(addr) => format!("MOVED {addr}"),
+                    None => "ERR not leader".to_string(),
+                };
+                exec.client.set_reply(RespData::Error(reply.into()));
+                return Ok(());
             }
 
             // Execute do_initial if needed

--- a/src/net/src/handle.rs
+++ b/src/net/src/handle.rs
@@ -46,7 +46,9 @@ pub async fn process_connection(
                     Ok(n) => {
                         if n == 0 { return Ok(()); }
 
-                        match resp_parser.parse(Bytes::copy_from_slice(&buf[..n])) {
+                        let parse_result =
+                            resp_parser.parse(Bytes::copy_from_slice(&buf[..n]));
+                        match parse_result {
                             RespParseResult::Complete(data) => {
                                 if let RespData::Array(Some(params)) = data {
                                     if params.is_empty() { continue; }
@@ -61,7 +63,9 @@ pub async fn process_connection(
                                     let response = client.take_reply();
                                     let mut encoder = RespEncoder::new(client.resp_version());
                                     encoder.encode_resp_data(&response);
-                                    match client.write(encoder.get_response().as_ref()).await {
+                                    let write_result =
+                                        client.write(encoder.get_response().as_ref()).await;
+                                    match write_result {
                                         Ok(_) => (),
                                         Err(e) => error!("Write error: {e}"),
                                     }

--- a/src/net/src/handle.rs
+++ b/src/net/src/handle.rs
@@ -100,13 +100,12 @@ async fn handle_command(
     let cmd_name = String::from_utf8_lossy(&client.cmd_name()).to_lowercase();
 
     // Auth check: deny non-NO_AUTH commands when not authenticated
-    if !client.is_authenticated() {
-        if let Some(cmd) = cmd_table.get(&cmd_name) {
-            if !cmd.has_flag(CmdFlags::NO_AUTH) {
-                client.set_reply(RespData::Error("NOAUTH Authentication required.".into()));
-                return;
-            }
-        }
+    if !client.is_authenticated()
+        && let Some(cmd) = cmd_table.get(&cmd_name)
+        && !cmd.has_flag(CmdFlags::NO_AUTH)
+    {
+        client.set_reply(RespData::Error("NOAUTH Authentication required.".into()));
+        return;
     }
 
     if let Some(cmd) = cmd_table.get(&cmd_name) {

--- a/src/net/src/network_handle.rs
+++ b/src/net/src/network_handle.rs
@@ -356,16 +356,16 @@ async fn process_command_batch(
         // Auth check: deny non-NO_AUTH commands when not authenticated
         if !client.is_authenticated() {
             let cmd_name_str = String::from_utf8_lossy(&command.cmd_name).to_lowercase();
-            if let Some(cmd) = cmd_table.get(&cmd_name_str) {
-                if !cmd.has_flag(CmdFlags::NO_AUTH) {
-                    client.set_reply(RespData::Error("NOAUTH Authentication required.".into()));
-                    let response = client.take_reply();
-                    let encoder_version = client.resp_version();
-                    let mut encoder = RespEncoder::new(encoder_version);
-                    encoder.encode_resp_data(&response);
-                    let _ = client.write(encoder.get_response().as_ref()).await;
-                    continue;
-                }
+            if let Some(cmd) = cmd_table.get(&cmd_name_str)
+                && !cmd.has_flag(CmdFlags::NO_AUTH)
+            {
+                client.set_reply(RespData::Error("NOAUTH Authentication required.".into()));
+                let response = client.take_reply();
+                let encoder_version = client.resp_version();
+                let mut encoder = RespEncoder::new(encoder_version);
+                encoder.encode_resp_data(&response);
+                let _ = client.write(encoder.get_response().as_ref()).await;
+                continue;
             }
         }
 

--- a/src/net/src/network_handle.rs
+++ b/src/net/src/network_handle.rs
@@ -387,7 +387,8 @@ async fn process_command_batch(
         let mut encoder = RespEncoder::new(encoder_version);
         encoder.encode_resp_data(&response);
 
-        match client.write(encoder.get_response().as_ref()).await {
+        let write_result = client.write(encoder.get_response().as_ref()).await;
+        match write_result {
             Ok(_) => debug!("Pipelined response sent successfully"),
             Err(e) => {
                 error!("Write error in pipeline: {}", e);

--- a/src/net/src/optimized_handler.rs
+++ b/src/net/src/optimized_handler.rs
@@ -158,8 +158,7 @@ impl OptimizedConnectionHandler {
         loop {
             // Read data using optimized buffer management
             let mut read_buffer = if self.config.enable_buffer_pooling {
-                let pooled_buffer = self.buffer_manager.get_buffer().await;
-                pooled_buffer
+                self.buffer_manager.get_buffer().await
             } else {
                 crate::buffer::PooledBuffer::new(8192, 0)
             };

--- a/src/net/src/optimized_handler.rs
+++ b/src/net/src/optimized_handler.rs
@@ -158,7 +158,8 @@ impl OptimizedConnectionHandler {
         loop {
             // Read data using optimized buffer management
             let mut read_buffer = if self.config.enable_buffer_pooling {
-                self.buffer_manager.get_buffer().await
+                let pooled_buffer = self.buffer_manager.get_buffer().await;
+                pooled_buffer
             } else {
                 crate::buffer::PooledBuffer::new(8192, 0)
             };
@@ -178,12 +179,17 @@ impl OptimizedConnectionHandler {
                             match resp_parser.parse(Bytes::copy_from_slice(&read_buffer.buffer[..n])) {
                                 RespParseResult::Complete(data) => {
                                     // Submit to pipeline for processing
-                                    match pipeline.submit_command(data, client.clone()).await {
+                                    let pipeline_result =
+                                        pipeline.submit_command(data, client.clone()).await;
+                                    match pipeline_result {
                                         Ok(response) => {
                                             // Send response
                                             let mut encoder = RespEncoder::new(RespVersion::RESP2);
                                             encoder.encode_resp_data(&response);
-                                            if let Err(e) = client.write(encoder.get_response().as_ref()).await {
+                                            let write_result = client
+                                                .write(encoder.get_response().as_ref())
+                                                .await;
+                                            if let Err(e) = write_result {
                                                 error!("Write error: {}", e);
                                                 if self.config.enable_buffer_pooling {
                                                     self.buffer_manager.return_buffer(read_buffer).await;
@@ -256,7 +262,9 @@ impl OptimizedConnectionHandler {
                                 return Ok(());
                             }
 
-                            match resp_parser.parse(Bytes::copy_from_slice(&read_buffer.buffer[..n])) {
+                            let parse_result = resp_parser
+                                .parse(Bytes::copy_from_slice(&read_buffer.buffer[..n]));
+                            match parse_result {
                                 RespParseResult::Complete(data) => {
                                     if let RespData::Array(Some(params)) = data {
                                         if params.is_empty() { continue; }
@@ -279,7 +287,10 @@ impl OptimizedConnectionHandler {
                                         let response = client.take_reply();
                                         let mut encoder = RespEncoder::new(RespVersion::RESP2);
                                         encoder.encode_resp_data(&response);
-                                        if let Err(e) = client.write(encoder.get_response().as_ref()).await {
+                                        let write_result = client
+                                            .write(encoder.get_response().as_ref())
+                                            .await;
+                                        if let Err(e) = write_result {
                                             error!("Write error: {}", e);
                                             if self.config.enable_buffer_pooling {
                                                 self.buffer_manager.return_buffer(read_buffer).await;

--- a/src/net/src/pipeline.rs
+++ b/src/net/src/pipeline.rs
@@ -229,7 +229,8 @@ impl CommandPipeline {
 
                     // Batch timeout - process partial batch
                     _ = batch_timer.tick() => {
-                        if let Some(batch) = current_batch.take() {
+                        let pending_batch = current_batch.take();
+                        if let Some(batch) = pending_batch {
                             if !batch.is_empty() && batch.is_expired(config.batch_timeout) {
                                 Self::process_batch(
                                     batch,
@@ -302,7 +303,8 @@ impl CommandPipeline {
 
         // Wait for all commands in batch to complete
         for handle in handles {
-            if let Err(e) = handle.await {
+            let join_result = handle.await;
+            if let Err(e) = join_result {
                 warn!("Command execution failed in batch {}: {}", batch_id, e);
             }
         }

--- a/src/net/src/pipeline.rs
+++ b/src/net/src/pipeline.rs
@@ -211,16 +211,16 @@ impl CommandPipeline {
                             }
                             None => {
                                 // Channel closed, process remaining batch and exit
-                                if let Some(batch) = current_batch.take() {
-                                    if !batch.is_empty() {
-                                        Self::process_batch(
-                                            batch,
-                                            storage.clone(),
-                                            cmd_table.clone(),
-                                            executor.clone(),
-                                            semaphore.clone(),
-                                        ).await;
-                                    }
+                                if let Some(batch) = current_batch.take()
+                                    && !batch.is_empty()
+                                {
+                                    Self::process_batch(
+                                        batch,
+                                        storage.clone(),
+                                        cmd_table.clone(),
+                                        executor.clone(),
+                                        semaphore.clone(),
+                                    ).await;
                                 }
                                 break;
                             }

--- a/src/net/src/pool.rs
+++ b/src/net/src/pool.rs
@@ -168,7 +168,8 @@ where
             }
 
             // Return an available connection if one exists
-            if let Some(mut conn) = available.pop_front() {
+            let available_connection = available.pop_front();
+            if let Some(mut conn) = available_connection {
                 conn.touch();
                 return Ok(ActiveConnection::new(conn, permit));
             }
@@ -224,7 +225,11 @@ where
         let mut kept = VecDeque::new();
         let mut removed_count = 0;
 
-        while let Some(conn) = available.pop_front() {
+        loop {
+            let next_connection = available.pop_front();
+            let Some(conn) = next_connection else {
+                break;
+            };
             if conn.is_idle(self.config.idle_timeout)
                 && (kept.len() + available.len()) > self.config.min_connections
             {

--- a/src/net/src/storage_client.rs
+++ b/src/net/src/storage_client.rs
@@ -133,7 +133,8 @@ impl StorageClient {
         if commands.len() <= 3 {
             let mut results = Vec::new();
             for command in commands {
-                match self.inner.send_request(command).await {
+                let request_result = self.inner.send_request(command).await;
+                match request_result {
                     Ok(result) => results.push(result),
                     Err(e) => return Err(e),
                 }
@@ -167,7 +168,8 @@ impl StorageClient {
         // Wait for all responses
         let mut results = Vec::new();
         for future in futures {
-            match future.await {
+            let response_result = future.await;
+            match response_result {
                 Ok(result) => results.push(result),
                 Err(e) => {
                     // For pipelined requests, we continue processing other commands

--- a/src/net/src/unix.rs
+++ b/src/net/src/unix.rs
@@ -95,7 +95,8 @@ mod unix_impl {
             info!("Listening on Unix Socket: {}", self.path);
 
             loop {
-                match listener.accept().await {
+                let accept_result = listener.accept().await;
+                match accept_result {
                     Ok((socket, _)) => {
                         let s = UnixStreamWrapper::new(socket);
                         let client = Arc::new(Client::new(Box::new(s)));

--- a/src/net/src/unix.rs
+++ b/src/net/src/unix.rs
@@ -85,10 +85,10 @@ mod unix_impl {
     #[async_trait]
     impl ServerTrait for UnixServer {
         async fn run(&self) -> Result<(), Box<dyn Error>> {
-            if let Err(e) = std::fs::remove_file(&self.path) {
-                if e.kind() != std::io::ErrorKind::NotFound {
-                    return Err(e.into());
-                }
+            if let Err(e) = std::fs::remove_file(&self.path)
+                && e.kind() != std::io::ErrorKind::NotFound
+            {
+                return Err(e.into());
             }
 
             let listener = UnixListener::bind(&self.path)?;

--- a/src/net/tests/performance_tests.rs
+++ b/src/net/tests/performance_tests.rs
@@ -119,7 +119,8 @@ impl NetworkPerformanceTests {
 
         // Collect results
         for handle in handles {
-            if let Ok((client_latencies, client_successful)) = handle.await {
+            let client_result = handle.await;
+            if let Ok((client_latencies, client_successful)) = client_result {
                 latencies.extend(client_latencies);
                 successful_ops += client_successful;
                 total_ops += test_config.operations_per_client;
@@ -190,7 +191,8 @@ impl NetworkPerformanceTests {
 
         // Collect results
         for handle in handles {
-            if let Ok((client_latencies, client_successful)) = handle.await {
+            let client_result = handle.await;
+            if let Ok((client_latencies, client_successful)) = client_result {
                 latencies.extend(client_latencies);
                 successful_ops += client_successful;
                 total_ops += test_config.operations_per_client;
@@ -260,7 +262,8 @@ impl NetworkPerformanceTests {
 
         // Collect results
         for handle in handles {
-            if let Ok((client_latencies, client_successful)) = handle.await {
+            let client_result = handle.await;
+            if let Ok((client_latencies, client_successful)) = client_result {
                 latencies.extend(client_latencies);
                 successful_ops += client_successful;
                 total_ops += test_config.operations_per_client;
@@ -332,7 +335,8 @@ impl NetworkPerformanceTests {
 
         // Collect results
         for handle in handles {
-            if let Ok((client_latencies, client_successful, _use_pooling)) = handle.await {
+            let client_result = handle.await;
+            if let Ok((client_latencies, client_successful, _use_pooling)) = client_result {
                 latencies.extend(client_latencies);
                 successful_ops += client_successful;
                 total_ops += test_config.operations_per_client;

--- a/src/raft/src/conversion.rs
+++ b/src/raft/src/conversion.rs
@@ -123,7 +123,8 @@ impl TryInto<AppendEntriesRequest<KiwiTypeConfig>> for &proto::AppendEntriesRequ
         // 转换 entries
         let mut entries = Vec::new();
         for proto_entry in &self.entries {
-            match proto_entry.try_into() {
+            let conversion_result = proto_entry.try_into();
+            match conversion_result {
                 Ok(entry) => entries.push(entry),
                 Err(e) => {
                     return Err(tonic::Status::invalid_argument(format!(
@@ -266,7 +267,8 @@ impl TryFrom<AppendEntriesRequest<KiwiTypeConfig>> for proto::AppendEntriesReque
         let mut entries = Vec::new();
         let mut errors = Vec::new();
         for (idx, e) in req.entries.into_iter().enumerate() {
-            match e.try_into() {
+            let conversion_result = e.try_into();
+            match conversion_result {
                 Ok(entry) => entries.push(entry),
                 Err(e) => errors.push(format!("entry[{}]: {}", idx, e)),
             }

--- a/src/raft/src/log_store_rocksdb.rs
+++ b/src/raft/src/log_store_rocksdb.rs
@@ -993,11 +993,8 @@ mod tests {
                     }
 
                     // Query the range
-                    let read_entries = {
-
-                        log_store.do_try_get_log_entries(start..=end).await
-                            .expect("Read should succeed")
-                    };
+                    let read_result = log_store.do_try_get_log_entries(start..=end).await;
+                    let read_entries = read_result.expect("Read should succeed");
 
                     // Expected entries in this range
                     let expected_entries: Vec<_> = sequential_entries.iter()
@@ -3413,12 +3410,8 @@ mod tests {
 
         // All clones should see the same data
         for (i, store) in [&log_store, &clone1, &clone2, &clone3].iter().enumerate() {
-            let read_entries = {
-                store
-                    .do_try_get_log_entries(1..=1)
-                    .await
-                    .expect("Read should succeed")
-            };
+            let read_result = store.do_try_get_log_entries(1..=1).await;
+            let read_entries = read_result.expect("Read should succeed");
 
             assert_eq!(read_entries.len(), 1, "Clone {} should see the entry", i);
             assert_eq!(read_entries[0].log_id.index, 1);

--- a/src/raft/src/network.rs
+++ b/src/raft/src/network.rs
@@ -246,10 +246,10 @@ impl RaftNetwork<KiwiTypeConfig> for KiwiNetwork {
             }
 
             let mut client = self.client.lock().await;
-            match client
+            let append_result = client
                 .append_entries(TonicRequest::new(proto_req.clone()))
-                .await
-            {
+                .await;
+            match append_result {
                 Ok(response) => {
                     let proto_resp = response.into_inner();
                     return (&proto_resp).try_into().map_err(|e| {
@@ -302,7 +302,8 @@ impl RaftNetwork<KiwiTypeConfig> for KiwiNetwork {
             }
 
             let mut client = self.client.lock().await;
-            match client.vote(TonicRequest::new(proto_req)).await {
+            let vote_result = client.vote(TonicRequest::new(proto_req)).await;
+            match vote_result {
                 Ok(response) => {
                     let proto_resp = response.into_inner();
                     // Proto → OpenRaft

--- a/src/raft/src/network.rs
+++ b/src/raft/src/network.rs
@@ -132,14 +132,14 @@ impl RaftNetworkFactory<KiwiTypeConfig> for KiwiNetworkFactory {
     async fn new_client(&mut self, target: NodeId, node: &Node) -> Self::Network {
         // Get the read lock to check if a client already exists for the target node
         let networks = self.networks.read().await;
-        if let Some(network) = networks.get(&target) {
-            if network.target == node.raft_addr {
-                return KiwiNetwork {
-                    client: Arc::clone(&network.client),
-                    target: node.raft_addr.clone(),
-                    config: self.config.clone(),
-                };
-            }
+        if let Some(network) = networks.get(&target)
+            && network.target == node.raft_addr
+        {
+            return KiwiNetwork {
+                client: Arc::clone(&network.client),
+                target: node.raft_addr.clone(),
+                config: self.config.clone(),
+            };
         }
 
         // Drop the read lock before acquiring the write lock
@@ -149,14 +149,14 @@ impl RaftNetworkFactory<KiwiTypeConfig> for KiwiNetworkFactory {
         let mut networks = self.networks.write().await;
 
         // Double-check if another async task has already created the client while we were waiting for the write lock
-        if let Some(network) = networks.get(&target) {
-            if network.target == node.raft_addr {
-                return KiwiNetwork {
-                    client: Arc::clone(&network.client),
-                    target: node.raft_addr.clone(),
-                    config: self.config.clone(),
-                };
-            }
+        if let Some(network) = networks.get(&target)
+            && network.target == node.raft_addr
+        {
+            return KiwiNetwork {
+                client: Arc::clone(&network.client),
+                target: node.raft_addr.clone(),
+                config: self.config.clone(),
+            };
         }
 
         networks.remove(&target);

--- a/src/raft/src/state_machine.rs
+++ b/src/raft/src/state_machine.rs
@@ -701,15 +701,15 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
         let _snapshot_state = Arc::clone(&self.snapshot_state_gate).lock_owned().await;
         // On first access, lazily load from persisted snapshot to recover last_applied
         // after restart (otherwise openraft would scan from index 0 and fail if logs were purged).
-        if self.last_applied.is_none() {
-            if let Some(snap) = load_current_snapshot(&self.snapshot_work_dir)? {
-                self.last_applied = snap.meta.last_log_id;
-                self.last_membership = snap.meta.last_membership.clone();
-                log::info!(
-                    "Recovered last_applied={:?} from persisted snapshot",
-                    self.last_applied
-                );
-            }
+        if self.last_applied.is_none()
+            && let Some(snap) = load_current_snapshot(&self.snapshot_work_dir)?
+        {
+            self.last_applied = snap.meta.last_log_id;
+            self.last_membership = snap.meta.last_membership.clone();
+            log::info!(
+                "Recovered last_applied={:?} from persisted snapshot",
+                self.last_applied
+            );
         }
         Ok((self.last_applied, self.last_membership.clone()))
     }

--- a/src/raft/tests/log_store_rocksdb_test.rs
+++ b/src/raft/tests/log_store_rocksdb_test.rs
@@ -301,10 +301,8 @@ async fn close_and_reopen_recovers_complete_raft_state() {
 
     let recovered_entries = {
         let mut reader = reopened.get_log_reader().await;
-        reader
-            .try_get_log_entries(1..=10)
-            .await
-            .expect("Failed to read recovered entries")
+        let read_result = reader.try_get_log_entries(1..=10).await;
+        read_result.expect("Failed to read recovered entries")
     };
     assert_eq!(recovered_entries.len(), 6);
     assert_eq!(
@@ -356,10 +354,8 @@ async fn dropping_one_log_store_clone_keeps_remaining_owner_usable() {
 
     let visible_entries = {
         let mut reader = remaining.get_log_reader().await;
-        reader
-            .try_get_log_entries(1..=6)
-            .await
-            .expect("Remaining clone should read entries")
+        let read_result = reader.try_get_log_entries(1..=6).await;
+        read_result.expect("Remaining clone should read entries")
     };
     assert_eq!(
         serde_json::to_vec(&visible_entries).expect("Failed to serialize visible entries"),
@@ -408,10 +404,8 @@ async fn dropping_one_log_store_clone_keeps_remaining_owner_usable() {
 
     let reopened_entries = {
         let mut reader = reopened.get_log_reader().await;
-        reader
-            .try_get_log_entries(1..=6)
-            .await
-            .expect("Reopened store should recover retained entries")
+        let read_result = reader.try_get_log_entries(1..=6).await;
+        read_result.expect("Reopened store should recover retained entries")
     };
     assert_eq!(
         serde_json::to_vec(&reopened_entries).expect("Failed to serialize reopened entries"),

--- a/src/server/src/main.rs
+++ b/src/server/src/main.rs
@@ -360,7 +360,11 @@ async fn start_server(
         // backpressure via a bounded channel.
         let raft_for_drain = raft_app.clone();
         tokio::spawn(async move {
-            while let Some((binlog, resp_tx)) = log_rx.recv().await {
+            loop {
+                let received = log_rx.recv().await;
+                let Some((binlog, resp_tx)) = received else {
+                    break;
+                };
                 let result = raft_for_drain
                     .client_write(binlog)
                     .await
@@ -433,28 +437,30 @@ async fn start_server(
             }
         });
 
-        Some(raft_app as Arc<dyn raft::leader_gate::LeaderGate>)
+        let raft_leader_gate = raft_app as Arc<dyn raft::leader_gate::LeaderGate>;
+        Some(raft_leader_gate)
     } else {
         None
     };
 
-    if let Some(server) = net::ServerFactory::create_server(
+    match net::ServerFactory::create_server(
         protocol,
         Some(addr.to_string()),
         runtime_manager,
         config.requirepass.clone(),
         leader_gate,
     ) {
-        tokio::spawn(async move {
-            if let Err(e) = server.run().await {
-                error!("Redis server error: {}", e);
-            }
-        });
-        Ok(())
-    } else {
-        Err(std::io::Error::other(format!(
+        Some(server) => {
+            tokio::spawn(async move {
+                if let Err(e) = server.run().await {
+                    error!("Redis server error: {}", e);
+                }
+            });
+            Ok(())
+        }
+        _ => Err(std::io::Error::other(format!(
             "Failed to create server for protocol '{}' on address '{}'",
             protocol, addr
-        )))
+        ))),
     }
 }

--- a/src/storage/src/expiration_manager.rs
+++ b/src/storage/src/expiration_manager.rs
@@ -130,12 +130,12 @@ impl ExpirationManager {
         let mut key_expiry = self.key_expiry.write();
 
         // Remove old expiration if exists
-        if let Some(old_expire_time) = key_expiry.get(key) {
-            if let Some(keys_set) = expiry_index.get_mut(old_expire_time) {
-                keys_set.remove(key);
-                if keys_set.is_empty() {
-                    expiry_index.remove(old_expire_time);
-                }
+        if let Some(old_expire_time) = key_expiry.get(key)
+            && let Some(keys_set) = expiry_index.get_mut(old_expire_time)
+        {
+            keys_set.remove(key);
+            if keys_set.is_empty() {
+                expiry_index.remove(old_expire_time);
             }
         }
 

--- a/src/storage/src/logindex/event_listener.rs
+++ b/src/storage/src/logindex/event_listener.rs
@@ -32,8 +32,8 @@ const EMPTY: u64 = u64::MAX;
 
 /// Pack generation (high 32 bits) and cf_id (low 32 bits) to avoid ABA in watchdog.
 #[inline]
-fn pack(gen: u64, cf_id: u32) -> u64 {
-    (gen << 32) | (cf_id as u64)
+fn pack(r#gen: u64, cf_id: u32) -> u64 {
+    (r#gen << 32) | (cf_id as u64)
 }
 
 /// Extract cf_id from packed value.
@@ -90,9 +90,9 @@ impl LogIndexAndSequenceCollectorPurger {
         if cf_id < 0 {
             self.manual_flushing_cf.store(EMPTY, Ordering::SeqCst);
         } else {
-            let gen = self.next_generation.fetch_add(1, Ordering::SeqCst);
+            let r#gen = self.next_generation.fetch_add(1, Ordering::SeqCst);
             self.manual_flushing_cf
-                .store(pack(gen, cf_id as u32), Ordering::SeqCst);
+                .store(pack(r#gen, cf_id as u32), Ordering::SeqCst);
         }
     }
 
@@ -174,8 +174,8 @@ impl EventListener for LogIndexAndSequenceCollectorPurger {
             return;
         };
 
-        let gen = self.next_generation.fetch_add(1, Ordering::SeqCst);
-        let packed = pack(gen, target_cf as u32);
+        let r#gen = self.next_generation.fetch_add(1, Ordering::SeqCst);
+        let packed = pack(r#gen, target_cf as u32);
 
         // Attempt to claim manual-flush state; abort if another flush is already in progress
         if self

--- a/src/storage/src/logindex/table_properties.rs
+++ b/src/storage/src/logindex/table_properties.rs
@@ -152,13 +152,12 @@ pub fn get_largest_log_index_from_collection(
 
     for (_, props) in collection.iter() {
         let user_props = props.user_collected_properties();
-        if let Some(pair) = read_stats_from_table_props(&user_props) {
-            if pair.applied_log_index() > max_log_index
-                || (pair.applied_log_index() == max_log_index && pair.seqno() > max_seqno)
-            {
-                max_log_index = pair.applied_log_index();
-                max_seqno = pair.seqno();
-            }
+        if let Some(pair) = read_stats_from_table_props(&user_props)
+            && (pair.applied_log_index() > max_log_index
+                || (pair.applied_log_index() == max_log_index && pair.seqno() > max_seqno))
+        {
+            max_log_index = pair.applied_log_index();
+            max_seqno = pair.seqno();
         }
     }
 

--- a/src/storage/src/redis.rs
+++ b/src/storage/src/redis.rs
@@ -539,7 +539,8 @@ impl Redis {
             for (i, cf_name) in self.handles.iter().enumerate() {
                 if i > 0 {
                     // Skip already compacted default CF
-                    if let Some(cf) = db.cf_handle(cf_name) {
+                    let cf_handle = db.cf_handle(cf_name);
+                    if let Some(cf) = cf_handle {
                         db.compact_range_cf(&cf, begin, end);
                     }
                 }
@@ -988,7 +989,7 @@ impl Redis {
 /// Returns an error if the database is not initialized or if any column family handle is not found.
 #[macro_export]
 macro_rules! get_db_and_cfs {
-    ($self:expr $(, $cf:expr)*) => {{
+    ($self:expr_2021 $(, $cf:expr_2021)*) => {{
         let db = $self.db().context(OptionNoneSnafu {
             message: "db is not initialized".to_string(),
         })?;

--- a/src/storage/src/redis.rs
+++ b/src/storage/src/redis.rs
@@ -490,8 +490,8 @@ impl Redis {
         // Set compaction filter factory
         if cf_name == ColumnFamilyIndex::MetaCF.name() {
             cf_opts.set_compaction_filter_factory(MetaCompactionFilterFactory);
-        } else if let Some(db_once_cell) = db_once_cell {
-            if let Some(data_type) = [
+        } else if let Some(db_once_cell) = db_once_cell
+            && let Some(data_type) = [
                 ColumnFamilyIndex::HashesDataCF,
                 ColumnFamilyIndex::SetsDataCF,
                 ColumnFamilyIndex::ListsDataCF,
@@ -501,10 +501,9 @@ impl Redis {
             .iter()
             .find(|cf| cf.name() == cf_name)
             .and_then(|cf| cf.data_type())
-            {
-                let factory = DataCompactionFilterFactory::new(Arc::clone(db_once_cell), data_type);
-                cf_opts.set_compaction_filter_factory(factory);
-            }
+        {
+            let factory = DataCompactionFilterFactory::new(Arc::clone(db_once_cell), data_type);
+            cf_opts.set_compaction_filter_factory(factory);
         }
 
         ColumnFamilyDescriptor::new(cf_name, cf_opts)
@@ -551,10 +550,10 @@ impl Redis {
     }
 
     pub fn get_property(&self, property: &str) -> Result<u64> {
-        if let Some(db) = &self.db {
-            if let Some(value) = db.property_int_value(property).context(RocksSnafu)? {
-                return Ok(value);
-            }
+        if let Some(db) = &self.db
+            && let Some(value) = db.property_int_value(property).context(RocksSnafu)?
+        {
+            return Ok(value);
         }
 
         OptionNoneSnafu {
@@ -568,10 +567,10 @@ impl Redis {
         &self,
         cf_index: ColumnFamilyIndex,
     ) -> Option<Arc<rocksdb::BoundColumnFamily<'_>>> {
-        if let Some(db) = &self.db {
-            if let Some(cf_name) = self.handles.get(cf_index as usize) {
-                return db.cf_handle(cf_name);
-            }
+        if let Some(db) = &self.db
+            && let Some(cf_name) = self.handles.get(cf_index as usize)
+        {
+            return db.cf_handle(cf_name);
         }
         None
     }

--- a/src/storage/src/redis_hashes.rs
+++ b/src/storage/src/redis_hashes.rs
@@ -177,10 +177,11 @@ impl Redis {
             let meta_val = ParsedHashesMetaValue::new(&meta_val_bytes[..])?;
             let version = meta_val.version();
             let data_key = MemberDataKey::new(_key, version, _field);
-            if let Some(data_val_bytes) = db
-                .get_cf_opt(data_cf, &data_key.encode()?, &read_options)
-                .context(RocksSnafu)?
-            {
+            let encoded_data_key = data_key.encode()?;
+            let data_value = db
+                .get_cf_opt(data_cf, &encoded_data_key, &read_options)
+                .context(RocksSnafu)?;
+            if let Some(data_val_bytes) = data_value {
                 let mut data_val = ParsedBaseDataValue::new(&data_val_bytes[..])?;
                 data_val.strip_suffix();
                 return Ok(Some(
@@ -343,11 +344,12 @@ impl Redis {
                 } else {
                     let version = parsed_meta.version();
                     let data_key = MemberDataKey::new(key, version, field);
+                    let encoded_data_key = data_key.encode()?;
+                    let data_value = db
+                        .get_cf_opt(data_cf, &encoded_data_key, &self.read_options)
+                        .context(RocksSnafu)?;
 
-                    match db
-                        .get_cf_opt(data_cf, &data_key.encode()?, &self.read_options)
-                        .context(RocksSnafu)?
-                    {
+                    match data_value {
                         Some(existing_data_bytes) => {
                             let mut existing_data =
                                 ParsedBaseDataValue::new(&existing_data_bytes[..])?;
@@ -550,10 +552,11 @@ impl Redis {
                 let version = meta_val.version();
                 for field in fields {
                     let data_key = MemberDataKey::new(key, version, field);
-                    match db
-                        .get_cf_opt(data_cf, &data_key.encode()?, &read_options)
-                        .context(RocksSnafu)?
-                    {
+                    let encoded_data_key = data_key.encode()?;
+                    let data_value = db
+                        .get_cf_opt(data_cf, &encoded_data_key, &read_options)
+                        .context(RocksSnafu)?;
+                    match data_value {
                         Some(data_val_bytes) => {
                             let mut data_val = ParsedBaseDataValue::new(&data_val_bytes[..])?;
                             data_val.strip_suffix();
@@ -788,11 +791,12 @@ impl Redis {
                 } else {
                     let version = parsed_meta.version();
                     let data_key = MemberDataKey::new(key, version, field);
+                    let encoded_data_key = data_key.encode()?;
+                    let data_value = db
+                        .get_cf_opt(data_cf, &encoded_data_key, &self.read_options)
+                        .context(RocksSnafu)?;
 
-                    match db
-                        .get_cf_opt(data_cf, &data_key.encode()?, &self.read_options)
-                        .context(RocksSnafu)?
-                    {
+                    match data_value {
                         Some(_) => Ok(0), // Field already exists
                         None => {
                             if !parsed_meta.check_modify_count(1) {
@@ -905,11 +909,12 @@ impl Redis {
                 } else {
                     let version = parsed_meta.version();
                     let data_key = MemberDataKey::new(key, version, field);
+                    let encoded_data_key = data_key.encode()?;
+                    let data_value = db
+                        .get_cf_opt(data_cf, &encoded_data_key, &self.read_options)
+                        .context(RocksSnafu)?;
 
-                    match db
-                        .get_cf_opt(data_cf, &data_key.encode()?, &self.read_options)
-                        .context(RocksSnafu)?
-                    {
+                    match data_value {
                         Some(old_val_bytes) => {
                             let mut old_val = ParsedBaseDataValue::new(&old_val_bytes[..])?;
                             old_val.strip_suffix();
@@ -1051,11 +1056,12 @@ impl Redis {
                 } else {
                     let version = parsed_meta.version();
                     let data_key = MemberDataKey::new(key, version, field);
+                    let encoded_data_key = data_key.encode()?;
+                    let data_value = db
+                        .get_cf_opt(data_cf, &encoded_data_key, &self.read_options)
+                        .context(RocksSnafu)?;
 
-                    match db
-                        .get_cf_opt(data_cf, &data_key.encode()?, &self.read_options)
-                        .context(RocksSnafu)?
-                    {
+                    match data_value {
                         Some(old_val_bytes) => {
                             let mut old_val = ParsedBaseDataValue::new(&old_val_bytes[..])?;
                             old_val.strip_suffix();

--- a/src/storage/src/redis_lists.rs
+++ b/src/storage/src/redis_lists.rs
@@ -583,7 +583,8 @@ impl Redis {
         {
             Some(data_value) => {
                 let parsed_data = ParsedBaseDataValue::new(BytesMut::from(data_value.as_slice()))?;
-                Ok(Some(parsed_data.user_value().to_vec()))
+                let user_value = parsed_data.user_value().to_vec();
+                Ok(Some(user_value))
             }
             None => Ok(None),
         }

--- a/src/storage/src/redis_sets.rs
+++ b/src/storage/src/redis_sets.rs
@@ -2271,27 +2271,27 @@ impl Redis {
         let meta_val = db
             .get_cf(&cf_meta, &dest_base_meta_key)
             .context(RocksSnafu)?;
-        if let Some(val) = meta_val {
-            if val.first().copied() == Some(DataType::Set as u8) {
-                let set_meta = ParsedSetsMetaValue::new(&val[..])?;
-                if set_meta.is_valid() {
-                    let version = set_meta.version();
+        if let Some(val) = meta_val
+            && val.first().copied() == Some(DataType::Set as u8)
+        {
+            let set_meta = ParsedSetsMetaValue::new(&val[..])?;
+            if set_meta.is_valid() {
+                let version = set_meta.version();
 
-                    // Delete all existing members
-                    let prefix = MemberDataKey::new(destination, version, &[]).encode_seek_key()?;
-                    let iter = db.iterator_cf_opt(
-                        &cf_data,
-                        ReadOptions::default(),
-                        IteratorMode::From(&prefix, Direction::Forward),
-                    );
+                // Delete all existing members
+                let prefix = MemberDataKey::new(destination, version, &[]).encode_seek_key()?;
+                let iter = db.iterator_cf_opt(
+                    &cf_data,
+                    ReadOptions::default(),
+                    IteratorMode::From(&prefix, Direction::Forward),
+                );
 
-                    for item in iter {
-                        let (raw_key, _) = item.context(RocksSnafu)?;
-                        if !raw_key.starts_with(&prefix) {
-                            break;
-                        }
-                        keys_to_delete.push(raw_key.to_vec());
+                for item in iter {
+                    let (raw_key, _) = item.context(RocksSnafu)?;
+                    if !raw_key.starts_with(&prefix) {
+                        break;
                     }
+                    keys_to_delete.push(raw_key.to_vec());
                 }
             }
         }
@@ -2444,10 +2444,11 @@ impl Redis {
 
             for member in &all_members[start_index..end_index] {
                 // Apply pattern matching if specified
-                if let Some(pat) = pattern {
-                    if pat != b"*" && !glob_match_bytes(pat, member) {
-                        continue;
-                    }
+                if let Some(pat) = pattern
+                    && pat != b"*"
+                    && !glob_match_bytes(pat, member)
+                {
+                    continue;
                 }
                 result_members.push(member.clone());
             }

--- a/src/storage/src/redis_strings.rs
+++ b/src/storage/src/redis_strings.rs
@@ -561,11 +561,12 @@ impl Redis {
 
         for key in keys {
             let string_key = BaseKey::new(key);
+            let encoded_string_key = string_key.encode()?;
+            let string_value = db
+                .get_opt(&encoded_string_key, &self.read_options)
+                .context(RocksSnafu)?;
 
-            match db
-                .get_opt(&string_key.encode()?, &self.read_options)
-                .context(RocksSnafu)?
-            {
+            match string_value {
                 Some(val) => {
                     let type_state = match self.check_type_state(val.as_slice(), DataType::String) {
                         Ok(state) => state,
@@ -2046,7 +2047,8 @@ impl Redis {
                 ColumnFamilyIndex::ZsetsDataCF,
                 ColumnFamilyIndex::ZsetsScoreCF,
             ] {
-                if let Some(cf) = self.get_cf_handle(cf_index) {
+                let cf_handle = self.get_cf_handle(cf_index);
+                if let Some(cf) = cf_handle {
                     // Prefix-scan data CF and delete all derived keys
                     let iter = db.iterator_cf(
                         &cf,
@@ -2146,7 +2148,8 @@ impl Redis {
         ];
 
         for cf_index in all_cf_indexes {
-            if let Some(cf) = self.get_cf_handle(cf_index) {
+            let cf_handle = self.get_cf_handle(cf_index);
+            if let Some(cf) = cf_handle {
                 let mut keys_chunk: Vec<Vec<u8>> = Vec::with_capacity(CHUNK_SIZE);
 
                 let iter = db.iterator_cf(&cf, rocksdb::IteratorMode::Start);
@@ -2226,33 +2229,44 @@ impl Redis {
             let (key_bytes, value_bytes) = item.context(RocksSnafu)?;
 
             // Decode the key to get the actual user key
-            if let Ok(base_key) = crate::format_base_key::ParsedBaseKey::new(&key_bytes[..]) {
+            let parsed_base_key_result = crate::format_base_key::ParsedBaseKey::new(&key_bytes[..]);
+            if let Ok(base_key) = parsed_base_key_result {
                 // Check if the string key is not expired
                 if !value_bytes.is_empty() {
-                    if let Ok(parsed) = ParsedStringsValue::new(&value_bytes[..]) {
+                    let parsed_string_result = ParsedStringsValue::new(&value_bytes[..]);
+                    if let Ok(parsed) = parsed_string_result {
                         if !parsed.is_stale() {
                             return Ok(Some(String::from_utf8_lossy(base_key.key()).to_string()));
                         }
                     }
                 }
-            } else if let Ok(meta_key) = crate::format_base_key::ParsedBaseKey::new(&key_bytes[..])
-            {
-                // Check if meta key is not expired
-                if !value_bytes.is_empty() {
-                    let is_valid = if let Ok(meta) =
-                        crate::format_base_meta_value::ParsedBaseMetaValue::new(&value_bytes[..])
-                    {
-                        !meta.is_stale() && meta.count() > 0
-                    } else if let Ok(list_meta) =
-                        crate::format_list_meta_value::ParsedListsMetaValue::new(&value_bytes[..])
-                    {
-                        !list_meta.is_stale() && list_meta.count() > 0
-                    } else {
-                        false
-                    };
+            } else {
+                let parsed_meta_key_result =
+                    crate::format_base_key::ParsedBaseKey::new(&key_bytes[..]);
+                if let Ok(meta_key) = parsed_meta_key_result {
+                    // Check if meta key is not expired
+                    if !value_bytes.is_empty() {
+                        let parsed_meta_result =
+                            crate::format_base_meta_value::ParsedBaseMetaValue::new(
+                                &value_bytes[..],
+                            );
+                        let is_valid = if let Ok(meta) = parsed_meta_result {
+                            !meta.is_stale() && meta.count() > 0
+                        } else {
+                            let parsed_list_meta_result =
+                                crate::format_list_meta_value::ParsedListsMetaValue::new(
+                                    &value_bytes[..],
+                                );
+                            if let Ok(list_meta) = parsed_list_meta_result {
+                                !list_meta.is_stale() && list_meta.count() > 0
+                            } else {
+                                false
+                            }
+                        };
 
-                    if is_valid {
-                        return Ok(Some(String::from_utf8_lossy(meta_key.key()).to_string()));
+                        if is_valid {
+                            return Ok(Some(String::from_utf8_lossy(meta_key.key()).to_string()));
+                        }
                     }
                 }
             }

--- a/src/storage/src/redis_strings.rs
+++ b/src/storage/src/redis_strings.rs
@@ -2234,10 +2234,10 @@ impl Redis {
                 // Check if the string key is not expired
                 if !value_bytes.is_empty() {
                     let parsed_string_result = ParsedStringsValue::new(&value_bytes[..]);
-                    if let Ok(parsed) = parsed_string_result {
-                        if !parsed.is_stale() {
-                            return Ok(Some(String::from_utf8_lossy(base_key.key()).to_string()));
-                        }
+                    if let Ok(parsed) = parsed_string_result
+                        && !parsed.is_stale()
+                    {
+                        return Ok(Some(String::from_utf8_lossy(base_key.key()).to_string()));
                     }
                 }
             } else {

--- a/src/storage/src/redis_zsets.rs
+++ b/src/storage/src/redis_zsets.rs
@@ -578,10 +578,10 @@ impl Redis {
             let score_str = format!("{}", score_key.score());
 
             // Apply pattern matching if specified
-            if let Some(pat) = pattern {
-                if !glob_match(&member, pat) {
-                    continue;
-                }
+            if let Some(pat) = pattern
+                && !glob_match(&member, pat)
+            {
+                continue;
             }
 
             results.push((member, score_str));
@@ -955,10 +955,10 @@ impl Redis {
             let member = score_key.member();
 
             // Check if we've passed the max boundary - break early for optimization
-            if let Some(ref max_m) = max_member {
-                if member > max_m.as_slice() {
-                    break;
-                }
+            if let Some(ref max_m) = max_member
+                && member > max_m.as_slice()
+            {
+                break;
             }
 
             // Check if member is within the lexicographical range
@@ -1261,35 +1261,35 @@ impl Redis {
         // fail with WRONGTYPE when the destination holds a different data type.
         if !dest_meta_val.is_empty() {
             // If the destination is a parseable ZSet, clean up its score/member data.
-            if let Ok(dest_meta) = ParsedZSetsMetaValue::new(&dest_meta_val[..]) {
-                if dest_meta.is_valid() {
-                    let dest_version = dest_meta.version();
+            if let Ok(dest_meta) = ParsedZSetsMetaValue::new(&dest_meta_val[..])
+                && dest_meta.is_valid()
+            {
+                let dest_version = dest_meta.version();
 
-                    // Delete all score keys and member keys
-                    let min_score_key =
-                        ZSetsScoreKey::new(destination, dest_version, f64::NEG_INFINITY, &[])
-                            .encode_seek_key()?;
-                    let iter = db.iterator_cf_opt(
-                        &cf_score,
-                        ReadOptions::default(),
-                        IteratorMode::From(&min_score_key, Direction::Forward),
-                    );
+                // Delete all score keys and member keys
+                let min_score_key =
+                    ZSetsScoreKey::new(destination, dest_version, f64::NEG_INFINITY, &[])
+                        .encode_seek_key()?;
+                let iter = db.iterator_cf_opt(
+                    &cf_score,
+                    ReadOptions::default(),
+                    IteratorMode::From(&min_score_key, Direction::Forward),
+                );
 
-                    for item in iter {
-                        let (raw_key, _) = item.context(RocksSnafu)?;
-                        let score_key = ParsedZSetsScoreKey::new(&raw_key)?;
+                for item in iter {
+                    let (raw_key, _) = item.context(RocksSnafu)?;
+                    let score_key = ParsedZSetsScoreKey::new(&raw_key)?;
 
-                        if destination != score_key.key() || dest_version != score_key.version() {
-                            break;
-                        }
-
-                        // Delete score key and member key
-                        batch.delete(ColumnFamilyIndex::ZsetsScoreCF, &raw_key)?;
-                        let member_key =
-                            MemberDataKey::new(destination, dest_version, score_key.member())
-                                .encode()?;
-                        batch.delete(ColumnFamilyIndex::ZsetsDataCF, &member_key)?;
+                    if destination != score_key.key() || dest_version != score_key.version() {
+                        break;
                     }
+
+                    // Delete score key and member key
+                    batch.delete(ColumnFamilyIndex::ZsetsScoreCF, &raw_key)?;
+                    let member_key =
+                        MemberDataKey::new(destination, dest_version, score_key.member())
+                            .encode()?;
+                    batch.delete(ColumnFamilyIndex::ZsetsDataCF, &member_key)?;
                 }
             }
             // Remove the old destination meta key so the new result can replace it.
@@ -1416,10 +1416,10 @@ impl Redis {
             let member = score_key.member();
 
             // Check if we've passed the max boundary
-            if let Some(ref max_m) = max_member {
-                if member > max_m.as_slice() {
-                    break;
-                }
+            if let Some(ref max_m) = max_member
+                && member > max_m.as_slice()
+            {
+                break;
             }
 
             if is_in_lex_range(
@@ -1599,10 +1599,10 @@ impl Redis {
 
             let member = score_key.member();
 
-            if let Some(ref max_m) = max_member {
-                if member > max_m.as_slice() {
-                    break;
-                }
+            if let Some(ref max_m) = max_member
+                && member > max_m.as_slice()
+            {
+                break;
             }
 
             if is_in_lex_range(

--- a/src/storage/src/redis_zsets.rs
+++ b/src/storage/src/redis_zsets.rs
@@ -109,9 +109,10 @@ impl Redis {
                                     ParsedBaseDataValue::new(&existing_member_val[..])?;
                                 parsed_base_data_val.strip_suffix();
                                 not_found = false;
-                                match String::from_utf8_lossy(&parsed_base_data_val.user_value())
-                                    .parse::<f64>()
-                                {
+                                let user_value = parsed_base_data_val.user_value();
+                                let parsed_score =
+                                    String::from_utf8_lossy(&user_value).parse::<f64>();
+                                match parsed_score {
                                     Ok(existing_score) => {
                                         if (existing_score - sm.score).abs() < f64::EPSILON {
                                             continue;
@@ -373,10 +374,10 @@ impl Redis {
                         let mut parsed_base_data_val =
                             ParsedBaseDataValue::new(&existing_member_val[..])?;
                         parsed_base_data_val.strip_suffix();
+                        let user_value = parsed_base_data_val.user_value();
+                        let parsed_score = String::from_utf8_lossy(&user_value).parse::<f64>();
 
-                        match String::from_utf8_lossy(&parsed_base_data_val.user_value())
-                            .parse::<f64>()
-                        {
+                        match parsed_score {
                             Ok(current_score) => {
                                 new_score = current_score + increment;
                                 if new_score.is_nan() || new_score.is_infinite() {
@@ -847,8 +848,10 @@ impl Redis {
                 // Get the member's score
                 let mut parsed_base_data_val = ParsedBaseDataValue::new(&existing_member_val[..])?;
                 parsed_base_data_val.strip_suffix();
+                let user_value = parsed_base_data_val.user_value();
+                let parsed_score = String::from_utf8_lossy(&user_value).parse::<f64>();
 
-                match String::from_utf8_lossy(&parsed_base_data_val.user_value()).parse::<f64>() {
+                match parsed_score {
                     Ok(score) => {
                         // Delete score key
                         let score_key = ZSetsScoreKey::new(key, version, score, member).encode()?;
@@ -2180,7 +2183,7 @@ fn is_in_lex_range(
     max_exclusive: bool,
 ) -> bool {
     // Check min boundary
-    if let Some(ref min) = min_member {
+    if let Some(min) = min_member {
         match member.cmp(min.as_slice()) {
             std::cmp::Ordering::Less => return false,
             std::cmp::Ordering::Equal if min_exclusive => return false,
@@ -2189,7 +2192,7 @@ fn is_in_lex_range(
     }
 
     // Check max boundary
-    if let Some(ref max) = max_member {
+    if let Some(max) = max_member {
         match member.cmp(max.as_slice()) {
             std::cmp::Ordering::Greater => return false,
             std::cmp::Ordering::Equal if max_exclusive => return false,

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -618,34 +618,30 @@ impl Storage {
     /// the cf_tracker with the actual state from the restored SST files.
     pub fn init_cf_trackers(&self) -> crate::Result<()> {
         for inst in &self.insts {
-            if let Some(ref cf_tracker) = inst.logindex_cf_tracker {
-                if let Some(ref db) = inst.db {
-                    // Query each CF's table properties through the concrete RocksDB so the
-                    // tracker mirrors the (log_index, seqno) high-water mark recorded in
-                    // the restored SST files.
-                    let rocksdb = db.as_ref();
-                    for cf_id in 0..crate::logindex::types::cf_metadata::COLUMN_FAMILY_COUNT {
-                        let cf_name = crate::logindex::types::cf_metadata::CF_NAMES_STR[cf_id];
-                        let cf_handle = rocksdb.cf_handle(cf_name);
-                        if let Some(cf) = cf_handle {
-                            let properties = rocksdb.get_properties_of_all_tables_cf(&cf);
-                            match properties {
-                                Ok(collection) => {
-                                    if let Some(pair) = crate::logindex::table_properties::get_largest_log_index_from_collection(&collection) {
-                                        let log_index = pair.applied_log_index();
-                                        let seqno = pair.seqno();
-                                        cf_tracker.set_flushed_log_index(cf_id, log_index, seqno);
-                                        // On snapshot restore, flushed and applied should be consistent
-                                        cf_tracker.set_applied_log_index(cf_id, log_index, seqno);
-                                    }
+            if let Some(ref cf_tracker) = inst.logindex_cf_tracker
+                && let Some(ref db) = inst.db
+            {
+                // Query each CF's table properties through the concrete RocksDB so the
+                // tracker mirrors the (log_index, seqno) high-water mark recorded in
+                // the restored SST files.
+                let rocksdb = db.as_ref();
+                for cf_id in 0..crate::logindex::types::cf_metadata::COLUMN_FAMILY_COUNT {
+                    let cf_name = crate::logindex::types::cf_metadata::CF_NAMES_STR[cf_id];
+                    let cf_handle = rocksdb.cf_handle(cf_name);
+                    if let Some(cf) = cf_handle {
+                        let properties = rocksdb.get_properties_of_all_tables_cf(&cf);
+                        match properties {
+                            Ok(collection) => {
+                                if let Some(pair) = crate::logindex::table_properties::get_largest_log_index_from_collection(&collection) {
+                                    let log_index = pair.applied_log_index();
+                                    let seqno = pair.seqno();
+                                    cf_tracker.set_flushed_log_index(cf_id, log_index, seqno);
+                                    // On snapshot restore, flushed and applied should be consistent
+                                    cf_tracker.set_applied_log_index(cf_id, log_index, seqno);
                                 }
-                                Err(e) => {
-                                    log::warn!(
-                                        "Failed to get properties for CF {}: {}",
-                                        cf_name,
-                                        e
-                                    );
-                                }
+                            }
+                            Err(e) => {
+                                log::warn!("Failed to get properties for CF {}: {}", cf_name, e);
                             }
                         }
                     }

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -626,8 +626,10 @@ impl Storage {
                     let rocksdb = db.as_ref();
                     for cf_id in 0..crate::logindex::types::cf_metadata::COLUMN_FAMILY_COUNT {
                         let cf_name = crate::logindex::types::cf_metadata::CF_NAMES_STR[cf_id];
-                        if let Some(cf) = rocksdb.cf_handle(cf_name) {
-                            match rocksdb.get_properties_of_all_tables_cf(&cf) {
+                        let cf_handle = rocksdb.cf_handle(cf_name);
+                        if let Some(cf) = cf_handle {
+                            let properties = rocksdb.get_properties_of_all_tables_cf(&cf);
+                            match properties {
                                 Ok(collection) => {
                                     if let Some(pair) = crate::logindex::table_properties::get_largest_log_index_from_collection(&collection) {
                                         let log_index = pair.applied_log_index();

--- a/src/storage/tests/redis_basic_test.rs
+++ b/src/storage/tests/redis_basic_test.rs
@@ -444,19 +444,22 @@ mod is_stale_tests {
         let mut meta = HashesMetaValue::new(Bytes::copy_from_slice(&count.to_le_bytes()));
         meta.inner.data_type = data_type;
         meta.set_etime(etime);
-        meta.encode().to_vec()
+        let encoded = meta.encode();
+        encoded.to_vec()
     }
 
     fn create_list_meta_value(count: u64, etime: u64) -> Vec<u8> {
         let mut meta = ListsMetaValue::new(Bytes::copy_from_slice(&count.to_le_bytes()));
         meta.set_etime(etime);
-        meta.encode().to_vec()
+        let encoded = meta.encode();
+        encoded.to_vec()
     }
 
     fn create_string_value(value: &[u8], etime: u64) -> Vec<u8> {
         let mut string_val = StringValue::new(Bytes::copy_from_slice(value));
         string_val.set_etime(etime);
-        string_val.encode().to_vec()
+        let encoded = string_val.encode();
+        encoded.to_vec()
     }
 
     #[test]

--- a/src/storage/tests/redis_string_test.rs
+++ b/src/storage/tests/redis_string_test.rs
@@ -804,10 +804,13 @@ mod redis_string_test {
             handle.join().unwrap();
         }
 
-        if let Ok(redis) = Arc::try_unwrap(redis_arc) {
-            cleanup_redis(redis, &test_db_path);
-        } else {
-            safe_cleanup_test_db(&test_db_path);
+        match Arc::try_unwrap(redis_arc) {
+            Ok(redis) => {
+                cleanup_redis(redis, &test_db_path);
+            }
+            _ => {
+                safe_cleanup_test_db(&test_db_path);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- migrate all 12 Kiwi workspace crates from Rust 2021 to Rust 2024 while retaining the pinned Rust 1.97.1 toolchain and resolver 2
- apply the compiler-generated edition migration plus explicit temporary/drop-order bindings for async, lock, oneshot, buffer-pool, Raft, and RocksDB paths
- close the remaining Edition 2024 Clippy diagnostics with behavior-preserving let chains and update the active developer documentation
- carry forward the still-valid CodeRabbit feedback from #370: fix Markdown heading hierarchy and document Windows/Linux/macOS native prerequisites, including Protobuf 27.1 on Windows

## Scope and invariants

- no dependency version or `Cargo.lock` change
- no `rust-toolchain.toml`, CI, Docker, nightly, release, storage-format, Redis-visible behavior, or OpenRaft protocol change
- no Embedded Redis Hot Tier implementation or dependency change
- `cargo metadata` resolves 12/12 workspace crates as Edition 2024 with `rust-version = 1.97.1`

## Requirements

- `REQ-WORK-003`: validation evidence below is bound to the exact branch, Head, platform, toolchain, command, result, and uncovered risk
- no Redis 8.8.1 compatibility, storage, Raft, or Hot Tier product requirement is changed by this build-language migration

## Commits

- `587c6d2` — `refactor: prepare code for Rust 2024`
- `d440d76` — `build: migrate Kiwi to Rust 2024 edition`

## Verification

### WSL / Linux

Environment: Ubuntu 24.04.3, Rust/Cargo 1.97.1 (`x86_64-unknown-linux-gnu`), independent target directory.

- `cargo fmt --all -- --check` — passed
- `cargo metadata --locked --format-version 1 --no-deps` — 12/12 Edition 2024 and Rust 1.97.1
- `cargo check --workspace --all-targets --all-features --locked` — passed
- `cargo clippy --all-features --workspace --locked -- -D warnings -D clippy::unwrap_used` — passed
- `RUST_TEST_THREADS=1 cargo test --workspace --all-features --locked` — 997 passed, 0 failed, 2 ignored across 42 result groups

The first Linux test attempt inherited a Windows compiler override (`CC=sccache cl.exe`) and failed before running any test. Re-running in the same independent target with `CC=/usr/bin/gcc` and `CXX=/usr/bin/g++` produced the result above.

### Windows MSVC

Environment: Rust 1.97.1 (`x86_64-pc-windows-msvc`), MSVC 19.50 x64, Protobuf 27.1, independent target directory.

- `cargo fmt --all -- --check` — passed
- metadata — 12/12 Edition 2024 and Rust 1.97.1
- `cargo check --workspace --all-targets --all-features --locked` — passed
- strict workspace Clippy — passed
- workspace excluding `net` — 949 passed, 0 failed, 2 ignored
- `net` library — 23/23 passed
- non-storage Net integration targets — all passed

The original Windows workspace test run executed 188 passing tests and then reported 8 failures in `storage_command_e2e_tests` because the server did not become connectable within five seconds. The same test, line, and error were reproduced from the exact base commit `3c55165`, so this is recorded as a Windows base issue rather than a PR regression.

### Additional audit

- `RUSTFLAGS=-Drust-2024-compatibility cargo check --workspace --all-targets --all-features --locked` — Kiwi compatibility diagnostics: 0
- `git diff --check origin/main...HEAD` — passed
- PowerShell Protobuf installation block — AST syntax passed; null/empty/whitespace/nonempty/already-present PATH cases verified and idempotent
- full diff reviewed for temporary-value lifetimes, locks, permits, oneshot senders, buffer return paths, RocksDB handles/iterators, and error propagation
- only additional Cargo note is the existing third-party `proc-macro-error2 v2.0.1` future-incompatibility report

## Known validation gap

A local Docker image build was not run because the available WSL Docker client could not connect to a daemon. This PR does not modify Docker files; GitHub CI remains the remote integration gate.

## Review carry-forward

- https://github.com/arana-db/kiwi/pull/370#discussion_r3651696805
- https://github.com/arana-db/kiwi/pull/370#discussion_r3651696807

AI assistance: code, tests, documentation, and review support. The full diff and the commands above were independently rechecked before publication.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup and development guidance to reflect Rust 2024 Edition and the Rust 1.97.1 toolchain.
  * Expanded Protobuf and `protoc` installation and verification instructions, including Windows guidance.
  * Improved formatting in Rust 2024 migration planning documents.

* **Refactor**
  * Updated the project for Rust 2024 compatibility while preserving existing runtime behavior.
  * Simplified internal control flow and error handling across networking, storage, runtime, and server components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->