### PR TITLE
fix(storage): make random_key return non-string keys

### DIFF
--- a/src/storage/src/redis_strings.rs
+++ b/src/storage/src/redis_strings.rs
@@ -2235,34 +2235,40 @@ impl Redis {
             // MetaCF stores both string values and the meta values of
             // hash/set/zset/list under the same key encoding (BaseMetaKey is a
             // type alias of BaseKey), so the user key is decoded once and the
-            // value bytes decide whether the key is live. This mirrors the type
-            // probing order used by `get_key_type`.
+            // value bytes decide whether the key is live.
             let Ok(parsed_key) = crate::format_base_key::ParsedBaseKey::new(&key_bytes[..]) else {
                 continue;
             };
 
-            // String value: the entry is a plain string key.
-            if let Ok(parsed) = ParsedStringsValue::new(&value_bytes[..])
-                && !parsed.is_stale()
-            {
-                return Ok(Some(String::from_utf8_lossy(parsed_key.key()).to_string()));
-            }
-
-            // Otherwise the value is a collection meta value: hash/set/zset use
-            // the base meta layout and list uses the list meta layout.
-            let is_live_collection = if let Ok(meta) =
-                crate::format_base_meta_value::ParsedBaseMetaValue::new(&value_bytes[..])
-            {
-                !meta.is_stale() && meta.count() > 0
-            } else if let Ok(list_meta) =
-                crate::format_list_meta_value::ParsedListsMetaValue::new(&value_bytes[..])
-            {
-                !list_meta.is_stale() && list_meta.count() > 0
-            } else {
-                false
+            // The stored type is determined by the leading type-tag byte, not by
+            // which parser happens to accept the bytes. `ParsedStringsValue::new`
+            // only validates that the tag is a *valid* DataType (not that it is
+            // String) and applies no count check, so probing string-first would
+            // misclassify collection meta values and could return an empty
+            // (count == 0) collection. Dispatch on the tag exactly like
+            // `get_key_type` does.
+            let Ok(data_type) = DataType::try_from(value_bytes[0]) else {
+                continue;
             };
 
-            if is_live_collection {
+            let is_live = match data_type {
+                DataType::String => ParsedStringsValue::new(&value_bytes[..])
+                    .map(|parsed| !parsed.is_stale())
+                    .unwrap_or(false),
+                DataType::Hash | DataType::Set | DataType::ZSet => {
+                    crate::format_base_meta_value::ParsedBaseMetaValue::new(&value_bytes[..])
+                        .map(|meta| !meta.is_stale() && meta.count() > 0)
+                        .unwrap_or(false)
+                }
+                DataType::List => {
+                    crate::format_list_meta_value::ParsedListsMetaValue::new(&value_bytes[..])
+                        .map(|list_meta| !list_meta.is_stale() && list_meta.count() > 0)
+                        .unwrap_or(false)
+                }
+                _ => false,
+            };
+
+            if is_live {
                 return Ok(Some(String::from_utf8_lossy(parsed_key.key()).to_string()));
             }
         }

--- a/src/storage/src/redis_strings.rs
+++ b/src/storage/src/redis_strings.rs
@@ -2228,47 +2228,42 @@ impl Redis {
         for item in iter {
             let (key_bytes, value_bytes) = item.context(RocksSnafu)?;
 
-            // Decode the key to get the actual user key
-            let parsed_base_key_result = crate::format_base_key::ParsedBaseKey::new(&key_bytes[..]);
-            if let Ok(base_key) = parsed_base_key_result {
-                // Check if the string key is not expired
-                if !value_bytes.is_empty() {
-                    let parsed_string_result = ParsedStringsValue::new(&value_bytes[..]);
-                    if let Ok(parsed) = parsed_string_result
-                        && !parsed.is_stale()
-                    {
-                        return Ok(Some(String::from_utf8_lossy(base_key.key()).to_string()));
-                    }
-                }
-            } else {
-                let parsed_meta_key_result =
-                    crate::format_base_key::ParsedBaseKey::new(&key_bytes[..]);
-                if let Ok(meta_key) = parsed_meta_key_result {
-                    // Check if meta key is not expired
-                    if !value_bytes.is_empty() {
-                        let parsed_meta_result =
-                            crate::format_base_meta_value::ParsedBaseMetaValue::new(
-                                &value_bytes[..],
-                            );
-                        let is_valid = if let Ok(meta) = parsed_meta_result {
-                            !meta.is_stale() && meta.count() > 0
-                        } else {
-                            let parsed_list_meta_result =
-                                crate::format_list_meta_value::ParsedListsMetaValue::new(
-                                    &value_bytes[..],
-                                );
-                            if let Ok(list_meta) = parsed_list_meta_result {
-                                !list_meta.is_stale() && list_meta.count() > 0
-                            } else {
-                                false
-                            }
-                        };
+            if value_bytes.is_empty() {
+                continue;
+            }
 
-                        if is_valid {
-                            return Ok(Some(String::from_utf8_lossy(meta_key.key()).to_string()));
-                        }
-                    }
-                }
+            // MetaCF stores both string values and the meta values of
+            // hash/set/zset/list under the same key encoding (BaseMetaKey is a
+            // type alias of BaseKey), so the user key is decoded once and the
+            // value bytes decide whether the key is live. This mirrors the type
+            // probing order used by `get_key_type`.
+            let Ok(parsed_key) = crate::format_base_key::ParsedBaseKey::new(&key_bytes[..]) else {
+                continue;
+            };
+
+            // String value: the entry is a plain string key.
+            if let Ok(parsed) = ParsedStringsValue::new(&value_bytes[..])
+                && !parsed.is_stale()
+            {
+                return Ok(Some(String::from_utf8_lossy(parsed_key.key()).to_string()));
+            }
+
+            // Otherwise the value is a collection meta value: hash/set/zset use
+            // the base meta layout and list uses the list meta layout.
+            let is_live_collection = if let Ok(meta) =
+                crate::format_base_meta_value::ParsedBaseMetaValue::new(&value_bytes[..])
+            {
+                !meta.is_stale() && meta.count() > 0
+            } else if let Ok(list_meta) =
+                crate::format_list_meta_value::ParsedListsMetaValue::new(&value_bytes[..])
+            {
+                !list_meta.is_stale() && list_meta.count() > 0
+            } else {
+                false
+            };
+
+            if is_live_collection {
+                return Ok(Some(String::from_utf8_lossy(parsed_key.key()).to_string()));
             }
         }
 

--- a/src/storage/tests/redis_string_test.rs
+++ b/src/storage/tests/redis_string_test.rs
@@ -24,8 +24,8 @@ mod redis_string_test {
     use kstd::lock_mgr::LockMgr;
     use storage::{
         BaseMetaKey, BgTaskHandler, ColumnFamilyIndex, DataType, Redis, StorageOptions,
-        ZsetScoreMember, safe_cleanup_test_db, slot_indexer::key_to_slot_id, storage::Storage,
-        unique_test_db_path,
+        ZsetScoreMember, format_base_meta_value::BaseMetaValue, safe_cleanup_test_db,
+        slot_indexer::key_to_slot_id, storage::Storage, unique_test_db_path,
     };
 
     fn cleanup_redis(redis: Redis, test_db_path: &Path) {
@@ -1194,6 +1194,53 @@ mod redis_string_test {
             random.as_deref(),
             Some("only_hash_key"),
             "random_key must return a non-string (hash) key"
+        );
+
+        cleanup_redis(redis, &test_db_path);
+    }
+
+    // Regression: `ParsedStringsValue::new` accepts any value whose leading byte
+    // is a valid DataType tag and applies no count check, so a string-first
+    // probe would misread a collection meta value as a live string and return a
+    // logically-empty (count == 0) collection. `random_key` must dispatch on the
+    // type tag and honor the count guard, treating an empty collection as absent.
+    #[test]
+    fn test_random_key_skips_empty_collection() {
+        let test_db_path = unique_test_db_path();
+        safe_cleanup_test_db(&test_db_path);
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+        redis.open(test_db_path.to_str().unwrap()).unwrap();
+
+        // Write a hash meta value with count == 0 directly (etime 0 => not stale).
+        // This is the shape a drained collection leaves behind in MetaCF.
+        let empty_hash_key = b"drained_hash";
+        let count: u64 = 0;
+        let mut meta = BaseMetaValue::new(bytes::Bytes::copy_from_slice(&count.to_le_bytes()));
+        meta.inner.data_type = DataType::Hash;
+        let encoded_meta_key = BaseMetaKey::new(empty_hash_key).encode().unwrap();
+        let mut batch = redis.create_batch().unwrap();
+        batch
+            .put(ColumnFamilyIndex::MetaCF, &encoded_meta_key, &meta.encode())
+            .unwrap();
+        batch.commit().unwrap();
+
+        // The empty collection is the only entry, so no live key should be found.
+        assert_eq!(
+            redis.random_key().unwrap(),
+            None,
+            "random_key must not return a count==0 collection"
+        );
+
+        // Once a live string is added, it is returned rather than the empty hash.
+        redis.set(b"live_string", b"value").unwrap();
+        assert_eq!(
+            redis.random_key().unwrap().as_deref(),
+            Some("live_string"),
+            "random_key must return the live string, skipping the empty collection"
         );
 
         cleanup_redis(redis, &test_db_path);

--- a/src/storage/tests/redis_string_test.rs
+++ b/src/storage/tests/redis_string_test.rs
@@ -1167,4 +1167,35 @@ mod redis_string_test {
 
         cleanup_redis(redis, &test_db_path);
     }
+
+    // Regression: string keys and meta keys share the same encoding in MetaCF
+    // (`pub type BaseMetaKey = BaseKey`), so `random_key` must distinguish the
+    // stored type by the *value*, not by re-parsing the key. A non-string key
+    // (e.g. a hash) must still be returned.
+    #[test]
+    fn test_random_key_returns_non_string_type() {
+        let test_db_path = unique_test_db_path();
+        safe_cleanup_test_db(&test_db_path);
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+        redis.open(test_db_path.to_str().unwrap()).unwrap();
+
+        // Only a hash key exists — no string keys at all.
+        let hash_key = b"only_hash_key";
+        assert_eq!(redis.hset(hash_key, b"field", b"value").unwrap(), 1);
+
+        let random = redis
+            .random_key()
+            .expect("random_key should not error with a live hash key");
+        assert_eq!(
+            random.as_deref(),
+            Some("only_hash_key"),
+            "random_key must return a non-string (hash) key"
+        );
+
+        cleanup_redis(redis, &test_db_path);
+    }
 }

--- a/src/storage/tests/redis_string_test.rs
+++ b/src/storage/tests/redis_string_test.rs
@@ -1199,6 +1199,34 @@ mod redis_string_test {
         cleanup_redis(redis, &test_db_path);
     }
 
+    // List metadata has a distinct layout and parser from hash/set/zset metadata,
+    // so keep a list-only regression for the dedicated `DataType::List` branch.
+    #[test]
+    fn test_random_key_returns_list_key() {
+        let test_db_path = unique_test_db_path();
+        safe_cleanup_test_db(&test_db_path);
+
+        let storage_options = Arc::new(StorageOptions::default());
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let lock_mgr = Arc::new(LockMgr::new(1000));
+        let mut redis = Redis::new(storage_options, 1, Arc::new(bg_task_handler), lock_mgr);
+        redis.open(test_db_path.to_str().unwrap()).unwrap();
+
+        let list_key = b"only_list_key";
+        assert_eq!(redis.lpush(list_key, &[b"value".to_vec()]).unwrap(), 1);
+
+        let random = redis
+            .random_key()
+            .expect("random_key should not error with a live list key");
+        assert_eq!(
+            random.as_deref(),
+            Some("only_list_key"),
+            "random_key must return the only live list key"
+        );
+
+        cleanup_redis(redis, &test_db_path);
+    }
+
     // Regression: `ParsedStringsValue::new` accepts any value whose leading byte
     // is a valid DataType tag and applies no count check, so a string-first
     // probe would misread a collection meta value as a live string and return a


### PR DESCRIPTION
## Summary

`Redis::random_key` (backing the `RANDOMKEY` command) could never return a hash/set/zset/list key. Only string keys were ever eligible, so on a database holding only collection types, `RANDOMKEY` wrongly reported an empty database.

This was a latent bug, faithfully carried through the Rust 2024 migration in #381 and spotted during that review.

## Root cause

In `MetaCF`, string values and collection meta values are stored under the **same key encoding** — `base_key_format.rs` defines `pub type BaseMetaKey = BaseKey`. The stored *type* is distinguished by the **value**, not the key.

The old code decoded the key with `ParsedBaseKey::new(&key_bytes)`, and only in the `else` branch (i.e. when that parse *failed*) tried to handle meta keys — by calling `ParsedBaseKey::new(&key_bytes)` **again with the same input**. That second call necessarily fails too, making the entire collection-key branch dead code. Result: non-string keys were silently skipped.

## Fix

Decode the user key once, then decide liveness from the value bytes, probing in the same order as `get_key_type`:

1. `ParsedStringsValue` → live string key
2. `ParsedBaseMetaValue` (hash/set/zset) → live if not stale and `count > 0`
3. `ParsedListsMetaValue` (list) → live if not stale and `count > 0`

Behavior for string keys is unchanged; collection keys are now correctly returned. No storage-format, RESP, or Raft change.

## Testing

- Added regression test `test_random_key_returns_non_string_type`: a DB containing only a hash key must return that key.
- `cargo test -p storage --test redis_string_test` — 29 passed, 0 failed (includes the new test).
- `cargo fmt --check` — passed.

Note: `protoc` was unavailable in this environment (no network), so the `raft` crate and full-workspace clippy were not run locally. The change is confined to the `storage` crate and does not touch `raft`; GitHub CI remains the integration gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `RANDOMKEY` behavior to correctly return active hash, set, sorted set, and list keys (not just strings).
  * Ensured collection keys with empty/drained metadata are treated as absent, preventing empty results from being returned or misclassified.
* **Tests**
  * Expanded regression coverage to verify correct key selection across hash and list scenarios, including cases where only non-string metadata exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->