### PR TITLE
build(security): fix cargo-deny audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,9 +570,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -580,11 +580,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -594,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -1926,25 +1925,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-error-attr3"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "be5bfc63c4dc85083c9daaf7112d0261701d4058677c3bff7f2afc44e30ef3e1"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error3"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "dd0d42490f6b7b143eef32b9e3522e42bf25dadc02c69ed72236f80adb949b5c"
 dependencies = [
- "proc-macro-error-attr2",
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3217,13 +3216,12 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
+checksum = "240e4b81c20a1d6d50d1d7265c658dfbd204e8b9ac4d80f3c931f39462196335"
 dependencies = [
  "darling",
- "once_cell",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ version = "0.1.0"
 description = "An enhanced Redis server implemented in Rust"
 readme = "README.md"
 repository = "https://github.com/arana-db/kiwi"
+license = "Apache-2.0"
 edition = "2024"
 rust-version = "1.97.1"
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,17 @@
+[advisories]
+ignore = [
+    { id = "RUSTSEC-2024-0436", reason = "paste is a transitive foyer dependency with no safe upgrade; remove this exception when foyer migrates to a maintained replacement" },
+    { id = "RUSTSEC-2025-0141", reason = "bincode 1.3.3 has no safe upgrade; remove this exception after the Raft serialization format is migrated and compatibility-tested" },
+]
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+    "Zlib",
+]
+confidence-threshold = 0.8

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,20 @@
+# Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [advisories]
 ignore = [
     { id = "RUSTSEC-2024-0436", reason = "paste is a transitive foyer dependency with no safe upgrade; remove this exception when foyer migrates to a maintained replacement" },

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "client"
 version = "0.1.0"
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cmd"
 version = "0.1.0"
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/src/common/macro/Cargo.toml
+++ b/src/common/macro/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "common-macro"
 version.workspace = true
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/src/common/runtime/Cargo.toml
+++ b/src/common/runtime/Cargo.toml
@@ -2,6 +2,7 @@
 name = "runtime"
 version.workspace = true
 description = "Dual runtime architecture for Kiwi database"
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/src/conf/Cargo.toml
+++ b/src/conf/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "conf"
 version.workspace = true
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/src/executor/Cargo.toml
+++ b/src/executor/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 description.workspace = true
 readme.workspace = true
 repository.workspace = true
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/src/kstd/Cargo.toml
+++ b/src/kstd/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kstd"
 version.workspace = true
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/src/net/Cargo.toml
+++ b/src/net/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "net"
 version.workspace = true
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/src/raft/Cargo.toml
+++ b/src/raft/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "raft"
 version.workspace = true
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/src/resp/Cargo.toml
+++ b/src/resp/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "resp"
 version.workspace = true
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 description.workspace = true
 readme.workspace = true
 repository.workspace = true
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "storage"
 version.workspace = true
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/tools/compat/Cargo.toml
+++ b/tools/compat/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kiwi-compat"
 version.workspace = true
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/tools/runtime-baseline/Cargo.toml
+++ b/tools/runtime-baseline/Cargo.toml
@@ -3,6 +3,7 @@ name = "runtime-baseline"
 version.workspace = true
 description = "Kiwi storage runtime baseline harness"
 repository.workspace = true
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 build = "build.rs"

--- a/tools/runtime-baseline/tests/build_identity_test.rs
+++ b/tools/runtime-baseline/tests/build_identity_test.rs
@@ -363,6 +363,7 @@ members = ["tools/runtime-baseline"]
 version = "0.1.0"
 description = "runtime baseline fixture"
 repository = "https://example.test/runtime-baseline"
+license = "Apache-2.0"
 edition = "2021"
 rust-version = "__RUST_VERSION__"
 


### PR DESCRIPTION
## Summary
- align workspace manifests on a shared Apache-2.0 license declaration
- add a focused deny.toml for the remaining transitive advisories without safe upgrades
- bump the validator derive support path so cargo-deny can resolve the current graph cleanly

## Validation
- WSL cargo-deny advisories/licenses check passed
- cargo metadata --format-version 1 --locked --no-deps passed
- git diff --check passed

## Notes
- this PR is scoped to the failing main security audit only
- conf rerun on this machine hit environment issues (missing Windows dlltool.exe and polluted WSL LD_LIBRARY_PATH), so the targeted evidence remains the earlier focused conf pass plus the current cargo-deny result

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added consistent Apache-2.0 licensing metadata across all project packages.
  * Added dependency license allowlists and security advisory handling configuration.
  * Documented approved exceptions for selected security advisories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->