### PR TITLE
docs(test): fix Kiwi binary name in test guides

### DIFF
--- a/tests/NEW_TESTS_GUIDE.md
+++ b/tests/NEW_TESTS_GUIDE.md
@@ -70,7 +70,7 @@
 
 1. **启动 Kiwi 服务器**（Python 测试需要）:
    ```bash
-   cargo run --bin server --release
+   cargo run --bin kiwi --release
    ```
 
 2. **安装 Python 依赖**:

--- a/tests/README.md
+++ b/tests/README.md
@@ -102,7 +102,7 @@ pytest tests/python/test_mset.py -v
 3. **服务器运行**：
    ```bash
    # 启动 Kiwi 服务器
-   cargo run --bin server --release
+   cargo run --bin kiwi --release
    
    # 或使用 Makefile
    make run
@@ -118,7 +118,7 @@ cargo test
 
 # 2. Python 集成测试（需要先启动服务器）
 # 终端 1：启动服务器
-cargo run --bin server --release
+cargo run --bin kiwi --release
 
 # 终端 2：运行测试
 pytest tests/python/ -v

--- a/tests/integration/test_mset.md
+++ b/tests/integration/test_mset.md
@@ -4,7 +4,7 @@
 
 ### 1. 启动服务器
 ```bash
-cargo run --bin server
+cargo run --bin kiwi
 ```
 
 ### 2. 使用 Redis CLI 连接并测试


### PR DESCRIPTION
## Summary
- use the actual `kiwi` binary name in the test directory README
- fix the same startup command in the new-tests and MSET guides

## Validation
- `rg -n --fixed-strings 'name = "kiwi"' src/server/Cargo.toml`
- verified no `cargo run --bin server` remains in the three changed guides
- `git diff --cached --check`

Documentation-only change; code tests are not required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test guides to use the `kiwi` server startup command.
  * Applied the corrected command across quick-start, Python integration, concurrency, Raft, and MSET testing instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->