### PR TITLE
build: cache RocksDB C/C++ compile via sccache + add PRD docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,12 +91,20 @@ jobs:
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
         shell: bash
 
+      - name: Configure C/C++ compiler caching
+        if: matrix.os != 'windows-latest'
+        run: |
+          echo "CC=sccache cc" >> $GITHUB_ENV
+          echo "CXX=sccache c++" >> $GITHUB_ENV
+        shell: bash
+
       - name: Cache Cargo registry
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            target
           key: ${{ runner.os }}-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-clippy-
@@ -160,12 +168,20 @@ jobs:
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
         shell: bash
 
+      - name: Configure C/C++ compiler caching
+        if: matrix.os != 'windows-latest'
+        run: |
+          echo "CC=sccache cc" >> $GITHUB_ENV
+          echo "CXX=sccache c++" >> $GITHUB_ENV
+        shell: bash
+
       - name: Cache Cargo registry
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Test development compiler caching
+        if: matrix.os == 'ubuntu-latest'
+        run: bash scripts/tests/test-dev-sccache-env.sh
+
       - name: Free disk space (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -104,7 +108,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-clippy-
@@ -181,7 +184,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
@@ -250,7 +252,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-

--- a/.planning/KANBAN.md
+++ b/.planning/KANBAN.md
@@ -1,10 +1,10 @@
 # Kiwi Kanban
 
-> 更新日期：2026-07-28
+> 更新日期：2026-07-30
 >
 > 当前里程碑：M1 Redis 8.8.1 Cache OFF compatibility foundation
 >
-> 当前 task 类型：planning-only；方案 A 规划完成并合并后，implementation 另开 task
+> 当前 task：PR `#388` implementation（`feat/rocksdb-build-accel-and-prd`）；已验证远端 Base `0f8d96238860a5c29a5582e461e4cdeb974431b3`、Head `b47cb1eebe098e2d4d2d784020dc283a8d026d28`
 >
 > 当前运行模式：Cache OFF
 >
@@ -12,7 +12,9 @@
 
 ## In Progress
 
-无。本 task 只完成方案 A 的规划落盘，不持有 implementation card。
+| ID | 工作项 | Requirement / Gate 关系 | 当前状态 |
+|---|---|---|---|
+| `PR388-001` | C/C++ sccache 构建接入、跨平台回归探针、PRD/用户故事及 review 一致性修复 | `REQ-STABILITY-003`、`REQ-WORK-001`、`REQ-WORK-003`、`REQ-WORK-005`；跨平台构建修复只维护 G6 CI 的可执行性与证据条件，不构成 Gate 通过证据 | 本地针对性验证通过并形成提交；远端发布状态和新 Head CI 结果以 PR/checks/threads 实时查询为准 |
 
 ## Ready for a separate implementation task
 
@@ -20,7 +22,7 @@
 
 | ID | 工作项 | Requirement / Decision | 前置条件 |
 |---|---|---|---|
-| `M1-001-T2` | Redis 8.8.1 trusted Oracle provenance：primary build、fresh-checkout independent rebuild、binary hash equality、rebuild runtime evidence | `REQ-COMPAT-001`、`REQ-COMPAT-008`、`REQ-COMPAT-009`、`REQ-COMPAT-010`；`D011`、`D012` | 本规划 PR 合并；新 implementation task/worktree；真实双 checkout reproducibility 是卡片内第一道实现门禁，不是启动前置条件 |
+| `M1-001-T2` | Redis 8.8.1 trusted Oracle provenance：primary build、fresh-checkout independent rebuild、binary hash equality、rebuild runtime evidence | `REQ-COMPAT-001`、`REQ-COMPAT-008`、`REQ-COMPAT-009`、`REQ-COMPAT-010`；`D011`、`D012` | PR `#383` 已合并；仍须新建专用 implementation task/worktree；当前 PR `#388` 不替代该任务；真实双 checkout reproducibility 是卡片内第一道实现门禁 |
 | `M1-002` | RESP2/RESP3 持久连接级 raw wire differential harness | `REQ-COMPAT-002`、`REQ-COMPAT-006` | `M1-001-T2` 产生可验证 provenance |
 | `M1-003` | Redis 8.8.1 TCL external-server runner | `REQ-COMPAT-004` | `M1-001-T2` |
 | `M1-004` | redis-rs test-only compatibility crate | `REQ-COMPAT-005`、`REQ-COMPAT-006` | `M1-001-T2` |
@@ -44,14 +46,14 @@
 
 ## Frozen by system stability gate
 
-下列卡片在 `docs/quality/system-stability-gate.md` 全部通过且用户重新批准前不得转入 Ready 或 In Progress。
+下列卡片在 `docs/quality/system-stability-gate.md` 全部通过、M7 前置设计完成审查且用户明确批准对应的单独 implementation task 前，不得转入 Ready 或 In Progress。Gate PASS、PR 合并或里程碑 Ready 均不自动授权生产实现。
 
 | ID | 工作项 | Requirement | Gate | 冻结范围 |
 |---|---|---|---|---|
-| `M7-001` | 建立并修改用于 Kiwi 发行的 Redis fork | `REQ-HOT-002`；`REQ-LICENSE-002` 至 `REQ-LICENSE-008` | System Stability Gate + 用户新批准 | fork 代码、patch、生产构建均禁止 |
-| `M7-002` | Embedded Redis Hot Tier 动态库 C ABI spike | `REQ-HOT-010`、`REQ-HOT-012`；`REQ-LICENSE-003`、`REQ-LICENSE-005`、`REQ-LICENSE-007` | System Stability Gate + 用户新批准 | `.so`、`.dylib`、`.dll`、import/static library 均禁止 |
-| `M7-003` | Kiwi 安全 loader、pairing manifest 和 FFI binding | `REQ-HOT-010`、`REQ-HOT-011`、`REQ-HOT-012` | System Stability Gate + 用户新批准 | 生产 crate 依赖、配置和加载路径均禁止 |
-| `M7-004` | String update-or-invalidate MVP | `REQ-HOT-001`、`REQ-HOT-003` 至 `REQ-HOT-007`、`REQ-HOT-009` | System Stability Gate + 用户新批准 | Cache ON 读写路径禁止 |
+| `M7-001` | 建立并修改用于 Kiwi 发行的 Redis fork | `REQ-HOT-002`；`REQ-LICENSE-002` 至 `REQ-LICENSE-008` | Gate PASS + 单独 implementation task 明确批准 | fork 代码、patch、生产构建均禁止 |
+| `M7-002` | Embedded Redis Hot Tier 动态库 C ABI spike | `REQ-HOT-010`、`REQ-HOT-012`；`REQ-LICENSE-003`、`REQ-LICENSE-005`、`REQ-LICENSE-007` | Gate PASS + 单独 implementation task 明确批准 | `.so`、`.dylib`、`.dll`、import/static library 均禁止 |
+| `M7-003` | Kiwi 安全 loader、pairing manifest 和 FFI binding | `REQ-HOT-010`、`REQ-HOT-011`、`REQ-HOT-012` | Gate PASS + 单独 implementation task 明确批准 | 生产 crate 依赖、配置和加载路径均禁止 |
+| `M7-004` | String update-or-invalidate MVP | `REQ-HOT-001`、`REQ-HOT-003` 至 `REQ-HOT-007`、`REQ-HOT-009` | Gate PASS + 单独 implementation task 明确批准 | Cache ON 读写路径禁止 |
 | `M8-001` | Cache OFF/ON differential 与热层故障注入 | `REQ-HOT-004` 至 `REQ-HOT-008`；`REQ-RAFT-002` | M7 全部资格门禁 | 不得用未实现热层替代当前正确性测试 |
 | `M8-002` | Redis/Kiwi OFF/Kiwi ON 性能与资源基线 | `REQ-PERF-001`、`REQ-PERF-002`、`REQ-PERF-003`；`REQ-OBS-003` | M7/M8 正确性门禁 | 性能工作不得先于语义与故障证明 |
 
@@ -87,9 +89,9 @@
 
 ## WIP 与授权规则
 
-- 同一时间只允许一个 implementation card 处于 In Progress；planning/docs task 不得隐式持有 implementation card。
+- 同一时间只允许一个 implementation card 处于 In Progress；当前为 `PR388-001`，planning/docs task 不得隐式持有 implementation card。
 - 规划批准不授权修改 source、tests、build scripts 或 CI，也不授权 stage/commit/push 实现文件。
 - 从 planning 转 implementation 必须创建新 Codex task、TaskId、worktree、dirty allowlist 和 recovery checkpoint；不能只把 recovery mode 从 `planning` 改成 `implementation`。
 - 冻结草稿不得覆盖、续写、清理或回退；后续实施只读参考并重新审计。
 - `M1-001-T2` 必须先通过真实双 checkout reproducibility；不能把方案 A 降级为 metadata self-attestation。
-- 系统稳定门禁通过后，M7 仍需用户重新明确批准，不能自动启动。
+- 系统稳定门禁通过后，M7 仍需用户明确批准一个单独 implementation task，不能因 Gate PASS、PR 合并或 Ready 状态自动启动。

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,49 +1,51 @@
 # Kiwi 当前状态
 
-> 更新时间：2026-07-28
+> 更新时间：2026-07-30
 >
-> 当前 task 类型：planning-only
+> 当前 task 类型：implementation
 >
-> 规划 PR：`#383`（`codex/redis-8.8.1-oracle-provenance-plan`）
+> 当前 PR：`#388`（`feat/rocksdb-build-accel-and-prd`）
 >
-> 规划 Base：`main` at `9e91707d774ad367d682e23677dcef79ecb14338`
+> 已验证远端快照：Base `main` at `0f8d96238860a5c29a5582e461e4cdeb974431b3`；Head `b47cb1eebe098e2d4d2d784020dc283a8d026d28`
 >
-> 状态：Task 1 已由 PR `#372` 合并；方案 A 已由规划 PR `#383` 固化；恢复时必须实时确认该 PR 是否已合并，implementation 只能在规划合并后另开 Codex task
+> 状态：PR `#388` 在 2026-07-30 复检时为 OPEN；本轮 review fix 已形成提交，发布状态、checks 和 review threads 必须实时查询
 >
-> 当前设计：`docs/superpowers/specs/2026-07-28-redis-8.8.1-trusted-oracle-provenance-design.md`
+> 当前范围：修复 C/C++ sccache 的 Windows 编译器回归和重复 `target` 缓存，补充自动回归探针，并统一版本化 PRD、用户故事与项目状态
 >
-> 当前实施计划：`docs/superpowers/plans/2026-07-28-redis-8.8.1-trusted-oracle-provenance.md`
+> Requirement 边界：`REQ-STABILITY-003`、`REQ-WORK-001`、`REQ-WORK-003`、`REQ-WORK-005`；跨平台构建修复只维护 G6 CI 的可执行性与证据条件，不构成任何稳定性 Gate 已通过的证据
 
 ## 当前目标
 
-本 task 只把 Redis 8.8.1 可信 Oracle provenance 的方案 A 固化到项目文档：primary build 产生候选和审计 metadata，verifier 在 fresh disposable exact checkout 中独立重建，要求 primary/rebuild binary SHA-256 完全一致，只运行 rebuild binary 取得正式 `INFO server` evidence，并在全部 cleanup 成功后发布 provenance v2。
+PR `#388` 是与 PR `#383` 规划任务分离的 implementation task。其既有范围是在 CI 与 `scripts/dev.sh` 中为 RocksDB C/C++ 编译接入 sccache，并新增由权威规划文档综合出的 PRD 与用户故事。本轮 review fix 处理 Windows compiler wrapper 回归、重复缓存、自动回归探针、文档 Requirement 映射、Hot Tier 授权边界和当前项目状态问题。
 
-本 task 不继续任何 Rust、test、Bash、PowerShell 或 CI 实现。Kiwi 底层兼容、RocksDB 和 OpenRaft 工作按既有 Roadmap 保持原节奏，方案 A 只替换 `M1-001` Task 2 的 provenance 信任模型。
+本 task 不实现 Redis Oracle provenance，不接受旧六文件 Oracle 草稿，也不启动 Embedded Redis Hot Tier。PR `#388` 的合并、CI 通过或 M7 Ready 均不能替代 Oracle implementation task 或 Hot Tier implementation task 的单独授权。
 
 ## 当前授权边界
 
 允许：
 
-- 更新 `AGENTS.md` 实际指向的 `CLAUDE.md`、`.planning/`、兼容/系统边界/稳定门禁合同、设计规格和实施计划。
-- 执行 Markdown、链接、Requirement/Decision ID、一致性和 Git diff 检查。
-- 在独立 planning branch 保存、提交和发布纯规划成果；不得带入实现草稿。
+- 在本轮 review fix 中修改 `.github/workflows/ci.yml`、`scripts/dev.sh`、`scripts/tests/test-dev-sccache-env.sh`、`docs/prd.md`、`docs/personas-and-user-stories.md`、`.planning/STATE.md` 和 `.planning/KANBAN.md`。
+- 执行 Markdown、链接、Requirement/Decision ID、一致性和 Git diff 等只读检查。
+- 记录已经发生并可验证的 PR/Base/Head 历史；瞬时 checks、threads 和 dirty ownership 继续实时查询。
 
 禁止：
 
-- 修改 `tools/compat`、`scripts/compat`、Cargo、CI 或生产源码。
+- 修改 Cargo、生产源码、Oracle provenance 实现、Hot Tier 实现或其他未授权路径。
 - 在旧 `redis-8.8.1-stability-foundation` worktree 继续、暂存、提交、push、清理或回退六文件实现草稿。
 - 把旧草稿的绿色测试、审查或真实构建准备表述为方案 A 已实现。
 - 扩大到 Embedded Redis Hot Tier、Redis fork、动态库、loader、Cache ON 或组合发行实现。
-- 在本 task 从 planning mode 静默切换到 implementation mode。
+- 在未获授权时 commit、push、merge、rebase、Resolve 或回复 GitHub review thread。
 
 ## 已确认决定
 
+- PR `#383` 已于 2026-07-28 合并：final Head `42c16bef899385bd2e1b1e16e2e0202d4a614590`，merge commit `58030e1331655546ea4547a9a94efc493534ef7d`；它只完成 Oracle 方案 A 的规划闭环。
+- PR `#388` 是独立 implementation task，不得继承或隐式扩大 PR `#383` 的 Oracle 实施授权。
 - `D011`：Redis Oracle required provenance 采用 verifier fresh-checkout independent rebuild 和 exact binary hash equality。
 - `D012`：规划 task 与实施 task 分离；规划批准不授权源码实现，提前产生的实现草稿冻结。
 - Redis 8.8.1 tag `8.8.1` / commit `77b6c308396c9700672390a210143a8496fb4b10` 是唯一兼容和 Oracle 基线。
 - Cache OFF、RocksDB 权威存储、OpenRaft 实现和 Embedded Redis Hot Tier 冻结边界均未改变。
 
-## M1-001 当前分解
+## Oracle provenance 历史状态（不属于当前 task）
 
 ### Task 1：exact compatibility manifest
 
@@ -55,14 +57,14 @@
 ### Task 2：trusted Oracle provenance
 
 - 设计：已采用方案 A。
-- 规划状态：方案 A 的 15 路径 planning-only Diff 由 PR `#383` 发布；本文件不缓存其易漂移的 Head、checks 或 merge 状态，恢复时必须实时查询。
+- 规划状态：方案 A 的 15 路径 planning-only Diff 已由 PR `#383` 合并；final Head `42c16bef899385bd2e1b1e16e2e0202d4a614590`，merge commit `58030e1331655546ea4547a9a94efc493534ef7d`。
 - 实施状态：未在已接受边界中开始。
 - 实施入口：`docs/superpowers/plans/2026-07-28-redis-8.8.1-trusted-oracle-provenance.md`。
-- 启动条件：PR `#383` 合并后另开 Codex task，从包含本规划的 clean commit 创建新 worktree，保存新 TaskId 和 recovery checkpoint。
+- 启动条件：另开专用于 Oracle provenance 的 implementation task，从包含本规划的 clean commit 创建新 worktree，保存新 TaskId 和 recovery checkpoint；当前 PR `#388` 不满足或替代该条件。
 
 ## 冻结实现草稿
 
-相关但不属于本 planning task dirty ownership：
+相关但不属于当前 PR `#388` dirty ownership：
 
 ```text
 Worktree:
@@ -80,7 +82,7 @@ D:\test\github\kiwi\.worktrees\redis-8.8.1-stability-foundation\.codex\recovery\
 
 该 worktree 存在六文件未提交草稿。它没有被方案 A 接受，不能在本 task 处理。后续 implementation task 可以只读分析其中的测试思想，但所有复用必须对照 `D011`、`REQ-COMPAT-008`、`REQ-COMPAT-009` 和 `REQ-COMPAT-010` 重新审计。
 
-## 本规划 task 的交付
+## PR `#383` 规划交付（历史）
 
 1. `D011`：独立重建信任模型。
 2. `D012`：规划/实施 task 分离。
@@ -94,19 +96,24 @@ D:\test\github\kiwi\.worktrees\redis-8.8.1-stability-foundation\.codex\recovery\
 ## 当前验证证据
 
 - PR `#372` 的合并状态、final Head 和 `main` merge commit 已实时确认。
-- PR `#383` 的规划提交只涉及 15 个 planning/docs 路径，并从 Task 1 合并后的 `main` 重放；禁止带入 Cargo、脚本、CI 或实现路径。
+- PR `#383` 已合并；其规划提交只涉及 15 个 planning/docs 路径，并从 Task 1 合并后的 `main` 重放，未带入 Cargo、脚本、CI 或实现路径。
 - 旧六文件草稿 worktree 已只读核对，并继续冻结。
-- 本规划 PR 只执行与文档风险相匹配的 Diff、链接、ID、Markdown 和 GitHub 状态检查；不运行 Kiwi、RocksDB 或 Redis 编译测试。
+- PR `#388` 的远端审查快照为 Base `0f8d96238860a5c29a5582e461e4cdeb974431b3`、Head `b47cb1eebe098e2d4d2d784020dc283a8d026d28`；本轮 review fix 已形成提交，当前发布状态须通过 GitHub 实时查询。
+- `wsl.exe --cd /mnt/d/test/github/review/kiwi-pr-388/source -- bash scripts/tests/test-dev-sccache-env.sh`：7 个 Windows/Unix/compiler 场景全部 PASS。
+- WSL Python/PyYAML 解析 `.github/workflows/ci.yml`：8 个 job 可解析，手写 `actions/cache` 的 `target` owner 为 0，compiler regression probe 恰有 1 个 CI step。
+- 文档一致性探针：59 个使用中的 `REQ-*`、4 个 `D*` 均能在权威文件解析，Markdown 表格结构通过。
+- `git diff --check`：通过；暂存区为空。当前环境没有 `shellcheck` 和 `actionlint`，未执行这两项。
+- checks、review threads 和 PR 状态不在本文件中缓存；任何当前结论必须重新查询 GitHub。
 
-这些结果只证明规划闭环，不证明方案 A 已实现。
+PR `#383` 的结果只证明 Oracle 规划闭环，不证明方案 A 已实现；PR `#388` 也不改变该结论。
 
 ## 下一条安全动作
 
-1. 实时查询 PR `#383` 的 state、Head、Base、checks、review threads 和文件列表，不从本文件推断 GitHub 当前状态。
-2. 若 PR `#383` 仍为 OPEN，保持 Task 2 六文件草稿冻结；只有用户另行明确授权后才能 merge。
-3. 若 PR `#383` 已 MERGED，确认 `main` 包含本规划，并继续保持旧六文件草稿冻结。
-4. 只有用户另开 implementation task 后，才从包含本规划的 clean `main` 创建新 worktree、TaskId 和 recovery checkpoint。
-5. 新 implementation task 先执行真实 Redis 双 checkout reproducibility 门禁；门禁通过前不复用或提交旧草稿。
+1. 对本轮七个 task-owned 路径执行 shell 回归、workflow YAML、Markdown、引用、Requirement/Decision ID、Git diff 和路径边界检查。
+2. 本轮 push 已获得单独授权；发布后重新查询新 Head 的 checks。Resolve 或回复 review thread 仍须对应的单独授权，不得把已发布提交表述为 CI 已验证内容。
+3. PR `#383` 的规划历史保持不变，旧六文件 Oracle 草稿继续冻结。
+4. 只有用户另开 Oracle provenance implementation task 后，才从包含方案 A 的 clean `main` 创建新 worktree、TaskId 和 recovery checkpoint，并先执行真实 Redis 双 checkout reproducibility 门禁。
+5. Hot Tier 继续 Frozen；Gate PASS 后仍须用户明确批准一个单独的 implementation task。
 
 ## 恢复检查
 
@@ -115,11 +122,12 @@ Get-Content -Raw AGENTS.md
 Get-Content -Raw .planning\PROJECT.md
 Get-Content -Raw .planning\STATE.md
 Get-Content -Raw .planning\KANBAN.md
-Get-Content -Raw docs\superpowers\specs\2026-07-28-redis-8.8.1-trusted-oracle-provenance-design.md
-Get-Content -Raw docs\superpowers\plans\2026-07-28-redis-8.8.1-trusted-oracle-provenance.md
+Get-Content -Raw docs\prd.md
+Get-Content -Raw docs\personas-and-user-stories.md
 if (Test-Path .codex\recovery\ACTIVE.md) { Get-Content -Raw .codex\recovery\ACTIVE.md }
 git status --porcelain=v2 --branch --untracked-files=all
 git diff --cached --name-only
+gh pr view 388 -R arana-db/kiwi --json state,baseRefOid,headRefOid,statusCheckRollup,reviewDecision
 ```
 
 如果 branch、HEAD、task type 或 dirty ownership 与 recovery 记录不同，先报告差异，不得自动 checkout、restore、reset、stash、clean 或覆盖文件。

--- a/docs/personas-and-user-stories.md
+++ b/docs/personas-and-user-stories.md
@@ -1,0 +1,111 @@
+# Kiwi 用户画像与用户故事
+
+> 补齐审计发现的缺失项：`.planning/` 与 `docs/quality/` 为工程/审计视角，**未显式定义终端用户画像与用户故事**。本文档从 REQUIREMENTS / ROADMAP / STATE / system-stability-gate 中可验证的工程事实反推画像，并补全用户故事。
+> 标注约定：
+> - **[事实/证据]**：用户故事映射到的 `REQ-*` 或门禁条目是项目批准需求（来源可追溯到 `.planning/REQUIREMENTS.md` 或 `docs/quality/system-stability-gate.md`）。
+> - **[反推/产品假设]**：画像本身、用户动机措辞、故事包装为产品视角推断，非用户调研结论；其底层 REQ 仍为真实事实。
+
+---
+
+## 画像 1：平台 / SRE 工程师
+
+> **[反推/产品假设]** 画像存在性反推自：可观测需求（REQ-OBS-001/002）、运维演练门禁（G7）、系统稳定性门禁（REQ-STABILITY-\*）、发行门禁（ROADMAP M9）。该角色关注“系统可运维、可观测、可恢复、风险可控”。
+
+### 用户故事
+
+1. **[事实/证据]** As a 平台/SRE 工程师, I want Redis 8.8.1 exact Oracle 可重复验证 Kiwi 兼容, so that 升级或重构不会在客户端无感知的情况下破坏语义。
+   → 映射：`REQ-COMPAT-001`、`REQ-COMPAT-002`、`REQ-COMPAT-003`。
+
+2. **[事实/证据]** As a 平台/SRE 工程师, I want 系统稳定性门禁 G1–G7 全部 PASS 且经用户重新明确批准后才允许进入热层, so that 引入内存状态层之前生产风险已被证明可控。
+   → 映射：`REQ-STABILITY-001`、`REQ-STABILITY-002`、`REQ-STABILITY-005`；门禁 G1–G7（system-stability-gate.md L61–L186）。
+
+3. **[事实/证据]** As a 平台/SRE 工程师, I want Raft 暴露 term/role/leader/commit index/last applied/snapshot/fsync 等指标, so that 排障时无需侵入进程即可定位一致性问题。
+   → 映射：`REQ-OBS-002`。
+
+4. **[事实/证据]** As a 平台/SRE 工程师, I want 崩溃后所有 RocksDB handle 释放并按路径真实 reopen 恢复, so that 我能确信恢复不是“复用旧对象”的假象。
+   → 映射：`REQ-STORAGE-002`；门禁 G2（system-stability-gate.md L80–L97）。
+
+5. **[事实/证据]** As a 平台/SRE 工程师, I want 运维手册覆盖磁盘满/无 Leader/Snapshot 失败/`SUBMIT_UNKNOWN` 处置, so that 故障时有可执行的处置流程而非依赖人工救火。
+   → 映射：门禁 G7（system-stability-gate.md L170–L185）；`REQ-RAFT-008`。
+
+---
+
+## 画像 2：Redis 迁移用户
+
+> **[反推/产品假设]** 画像存在性反推自：RESP2/3 字节级兼容（REQ-COMPAT-002）、兼容矩阵（REQ-COMPAT-003）、redis-rs 仅测试边界（REQ-COMPAT-005）、Pipeline/连接行为回归（REQ-COMPAT-006）。该角色关心“以最小改造从 Redis 迁移到 Kiwi”。
+
+### 用户故事
+
+1. **[事实/证据]** As a Redis 迁移用户, I want RESP2 与 RESP3 原始 frame 与 Redis 8.8.1 字节级一致（含二进制 payload、null、error、push、attribute、aggregate 类型）, so that 现有客户端无需改造即可切换。
+   → 映射：`REQ-COMPAT-002`；门禁 G1（system-stability-gate.md L65–L66）。
+
+2. **[事实/证据]** As a Redis 迁移用户, I want Pipeline 中间错误、partial I/O、连接关闭、Push 交错都有回归测试, so that 高并发/弱网场景下的客户端行为不漂移。
+   → 映射：`REQ-COMPAT-006`；门禁 G1（L67）。
+
+3. **[事实/证据]** As a Redis 迁移用户, I want 兼容矩阵记录命令/模式/返回类型/错误/known difference 与测试证据, so that 我能明确知道哪些命令可用、哪些有已知差异。
+   → 映射：`REQ-COMPAT-003`；门禁 G1（L68）。
+
+4. **[事实/证据]** As a Redis 迁移用户, I want 任何新增公共命令/配置/错误/RESP 字段先有 Redis 8.8.1 exact Oracle 证据, so that 我不会遇到“凭经验推断”的语义偏差。
+   → 映射：`REQ-COMPAT-007`、`REQ-COMPAT-001`。
+
+5. **[事实/证据]** As a Redis 迁移用户, I want Redis 官方 TCL suite 固定到 exact upstream commit 且每个 skip 都有 owner/Issue/理由/解除条件, so that 兼容覆盖透明、不被静默跳过。
+   → 映射：`REQ-COMPAT-004`；门禁 G1（L69）。
+
+---
+
+## 画像 3：存储 / 内核开发者
+
+> **[反推/产品假设]** 画像存在性反推自：RocksDB 权威存储（REQ-STORAGE-001）、encoding 规范（REQ-STORAGE-005）、磁盘格式版本（REQ-STORAGE-003）、故障注入（REQ-STORAGE-004）。该角色关心“数据真相层正确、可恢复、格式可迁移”。
+
+### 用户故事
+
+1. **[事实/证据]** As a 存储/内核开发者, I want RocksDB 保存全量权威状态且恢复时所有 DB/CF/iterator/snapshot/后台任务 handle 完全释放后再按原路径重新打开, so that 恢复的真实性与不变量可被测试证明。
+   → 映射：`REQ-STORAGE-001`、`REQ-STORAGE-002`；门禁 G2（L84–L87）。
+
+2. **[事实/证据]** As a 存储/内核开发者, I want key/value encoding 满足 binary-safe/round-trip/order-preserving/prefix-safe/canonical/stable, so that 升级、comparator 变更、compaction 不会破坏数据顺序或语义。
+   → 映射：`REQ-STORAGE-005`（`format_base_key.rs`、`format_*`、`custom_comparator.rs`）。
+
+3. **[事实/证据]** As a 存储/内核开发者, I want 磁盘格式带 format version、Comparator 身份与迁移/拒绝策略, so that 不兼容的磁盘格式不会被静默打开。
+   → 映射：`REQ-STORAGE-003`；门禁 G2 阻断条件（L97）。
+
+4. **[事实/证据]** As a 存储/内核开发者, I want 部分写/尾部损坏/metadata-log 不一致/Snapshot 损坏/磁盘满都有故障测试, so that 真实介质故障下数据可恢复、不生成未承诺状态。
+   → 映射：`REQ-STORAGE-004`；门禁 G2（L89–L90）。
+
+5. **[事实/证据]** As a 存储/内核开发者, I want 任何派生状态/索引/未来热层能从 RocksDB 权威数据删除后重建, so that 热层失败不会导致权威真相丢失或被错误状态替代。
+   → 映射：`REQ-STORAGE-006`；关联 `REQ-HOT-001`（P2 冻结）。
+
+---
+
+## 画像 4：QA / 稳定性工程师
+
+> **[反推/产品假设]** 画像存在性反推自：Oracle provenance（REQ-COMPAT-008~010）、确定性 simulator（REQ-RAFT-006）、Jepsen/Elle（REQ-RAFT-007）、性能报告（REQ-PERF-002/003）。该角色关心“证据可重复、一致性可证明、性能可解释”。
+
+### 用户故事
+
+1. **[事实/证据]** As a QA/稳定性工程师, I want Oracle provenance 通过 primary build 与 verifier fresh-checkout 独立重建且 binary SHA-256 完全一致来建立信任, so that 测试 Oracle 不可由自洽 metadata + 任意 binary 拼接伪造。
+   → 映射：`REQ-COMPAT-008`、`REQ-COMPAT-009`、`REQ-COMPAT-010`；D011；门禁 G1（L65、L230）。
+
+2. **[事实/证据]** As a QA/稳定性工程师, I want 确定性 OpenRaft simulator + 3/5 节点进程级故障 + Elle/Jepsen history checker, so that Election/Log Matching/State Machine Safety 与线性一致性有机器可检查证据。
+   → 映射：`REQ-RAFT-006`、`REQ-RAFT-007`；门禁 G3（L107）、G4（L126）。
+
+3. **[事实/证据]** As a QA/稳定性工程师, I want 非幂等写断线被分类为 `SUBMIT_UNKNOWN` 且测试/客户端不自动重放, so that 不会因盲目重试造成重复写或状态分裂。
+   → 映射：`REQ-RAFT-008`；门禁 G3（L110）。
+
+4. **[事实/证据]** As a QA/稳定性工程师, I want 性能报告包含 P50/P95/P99/P99.9/吞吐/CPU/峰值内存/写放大与测试环境, so that 平均吞吐提升不会掩盖尾延迟、内存失控或恢复退化。
+   → 映射：`REQ-PERF-002`、`REQ-PERF-003`；门禁 G5（L144）。
+
+5. **[事实/证据]** As a QA/稳定性工程师, I want 每条 REQ 都有可重复证据且 P0/P1 在 Gate Review 时为零, so that “绿色测试”不能替代真实边界验证（不可妥协原则 #10）。
+   → 映射：REQUIREMENTS.md L5 证据规则；system-stability-gate.md L188–L196（P0/P1 清零、required difference 为零）。
+
+---
+
+## 汇总：画像 → REQ 映射矩阵
+
+| 画像 | 主要 REQ 覆盖 | 关联门禁 |
+|---|---|---|
+| 平台/SRE 工程师 | REQ-STABILITY-001~006、REQ-OBS-002、REQ-STORAGE-002、REQ-RAFT-008 | G1–G7（尤其 G2/G7） |
+| Redis 迁移用户 | REQ-COMPAT-001~007 | G1 |
+| 存储/内核开发者 | REQ-STORAGE-001~006 | G2 |
+| QA/稳定性工程师 | REQ-COMPAT-008~010、REQ-RAFT-006~008、REQ-PERF-002/003 | G1/G3/G4/G5 |
+
+> 说明：所有 P2 冻结项（`REQ-HOT-*`、`REQ-LICENSE-002~008`、`REQ-OBS-003`）在当前主线（Cache OFF）中无对应活跃用户故事，仅作为 M7 之后解冻时的待办合同，故未在上述活跃故事中展开。

--- a/docs/personas-and-user-stories.md
+++ b/docs/personas-and-user-stories.md
@@ -16,8 +16,8 @@
 1. **[事实/证据]** As a 平台/SRE 工程师, I want Redis 8.8.1 exact Oracle 可重复验证 Kiwi 兼容, so that 升级或重构不会在客户端无感知的情况下破坏语义。
    → 映射：`REQ-COMPAT-001`、`REQ-COMPAT-002`、`REQ-COMPAT-003`。
 
-2. **[事实/证据]** As a 平台/SRE 工程师, I want 系统稳定性门禁 G1–G7 全部 PASS 且经用户重新明确批准后才允许进入热层, so that 引入内存状态层之前生产风险已被证明可控。
-   → 映射：`REQ-STABILITY-001`、`REQ-STABILITY-002`、`REQ-STABILITY-005`；门禁 G1–G7（system-stability-gate.md L61–L186）。
+2. **[事实/证据]** As a 平台/SRE 工程师, I want 系统稳定性门禁 G1–G7 全部 PASS 后只提出新的授权请求，并由用户明确批准一个单独的 implementation task, so that Gate PASS、PR 合并或 M7 Ready 都不会被误当成生产实现授权。
+   → 映射：`REQ-STABILITY-001`、`REQ-STABILITY-002`、`REQ-STABILITY-005`、`REQ-STABILITY-006`；门禁 G1–G7 与授权边界（system-stability-gate.md L37、L57、L234–L240）。
 
 3. **[事实/证据]** As a 平台/SRE 工程师, I want Raft 暴露 term/role/leader/commit index/last applied/snapshot/fsync 等指标, so that 排障时无需侵入进程即可定位一致性问题。
    → 映射：`REQ-OBS-002`。
@@ -26,7 +26,10 @@
    → 映射：`REQ-STORAGE-002`；门禁 G2（system-stability-gate.md L80–L97）。
 
 5. **[事实/证据]** As a 平台/SRE 工程师, I want 运维手册覆盖磁盘满/无 Leader/Snapshot 失败/`SUBMIT_UNKNOWN` 处置, so that 故障时有可执行的处置流程而非依赖人工救火。
-   → 映射：门禁 G7（system-stability-gate.md L170–L185）；`REQ-RAFT-008`。
+   → 映射：门禁 G7（system-stability-gate.md L171–L186）；`REQ-RAFT-008`。
+
+6. **[事实/证据]** As a 平台/SRE 工程师, I want Gate Review 绑定可重放证据，并在 M7 前完成许可证、ABI、安全加载和验收合同设计, so that 前置设计能够接受审查而 Redis-derived 生产实现仍保持冻结。
+   → 映射：`REQ-STABILITY-003`、`REQ-STABILITY-004`、`REQ-STABILITY-006`；`REQ-LICENSE-002~008`（仅设计与发布前复核）；门禁前允许项（system-stability-gate.md L21–L27）与 M7 进入条件（L234–L240）。
 
 ---
 
@@ -36,7 +39,7 @@
 
 ### 用户故事
 
-1. **[事实/证据]** As a Redis 迁移用户, I want RESP2 与 RESP3 原始 frame 与 Redis 8.8.1 字节级一致（含二进制 payload、null、error、push、attribute、aggregate 类型）, so that 现有客户端无需改造即可切换。
+1. **[事实/证据]** As a Redis 迁移用户, I want RESP2 与 RESP3 原始 frame 与 Redis 8.8.1 做字节级 differential（含二进制 payload、null、error、push、attribute、aggregate 类型）, so that 我能评估迁移改造并通过兼容矩阵识别仍需处理的差异。
    → 映射：`REQ-COMPAT-002`；门禁 G1（system-stability-gate.md L65–L66）。
 
 2. **[事实/证据]** As a Redis 迁移用户, I want Pipeline 中间错误、partial I/O、连接关闭、Push 交错都有回归测试, so that 高并发/弱网场景下的客户端行为不漂移。
@@ -103,9 +106,9 @@
 
 | 画像 | 主要 REQ 覆盖 | 关联门禁 |
 |---|---|---|
-| 平台/SRE 工程师 | REQ-STABILITY-001~006、REQ-OBS-002、REQ-STORAGE-002、REQ-RAFT-008 | G1–G7（尤其 G2/G7） |
-| Redis 迁移用户 | REQ-COMPAT-001~007 | G1 |
-| 存储/内核开发者 | REQ-STORAGE-001~006 | G2 |
+| 平台/SRE 工程师 | REQ-COMPAT-001~003、REQ-STABILITY-001~006、REQ-OBS-002、REQ-STORAGE-002、REQ-RAFT-008、REQ-LICENSE-002~008（设计/复核） | G1–G7（尤其 G2/G6/G7） |
+| Redis 迁移用户 | REQ-COMPAT-001~004、REQ-COMPAT-006/007 | G1 |
+| 存储/内核开发者 | REQ-STORAGE-001~006；关联 REQ-HOT-001 验收合同 | G2 |
 | QA/稳定性工程师 | REQ-COMPAT-008~010、REQ-RAFT-006~008、REQ-PERF-002/003 | G1/G3/G4/G5 |
 
-> 说明：所有 P2 冻结项（`REQ-HOT-*`、`REQ-LICENSE-002~008`、`REQ-OBS-003`）在当前主线（Cache OFF）中无对应活跃用户故事，仅作为 M7 之后解冻时的待办合同，故未在上述活跃故事中展开。
+> 说明：当前没有任何 P2 **生产实现**用户故事获得授权。M7 前的来源、许可证、ABI、安全加载、可观测性接口和验收合同设计仍是活跃前置工作；上文对 `REQ-HOT-001`、`REQ-LICENSE-002~008` 的关联只表示设计/复核责任，不授权 fork、动态库、loader、发行接入或 Cache ON 数据路径。

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,9 +1,9 @@
 # Kiwi 产品需求文档（PRD）
 
-> 综合来源：`.planning/PROJECT.md`（项目宪法）、`.planning/REQUIREMENTS.md`（可验收需求 v2）、`.planning/ROADMAP.md`（唯一路线图）、`.planning/STATE.md`（当前状态）、`.planning/DECISIONS.md`（已批准决定）。
+> 综合来源：`.planning/PROJECT.md`（项目宪法）、`.planning/REQUIREMENTS.md`（可验收需求 v2）、`.planning/ROADMAP.md`（唯一路线图）、`.planning/DECISIONS.md`（已批准决定）、`.planning/STATE.md` 与 `.planning/KANBAN.md`（执行状态）。
 > 稳定性门禁 G1–G7 引用：`docs/quality/system-stability-gate.md`。
-> 文档性质：纯本地规划文档，不修改 git、CI 或生产源码。
-> 编写日期：2026-07-28（与 STATE.md 同步）。
+> 文档性质：版本化的长期产品目标与验收合同；PR、Head、checks、dirty ownership 和任务授权等瞬时状态只由 `.planning/STATE.md`、`.planning/KANBAN.md`、本地 recovery 记录和 GitHub 实时状态维护。
+> 对齐日期：2026-07-30。
 
 ---
 
@@ -14,8 +14,8 @@
 Kiwi 是一个以 **Redis 8.8.1 exact tag 可观察语义兼容**为目标的生产级 **Rust Redis-compatible 数据库**。
 
 - 使用 **RocksDB** 保存全量、权威、可恢复的数据。
-- 使用 **OpenRaft** 提供经过故障验证的强一致、高可用、成员变更、快照和恢复能力。
-- 内嵌 Redis 8.8.1 原生内存热数据层（Embedded Redis Hot Tier）属于**后续性能增强**：现在只冻结来源、许可证、ABI、正确性和发行接口合同，**不进入生产实现**；只有整体系统通过稳定性门禁并获得明确批准后，才能启动（PROJECT.md L13）。
+- 目标是使用 **OpenRaft** 提供强一致、高可用、成员变更、快照和恢复能力，并在 M4/M5 以故障测试建立证据；此目标不表示相关门禁已经通过。
+- 内嵌 Redis 8.8.1 原生内存热数据层（Embedded Redis Hot Tier）属于**后续性能增强**：现在只冻结来源、许可证、ABI、正确性和发行接口合同，**不进入生产实现**；只有整体系统通过稳定性门禁且用户明确批准一个单独的 implementation task 后，才能启动（PROJECT.md L13；REQ-STABILITY-006）。
 
 **固定基线（来源：`.planning/PROJECT.md` L17–L32）**
 
@@ -44,7 +44,7 @@ Kiwi 是一个以 **Redis 8.8.1 exact tag 可观察语义兼容**为目标的生
 | 反推画像 | 反推依据（来源） |
 |---|---|
 | 平台 / SRE 工程师 | 可观测（REQ-OBS-001/002）、运维演练（G7, ROADMAP M9）、稳定门禁（REQ-STABILITY-001~006） |
-| Redis 迁移用户 | RESP2/3 字节级兼容（REQ-COMPAT-002）、兼容矩阵（REQ-COMPAT-003）、客户端零改造（REQ-COMPAT-005/006） |
+| Redis 迁移用户 | RESP2/3 原始 frame differential（REQ-COMPAT-002）、兼容矩阵与已知差异（REQ-COMPAT-003）、Pipeline/连接行为回归（REQ-COMPAT-006） |
 | 存储 / 内核开发者 | RocksDB 权威（REQ-STORAGE-001~006）、encoding 规范（REQ-STORAGE-005）、format version（REQ-STORAGE-003） |
 | QA / 稳定性工程师 | Oracle provenance（REQ-COMPAT-008~010）、Jepsen/Elle（REQ-RAFT-007）、确定性 simulator（REQ-RAFT-006） |
 
@@ -54,19 +54,19 @@ Kiwi 是一个以 **Redis 8.8.1 exact tag 可观察语义兼容**为目标的生
 
 **分级依据（可辩护）**
 
-- **P0 = 稳定性门禁与当前里程碑阻塞项**：进入 M7 前的硬门禁（REQ-STABILITY-\*）、本 planning task 直接相关的 Oracle provenance 信任根（REQ-COMPAT-008/009/010）、以及门禁证据可复现的前提（REQ-WORK-\*）。这些不满足则 M7 保持冻结（ROADMAP M6/M7）。
+- **P0 = 稳定性门禁与当前里程碑阻塞项**：进入 M7 前的硬门禁（REQ-STABILITY-\*）、M1-001-T2 的 Oracle provenance 信任根（REQ-COMPAT-008/009/010）、以及门禁证据可复现的前提（REQ-WORK-\*）。这些不满足则 M7 保持冻结（ROADMAP M6/M7）。
 - **P1 = 核心兼容、存储、一致性与可观测/性能**：当前 Cache OFF 产品主线的必修项，纳入 M1–M6 验收（REQ-COMPAT-001~007、REQ-STORAGE-\*、REQ-RAFT-\*、REQ-OBS-001/002、REQ-PERF-\*、REQ-LICENSE-001）。
-- **P2 = 未来热层与组合发行**：M7 之后、当前冻结，仅作合同/设计（REQ-HOT-\*、REQ-LICENSE-002~008、REQ-OBS-003）。
+- **P2 = 未来热层与组合发行**：生产实现与发行接入当前冻结；M7 前允许且必须完成适用的来源、许可证、ABI、安全加载和验收合同设计（REQ-HOT-\*、REQ-LICENSE-002~008、REQ-OBS-003）。
 
 ### P0（门禁 / 当前阻塞）
 
-- `REQ-STABILITY-001`：启动热层生产实现前须门禁明确通过 + 用户批准解除冻结。
+- `REQ-STABILITY-001`：启动热层生产实现前须门禁明确通过，且用户须明确批准一个单独的 implementation task。
 - `REQ-STABILITY-002`：门禁至少覆盖 Redis 8.8.1 differential、RocksDB close/reopen、Raft commit/apply/durability、Snapshot、成员变更、进程级故障注入、资源边界、可观测性。
 - `REQ-STABILITY-003`：门禁证据须绑定 branch/HEAD/平台/工具链/命令/结果/未覆盖风险；仅单测不算稳定。
 - `REQ-STABILITY-004`：门禁未过期间只允许设计热层合同，禁止新增 Redis-derived 生产依赖/loader/数据路径/默认配置。
 - `REQ-STABILITY-005`：任何解除冻结决定须追加到 DECISIONS.md 并同步 Roadmap/State/Kanban，不得由 PR 隐式解除。
-- `REQ-STABILITY-006`：门禁通过只授权新规划与授权请求，不自动授权 fork/loader/发行/热层实现。
-- `REQ-COMPAT-008`：Oracle provenance 须 primary build 与 verifier 独立重建 binary SHA-256 完全一致，正式证据只来自独立重建产物（当前 M1-001 Task 2 核心，STATE.md L55–L61）。
+- `REQ-STABILITY-006`：门禁通过只允许提交新规划与授权请求；即使用户同意 M7 转为 Ready，fork/loader/发行/热层实现仍只能在单独获批的 implementation task 中执行。
+- `REQ-COMPAT-008`：Oracle provenance 须 primary build 与 verifier 独立重建 binary SHA-256 完全一致，正式证据只来自独立重建产物（M1-001 Task 2 核心，见 STATE.md“Oracle provenance 历史状态”）。
 - `REQ-COMPAT-009`：Oracle controller bootstrap/Git/CC/Make 须来自声明 Linux 信任边界，记录路径/版本/SHA-256/identity，路径替换风险下经 held FD 执行。
 - `REQ-COMPAT-010`：provenance 须在所有步骤成功后原子发布；不支持平台显式 FAIL 或带原因静态忽略，不得 early-return 假 PASS。
 - `REQ-WORK-001`：长期事实写入 `.planning/`，不只在会话记忆。
@@ -123,17 +123,20 @@ Kiwi 是一个以 **Redis 8.8.1 exact tag 可观察语义兼容**为目标的生
 
 | 类别 | 要求摘要 | 来源 REQ |
 |---|---|---|
-| 稳定性 | 系统稳定性门禁 G1–G7 全 PASS 才允许进入热层；门禁覆盖兼容/恢复/Raft/故障/可观测/资源/运维；仅单测或通过 CI 全绿不构成稳定（PROJECT.md 不可妥协原则 #2、#10）。 | REQ-STABILITY-001~006；G1–G7 |
+| 稳定性 | 系统稳定性门禁 G1–G7 全 PASS 只允许提出新的热层规划与授权请求；用户还须明确批准一个单独的 implementation task，生产实现不得自动启动。门禁覆盖兼容/恢复/Raft/故障/可观测/资源/运维；仅单测或 CI 全绿不构成稳定（PROJECT.md 不可妥协原则 #2、#10）。 | REQ-STABILITY-001~006；G1–G7 |
 | 性能 | 基线含 Redis 8.8.1 vs Kiwi Cache OFF；报告须含 P50/P95/P99/P99.9/吞吐/CPU/峰值内存/写放大/环境；平均吞吐不得掩盖尾延迟、内存失控、语义变化、恢复退化。 | REQ-PERF-001~003 |
 | 可观测 | 核心路径暴露结果/错误/延迟/资源/恢复状态；Raft 暴露 term/role/leader/commit/fsync 等指标；日志不泄露敏感数据。 | REQ-OBS-001/002 |
 | 可靠（正确性/恢复/一致性） | RocksDB 全量权威；真实 close/reopen；原子性合同；编码 binary-safe/stable；写成功须 commit+apply+durability；线性一致门禁；崩溃后可由持久证据恢复（不可妥协原则 #1、#3、#6）。 | REQ-STORAGE-001~006；REQ-RAFT-001~008；REQ-COMPAT-001~007 |
-| 安全供应链 | Oracle provenance 独立重建 + binary hash equality；依赖固定 exact commit；可生成 SBOM；许可证/notice 完整；组合发行对应源码精确（不可妥协原则 #9）。 | REQ-COMPAT-008~010；REQ-LICENSE-001~008；REQ-WORK-001~005 |
+| 安全供应链 | Oracle provenance 独立重建 + binary hash equality；依赖固定 exact commit；可生成 SBOM；许可证/notice 完整；组合发行对应源码精确（不可妥协原则 #9）。 | REQ-COMPAT-008~010；REQ-LICENSE-001~008 |
+| 治理与工作连续性 | 长期事实、任务状态、branch/HEAD/授权、dirty ownership 和规划/实施边界可恢复；发生漂移时停止写操作。 | REQ-WORK-001~005 |
 
 ---
 
 ## 5. 范围：含 / 不含 / 延期
 
 ### 含（当前产品主线，Cache OFF）
+
+> 本节定义当前主线的目标与验收范围，不表示各项已经实现或通过门禁；实际进度只以 `.planning/STATE.md`、`.planning/KANBAN.md` 和可重复验证证据为准。
 
 - Redis 8.8.1 可观察语义兼容（Oracle 验证，不依赖热层）。
 - RocksDB 全量权威存储与真实恢复。
@@ -152,7 +155,7 @@ Kiwi 是一个以 **Redis 8.8.1 exact tag 可观察语义兼容**为目标的生
 
 ### 延期（冻结，来源 PROJECT.md L62–L82；ROADMAP M7 L158–L160）
 
-- 内嵌 Redis 8.8.1 原生内存热数据层（Embedded Redis Hot Tier）：仅冻结来源/许可证/ABI/正确性/发行接口合同，**不进入生产实现**，须 M6 通过且用户重新明确批准后才解冻（REQ-STABILITY-001/005；D009）。
+- 内嵌 Redis 8.8.1 原生内存热数据层（Embedded Redis Hot Tier）：仅冻结来源/许可证/ABI/正确性/发行接口合同，**不进入生产实现**；须 M6 通过且用户重新明确批准一个单独的 implementation task 后才解冻（REQ-STABILITY-001/005/006；D009）。
 - Multi-Raft 与远期容量（ROADMAP M10，启动条件见 L222）。
 
 ---
@@ -169,9 +172,9 @@ Kiwi 是一个以 **Redis 8.8.1 exact tag 可观察语义兼容**为目标的生
 | **G4** | 进程/网络/磁盘故障证明 | kill/pause/partition/磁盘满/fsync error；Snapshot Install 与成员变更并发；Elle/Jepsen checker；每故障有可重放证据（L117–L133）。 |
 | **G5** | 长期运行与资源边界 | 单节点 ≥24h、3 节点 ≥72h Cache OFF 稳定；FD/线程/内存/WAL 有上界；P50–P99.9 持续记录；超预算即失败（L135–L150）。 |
 | **G6** | 工程质量与供应链 | Linux/macOS/Windows required CI 同 commit 通过；sanitizer/Miri/fuzz/dependency audit；生产路径无外部输入触发 `unwrap()`；依赖可固定可 SBOM；AGPL 义务与 Corresponding Source 已计划法律复核（L152–L168）。 |
-| **G7** | 运维/升级/恢复演练 | 空环境部署单/3 节点；备份/恢复/证书轮换演练；滚动升级或明确停机流程；回滚不依赖人工修复；故障手册可区分安全重试与结果未知写（L170–L185）。 |
+| **G7** | 运维/升级/恢复演练 | 空环境部署单/3 节点；备份/恢复/证书轮换演练；滚动升级或明确停机流程；回滚不依赖人工修复；故障手册可区分安全重试与结果未知写（L171–L186）。 |
 
-**门禁判定（L236、L230）**：G1–G7 全部 `PASS` + 代码/发行候选未失效变化 + 无未解决 P0/P1 + 无不可重放 required failure + 用户重新明确批准 → M7 由 Frozen 转 Ready。任一 required artifact 缺失、schema 校验失败、toolchain 不受控、binary hash 不一致、runtime evidence 未绑定 verifier rebuild、cleanup 任一步失败或仅 self-reported metadata → **G1 必须 FAIL**。
+**门禁判定（进入条件 L234–L240；G1 FAIL 条件 L228–L230）**：满足全部五项进入条件后，M7 才能由 Frozen 转 Ready；用户批准的对象必须是一个单独的 implementation task，不能由 Gate PASS、PR 合并或 Ready 状态自动推导生产实现授权。任一 required artifact 缺失、schema 校验失败、toolchain 不受控、binary hash 不一致、runtime evidence 未绑定 verifier rebuild、cleanup 任一步失败或仅 self-reported metadata → **G1 必须 FAIL**。
 
 ### 6.2 REQ 证据规则（来源 REQUIREMENTS.md L5）
 
@@ -192,28 +195,28 @@ Kiwi 是一个以 **Redis 8.8.1 exact tag 可观察语义兼容**为目标的生
 | **M4** | 生产级单 Raft Group（`kiwi_redisraft_public_v1`、Linearizable Read、Membership、Snapshot）。 | 公开 Profile 100% 通过；3/5 节点正常/成员变更/恢复可重复；Cache OFF 无一致性绕行（L107–L122）。 |
 | **M5** | 分布式故障与一致性证明（partition/kill/disk fault/Jepsen/SUBMIT_UNKNOWN）。 | Election/Log Matching/State Machine Safety/线性一致/durability 均有机器可检查证据（L124–L139）。 |
 | **M6** | 系统稳定门禁（G1–G7）。 | 所有 P0/P1 清零；保留差异/豁免有 owner/期限/退出条件；Gate Review 绑定 exact commit（L141–L156）。 |
-| **[用户重新明确批准]** | 解冻热层生产实现的前置授权。 | 不自动授权（REQ-STABILITY-006）。 |
-| **M7** | Embedded Redis Hot Tier 资格验证与实现（**延期且冻结**）。 | 关闭/删除热层不影响正确性；热层失败不返回旧值；组合发行 Corresponding Source 检查通过（L158–L187）。 |
+| **[用户重新明确批准]** | 将 M7 转为 Ready，并批准一个范围明确、与规划 task 分离的 implementation task。 | Gate PASS 或 Ready 状态均不自动授权生产实现（REQ-STABILITY-006）。 |
+| **M7** | Embedded Redis Hot Tier 资格验证与实现（**延期且冻结**）。 | 仅在单独 implementation task 获批后执行；关闭/删除热层不影响正确性，热层失败不返回旧值，组合发行 Corresponding Source 检查通过（L158–L187）。 |
 | **M8** | Cache ON 正确性、故障与性能证明。 | Cache ON 与 Cache OFF 可观察结果一致；故障只降级性能；收益可重复且尾延迟/内存/恢复/写放大不越预算（L189–L202）。 |
 | **M9** | 生产发行门禁（CI/SBOM/回滚/运维手册）。 | 同版本可空环境部署/验证/备份/恢复/升级/回滚；发行包/源码/运行时身份完全对应（L204–L218）。 |
 | **M10** | Multi-Raft 与远期容量（启动条件：单 Group 门禁完成且有瓶颈证据）。 | 候选：Redis Cluster slot、Meta Group、S3 Snapshot、冷对象归档（L220–L232）。 |
 
-> 依赖顺序：M1/M2 可有限并行；M3 依赖二者；M4/M5 须 Cache OFF 为唯一 required 模式；M7 在 M6 通过 + 用户批准前保持冻结；M10 不得在单 Group 稳定性与故障证明完成前启动主线（ROADMAP L34）。
+> 依赖顺序：M1/M2 可有限并行；M3 依赖二者；M4/M5 须 Cache OFF 为唯一 required 模式；M7 在 M6 通过且用户批准单独 implementation task 前保持冻结；M10 不得在单 Group 稳定性与故障证明完成前启动主线（ROADMAP L34）。
 
 ---
 
-## 8. 待确认问题（未决项 / 开放问题）
+## 8. 未决项与已确认历史
 
-> 以下问题为**开放问题**，PRD 不预设结论，须由相应 owner / 用户澄清。
+> 以下条目区分仍待决定的产品问题与已经确认的历史状态；PRD 不缓存 checks、review threads 或 dirty ownership 等瞬时执行状态。
 
-1. **Hot Tier 批准状态**：M7 仍冻结。解冻须 M6（G1–G7 全 PASS）+ 用户在看到 Gate Review 后**重新明确批准**（PROJECT.md L13；ROADMAP M7 L160；REQ-STABILITY-001/005）。当前无批准记录。
-2. **PR `#383` 状态**：规划 PR `codex/redis-8.8.1-oracle-provenance-plan`，仅 15 个 planning/docs 路径，未带入实现。STATE.md 要求**实时查询 GitHub** 确认 state/Head/Base/checks，**不缓存**（STATE.md L7、L58、L105）。若仍 OPEN，六文件草稿保持冻结。
-3. **provenance 实现进度**：方案 A（D011）已批准，但实现**未在接受边界内开始**（STATE.md L59、L101）。当前 PR `#383` 只是“规划闭环”，不代表方案 A 已实现。
+1. **Hot Tier 批准状态**：M7 仍冻结。M6（G1–G7）通过只允许提出授权请求；用户必须在看到 Gate Review 后明确批准一个单独的 implementation task（PROJECT.md L13；ROADMAP M7 L160；REQ-STABILITY-001/005/006）。当前无批准记录。
+2. **PR `#383` 历史状态**：规划 PR `codex/redis-8.8.1-oracle-provenance-plan` 已于 2026-07-28 合并，final Head `42c16bef899385bd2e1b1e16e2e0202d4a614590`，merge commit `58030e1331655546ea4547a9a94efc493534ef7d`；它只固化 planning/docs，不带入实现。
+3. **provenance 实现进度**：方案 A（D011）已批准，但实现**未在接受边界内开始**（STATE.md Oracle provenance 历史状态）。PR `#383` 只完成规划闭环，不代表方案 A 已实现。
 4. **`arana-db/redis` 下游 baseline**：下游 exact commit、patch 清单、构建配置、产物 hash 尚未建立，当前不是 Kiwi 构建输入（PROJECT.md L28、L34）。
 5. **组合发行开源许可证专项复核**：首次公开发布含 Redis-derived native library 的组合发行前必须完成，当前未执行（REQ-LICENSE-008；D002）。
-6. **冻结六文件草稿处置**：`.worktrees/redis-8.8.1-stability-foundation` 存在六文件未提交草稿（frozen base `2507a0c…`），未由方案 A 接受；后续 implementation task 可只读参考但须逐项对照 D011、REQ-COMPAT-008~010 重新审计（STATE.md L63–L81）。
+6. **Oracle 草稿接受边界**：PR `#383` 未接受旧六文件实现草稿；后续独立 Oracle implementation task 只能将其作为只读参考，并须逐项对照 D011、REQ-COMPAT-008~010 重新审计。精确 worktree、dirty ownership 和 recovery checkpoint 不在 PRD 中缓存。
 7. **Multi-Raft 启动条件**：单 Group 兼容/持久化/一致性/故障/稳定门禁未完成，且无 Leader 吞吐/容量/隔离/故障域瓶颈证据 → M10 不启动（ROADMAP M10 L222）。
-8. **当前运行模式**：Cache OFF 为当前唯一 required 模式（ROADMAP L7；REQ-PERF-001）。Cache ON 测试与对比基线须 M7 获批后引入。
+8. **当前运行模式**：Cache OFF 为当前唯一 required 模式（ROADMAP L7；REQ-PERF-001）。Cache ON 测试与对比基线只能在 M7 条件满足且单独 implementation task 获批后引入。
 
 ---
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,235 @@
+# Kiwi 产品需求文档（PRD）
+
+> 综合来源：`.planning/PROJECT.md`（项目宪法）、`.planning/REQUIREMENTS.md`（可验收需求 v2）、`.planning/ROADMAP.md`（唯一路线图）、`.planning/STATE.md`（当前状态）、`.planning/DECISIONS.md`（已批准决定）。
+> 稳定性门禁 G1–G7 引用：`docs/quality/system-stability-gate.md`。
+> 文档性质：纯本地规划文档，不修改 git、CI 或生产源码。
+> 编写日期：2026-07-28（与 STATE.md 同步）。
+
+---
+
+## 1. 产品目标 / 北极星
+
+**北极星（来源：`.planning/PROJECT.md` L9–L15）**
+
+Kiwi 是一个以 **Redis 8.8.1 exact tag 可观察语义兼容**为目标的生产级 **Rust Redis-compatible 数据库**。
+
+- 使用 **RocksDB** 保存全量、权威、可恢复的数据。
+- 使用 **OpenRaft** 提供经过故障验证的强一致、高可用、成员变更、快照和恢复能力。
+- 内嵌 Redis 8.8.1 原生内存热数据层（Embedded Redis Hot Tier）属于**后续性能增强**：现在只冻结来源、许可证、ABI、正确性和发行接口合同，**不进入生产实现**；只有整体系统通过稳定性门禁并获得明确批准后，才能启动（PROJECT.md L13）。
+
+**固定基线（来源：`.planning/PROJECT.md` L17–L32）**
+
+| 维度 | 取值 |
+|---|---|
+| Redis tag / commit | `8.8.1` / `77b6c308396c9700672390a210143a8496fb4b10` |
+| Redis 许可证选项 | RSALv2 / SSPLv1 / AGPLv3 |
+| 选定 Redis fork 许可证 | `AGPL-3.0-only` |
+| Kiwi 语言 | Rust |
+| Kiwi 自有源码许可证 | Apache-2.0 |
+| 持久化真相 | RocksDB |
+| 共识 | OpenRaft |
+| 未来热层来源 | `arana-db/redis`（下游 exact pin 待定） |
+| Raft API 模型 | RedisRaft public compatibility profile |
+| Rust 客户端 | redis-rs（仅测试） |
+| Oracle 来源证明 | independent rebuild + binary-hash equality |
+
+> 约束红线（PROJECT.md L15）：任何 Raft、分片、存储格式、兼容性或未来热层优化，都**不得改变** Redis 8.8.1 的可观察语义、已声明的持久化边界和一致性承诺。
+
+---
+
+## 2. 用户画像与场景（反推）
+
+> ⚠️ 本节为**反推**：`.planning/` 文档是工程与审计视角，未显式定义终端用户。**以下画像从 REQUIREMENTS / ROADMAP / STATE 中可验证的工程事实反推得出**，非用户调研结论。详细用户故事与 REQ 映射见 `docs/personas-and-user-stories.md`。
+
+| 反推画像 | 反推依据（来源） |
+|---|---|
+| 平台 / SRE 工程师 | 可观测（REQ-OBS-001/002）、运维演练（G7, ROADMAP M9）、稳定门禁（REQ-STABILITY-001~006） |
+| Redis 迁移用户 | RESP2/3 字节级兼容（REQ-COMPAT-002）、兼容矩阵（REQ-COMPAT-003）、客户端零改造（REQ-COMPAT-005/006） |
+| 存储 / 内核开发者 | RocksDB 权威（REQ-STORAGE-001~006）、encoding 规范（REQ-STORAGE-005）、format version（REQ-STORAGE-003） |
+| QA / 稳定性工程师 | Oracle provenance（REQ-COMPAT-008~010）、Jepsen/Elle（REQ-RAFT-007）、确定性 simulator（REQ-RAFT-006） |
+
+---
+
+## 3. 需求池（REQ-\* 分级）
+
+**分级依据（可辩护）**
+
+- **P0 = 稳定性门禁与当前里程碑阻塞项**：进入 M7 前的硬门禁（REQ-STABILITY-\*）、本 planning task 直接相关的 Oracle provenance 信任根（REQ-COMPAT-008/009/010）、以及门禁证据可复现的前提（REQ-WORK-\*）。这些不满足则 M7 保持冻结（ROADMAP M6/M7）。
+- **P1 = 核心兼容、存储、一致性与可观测/性能**：当前 Cache OFF 产品主线的必修项，纳入 M1–M6 验收（REQ-COMPAT-001~007、REQ-STORAGE-\*、REQ-RAFT-\*、REQ-OBS-001/002、REQ-PERF-\*、REQ-LICENSE-001）。
+- **P2 = 未来热层与组合发行**：M7 之后、当前冻结，仅作合同/设计（REQ-HOT-\*、REQ-LICENSE-002~008、REQ-OBS-003）。
+
+### P0（门禁 / 当前阻塞）
+
+- `REQ-STABILITY-001`：启动热层生产实现前须门禁明确通过 + 用户批准解除冻结。
+- `REQ-STABILITY-002`：门禁至少覆盖 Redis 8.8.1 differential、RocksDB close/reopen、Raft commit/apply/durability、Snapshot、成员变更、进程级故障注入、资源边界、可观测性。
+- `REQ-STABILITY-003`：门禁证据须绑定 branch/HEAD/平台/工具链/命令/结果/未覆盖风险；仅单测不算稳定。
+- `REQ-STABILITY-004`：门禁未过期间只允许设计热层合同，禁止新增 Redis-derived 生产依赖/loader/数据路径/默认配置。
+- `REQ-STABILITY-005`：任何解除冻结决定须追加到 DECISIONS.md 并同步 Roadmap/State/Kanban，不得由 PR 隐式解除。
+- `REQ-STABILITY-006`：门禁通过只授权新规划与授权请求，不自动授权 fork/loader/发行/热层实现。
+- `REQ-COMPAT-008`：Oracle provenance 须 primary build 与 verifier 独立重建 binary SHA-256 完全一致，正式证据只来自独立重建产物（当前 M1-001 Task 2 核心，STATE.md L55–L61）。
+- `REQ-COMPAT-009`：Oracle controller bootstrap/Git/CC/Make 须来自声明 Linux 信任边界，记录路径/版本/SHA-256/identity，路径替换风险下经 held FD 执行。
+- `REQ-COMPAT-010`：provenance 须在所有步骤成功后原子发布；不支持平台显式 FAIL 或带原因静态忽略，不得 early-return 假 PASS。
+- `REQ-WORK-001`：长期事实写入 `.planning/`，不只在会话记忆。
+- `REQ-WORK-002`：当前任务状态写入 `.codex/recovery/ACTIVE.md`，checkpoint 追加式保存。
+- `REQ-WORK-003`：恢复状态须记录 branch/HEAD/授权/dirty 归属/证据/剩余工作/下一条安全动作。
+- `REQ-WORK-004`：branch/HEAD/dirty 漂移时新会话停止写操作并报告差异。
+- `REQ-WORK-005`：规划 task 与实施 task 使用不同任务边界；提前产生的实现草稿必须冻结（D012）。
+
+### P1（核心兼容 / 存储 / 一致性 / 可观测 / 性能）
+
+- `REQ-COMPAT-001`：普通 Redis 行为以 Redis 8.8.1 exact commit 为唯一 Oracle。
+- `REQ-COMPAT-002`：RESP2 与 RESP3 原始 frame 须做 differential，不依赖 typed conversion。
+- `REQ-COMPAT-003`：兼容矩阵须记录命令/模式/返回类型/错误/known difference/测试证据。
+- `REQ-COMPAT-004`：Redis 官方 TCL suite 固定到同一 exact upstream commit；skip 须有 owner/Issue/理由/解除条件。
+- `REQ-COMPAT-005`：redis-rs 只进独立测试工具或 dev dependency，生产 server crate 不得依赖。
+- `REQ-COMPAT-006`：Pipeline 中间错误、partial I/O、连接关闭、Push 交错、二进制 payload 须有回归测试。
+- `REQ-COMPAT-007`：新增公共命令/配置/错误/RESP/客户端接口须先取得 Redis 8.8.1 exact Oracle 证据。
+- `REQ-STORAGE-001`：RocksDB 保存全量权威数据；Raft metadata/last_applied/业务状态须有原子性合同。
+- `REQ-STORAGE-002`：恢复测试须释放所有 DB handle 再从路径重新打开。
+- `REQ-STORAGE-003`：磁盘格式须带 format version、Comparator 身份和迁移策略。
+- `REQ-STORAGE-004`：部分写、尾部损坏、metadata/log 不一致、Snapshot 损坏、磁盘满须有故障测试。
+- `REQ-STORAGE-005`：Kiwi key/value encoding 须 binary-safe/round-trip/order-preserving/prefix-safe/canonical/stable（`format_base_key.rs`、`format_*`、`custom_comparator.rs`）。
+- `REQ-STORAGE-006`：派生状态/索引/未来热层须能从 RocksDB 权威数据删除后重建，不能成为成功回复/恢复唯一依据。
+- `REQ-RAFT-001`：写成功回复须发生在 quorum commit + 本地 apply + 所选 durability profile 满足之后。
+- `REQ-RAFT-002`：Linearizable Read 即使经未来热层也须通过 Leader/ReadIndex/Lease 门禁。
+- `REQ-RAFT-003`：实现并冻结 `kiwi_redisraft_public_v1`，公开清单内行为 100% 通过。
+- `REQ-RAFT-004`：RedisRaft 内部 `RAFT.AE`/`RAFT.REQUESTVOTE`/`RAFT.SNAPSHOT` 不是公共兼容要求。
+- `REQ-RAFT-005`：成员变更、Leader Transfer、Snapshot、日志回滚、真实 close/reopen 须进 required CI/分层门禁。
+- `REQ-RAFT-006`：建立带 seed 的 OpenRaft deterministic simulator，检查 Election/Log Matching/State Machine Safety。
+- `REQ-RAFT-007`：建立 3/5 节点进程级 kill/pause/partition/restart/disk fault 与 Elle/Jepsen history 测试。
+- `REQ-RAFT-008`：非幂等写断线须标记 `SUBMIT_UNKNOWN`，测试和客户端不得自动重放。
+- `REQ-OBS-001`：核心数据路径须暴露请求结果/错误类别/延迟/资源使用/恢复状态；日志不泄露敏感数据。
+- `REQ-OBS-002`：Raft 须暴露 term/role/leader/commit index/last applied/snapshot/membership/replication/fsync 指标。
+- `REQ-PERF-001`：性能基线至少含 Redis 8.8.1 与同数据集/协议/持久化声明下的 Kiwi；热层获准后增加 Cache OFF/ON 对照。
+- `REQ-PERF-002`：性能报告须含 P50/P95/P99/P99.9/吞吐/CPU/峰值内存/写放大/测试环境。
+- `REQ-PERF-003`：平均吞吐提升不能掩盖尾延迟/内存失控/语义变化/恢复退化。
+- `REQ-LICENSE-001`：Kiwi 自有、可独立识别源码保持 Apache-2.0，保留文件级版权与 SPDX 声明。
+
+### P2（未来热层 / 组合发行 —— 冻结中，仅合同/设计）
+
+- `REQ-HOT-001` ~ `REQ-HOT-012`：热层全部 12 条验收合同（RocksDB 权威、arana-db/redis 来源、不进 Raft/Snapshot/Backup、可观察结果不变、update-or-invalidate、异步 fill 校验、TTL 绝对毫秒、Cache ON/OFF 同测、首期仅 String、版本化 C ABI、安全加载校验、专项审计）。详见 REQUIREMENTS.md L38–L53。
+- `REQ-LICENSE-002`：未来 Redis-derived native library 须源自 Redis 8.8.1 exact commit 并明确选 `AGPL-3.0-only`。
+- `REQ-LICENSE-003`：Redis 派生源码须保留上游版权/许可证/来源/修改记录/下游 exact commit/补丁/构建选项。
+- `REQ-LICENSE-004`：含 Redis-derived native library 的官方组合发行不得标 Apache-2.0-only，须履 AGPL-3.0-only 义务。
+- `REQ-LICENSE-005`：组合发行须提供与二进制精确匹配的 Kiwi 源码/Redis fork 源码/修改/ABI/绑定生成/构建脚本/许可证/第三方通知/SBOM。
+- `REQ-LICENSE-006`：运行时源码身份与对应源码入口须绑定 exact release/tag/commit，不指向浮动分支。
+- `REQ-LICENSE-007`：动态链接/独立仓库/运行时加载只能作工程边界，不得作免除组合发行许可证义务依据。
+- `REQ-LICENSE-008`：首次公开发布含 Redis-derived native library 组合发行前须完成开源许可证专项复核并记录结论。
+- `REQ-OBS-003`：未来热层启用后须暴露 hit/miss/fill/fill-drop/eviction/expire/update-failure/invalidate/generation-reset/load latency。
+
+---
+
+## 4. 非功能需求（来自 REQUIREMENTS）
+
+| 类别 | 要求摘要 | 来源 REQ |
+|---|---|---|
+| 稳定性 | 系统稳定性门禁 G1–G7 全 PASS 才允许进入热层；门禁覆盖兼容/恢复/Raft/故障/可观测/资源/运维；仅单测或通过 CI 全绿不构成稳定（PROJECT.md 不可妥协原则 #2、#10）。 | REQ-STABILITY-001~006；G1–G7 |
+| 性能 | 基线含 Redis 8.8.1 vs Kiwi Cache OFF；报告须含 P50/P95/P99/P99.9/吞吐/CPU/峰值内存/写放大/环境；平均吞吐不得掩盖尾延迟、内存失控、语义变化、恢复退化。 | REQ-PERF-001~003 |
+| 可观测 | 核心路径暴露结果/错误/延迟/资源/恢复状态；Raft 暴露 term/role/leader/commit/fsync 等指标；日志不泄露敏感数据。 | REQ-OBS-001/002 |
+| 可靠（正确性/恢复/一致性） | RocksDB 全量权威；真实 close/reopen；原子性合同；编码 binary-safe/stable；写成功须 commit+apply+durability；线性一致门禁；崩溃后可由持久证据恢复（不可妥协原则 #1、#3、#6）。 | REQ-STORAGE-001~006；REQ-RAFT-001~008；REQ-COMPAT-001~007 |
+| 安全供应链 | Oracle provenance 独立重建 + binary hash equality；依赖固定 exact commit；可生成 SBOM；许可证/notice 完整；组合发行对应源码精确（不可妥协原则 #9）。 | REQ-COMPAT-008~010；REQ-LICENSE-001~008；REQ-WORK-001~005 |
+
+---
+
+## 5. 范围：含 / 不含 / 延期
+
+### 含（当前产品主线，Cache OFF）
+
+- Redis 8.8.1 可观察语义兼容（Oracle 验证，不依赖热层）。
+- RocksDB 全量权威存储与真实恢复。
+- OpenRaft 单 Raft Group 强一致、高可用、成员变更、Snapshot（PROJECT.md L47–L59；ROADMAP 依赖顺序 L19–L31）。
+- 系统稳定性门禁 G1–G7（ROADMAP M6）。
+
+### 不含（当前非目标，来源 PROJECT.md L108–L116）
+
+- 在系统稳定性门禁批准前实现/集成/打包/启用 Embedded Redis Hot Tier。
+- Redis Stack/Search/JSON/TimeSeries/Bloom 完整实现（除非后续独立需求明确纳入）。
+- 单 Group 正确性闭环前建设 Multi-Raft。
+- 用 S3 直接替代本地 RocksDB 在线文件系统。
+- AI 向量数据库、Agent Memory、语义缓存、推理 KV Cache。
+- 将 RedisRaft 内部 RPC 命令暴露为 Kiwi 公共接口。
+- 把历史 `pikiwidb/rediscache` 代码未经来源和许可证审计直接复制到 Kiwi。
+
+### 延期（冻结，来源 PROJECT.md L62–L82；ROADMAP M7 L158–L160）
+
+- 内嵌 Redis 8.8.1 原生内存热数据层（Embedded Redis Hot Tier）：仅冻结来源/许可证/ABI/正确性/发行接口合同，**不进入生产实现**，须 M6 通过且用户重新明确批准后才解冻（REQ-STABILITY-001/005；D009）。
+- Multi-Raft 与远期容量（ROADMAP M10，启动条件见 L222）。
+
+---
+
+## 6. 验收标准
+
+### 6.1 稳定性门禁 G1–G7（来源 `docs/quality/system-stability-gate.md`）
+
+| 门禁 | 主题 | 核心 Required（摘要） |
+|---|---|---|
+| **G1** | Redis 8.8.1 Cache OFF 兼容 | Oracle exact commit 固定；primary/verifier rebuild binary SHA-256 一致；正式 `INFO server` 仅来自 rebuild；RESP2/3 raw frame 比较；TCL skip 有 owner；redis-rs 不在生产依赖图（L61–L78）。 |
+| **G2** | RocksDB 权威状态与恢复 | RocksDB 单独保存权威状态；写入/Raft metadata/last_applied 原子性；TTL 绝对时间；全部 handle 释放后真实 reopen；format version/Comparator/encoding 测试；部分写/磁盘满/只读 FS 故障（L80–L97）。 |
+| **G3** | OpenRaft 正确性与公开接口 | `kiwi_redisraft_public_v1` 100% 通过；写成功在 commit+apply+durability 后；Linearizable Read 无绕行；deterministic simulator；3/5 节点端到端；`SUBMIT_UNKNOWN` 不自动重试（L99–L115）。 |
+| **G4** | 进程/网络/磁盘故障证明 | kill/pause/partition/磁盘满/fsync error；Snapshot Install 与成员变更并发；Elle/Jepsen checker；每故障有可重放证据（L117–L133）。 |
+| **G5** | 长期运行与资源边界 | 单节点 ≥24h、3 节点 ≥72h Cache OFF 稳定；FD/线程/内存/WAL 有上界；P50–P99.9 持续记录；超预算即失败（L135–L150）。 |
+| **G6** | 工程质量与供应链 | Linux/macOS/Windows required CI 同 commit 通过；sanitizer/Miri/fuzz/dependency audit；生产路径无外部输入触发 `unwrap()`；依赖可固定可 SBOM；AGPL 义务与 Corresponding Source 已计划法律复核（L152–L168）。 |
+| **G7** | 运维/升级/恢复演练 | 空环境部署单/3 节点；备份/恢复/证书轮换演练；滚动升级或明确停机流程；回滚不依赖人工修复；故障手册可区分安全重试与结果未知写（L170–L185）。 |
+
+**门禁判定（L236、L230）**：G1–G7 全部 `PASS` + 代码/发行候选未失效变化 + 无未解决 P0/P1 + 无不可重放 required failure + 用户重新明确批准 → M7 由 Frozen 转 Ready。任一 required artifact 缺失、schema 校验失败、toolchain 不受控、binary hash 不一致、runtime evidence 未绑定 verifier rebuild、cleanup 任一步失败或仅 self-reported metadata → **G1 必须 FAIL**。
+
+### 6.2 REQ 证据规则（来源 REQUIREMENTS.md L5）
+
+- 每个实现工作项**必须引用至少一个 `REQ-*`**。
+- 每个 `REQ-*` **必须有可重复证据**（可重复、可重放、可审计）。
+- Gate Review 时：P0/P1 必须为零；required compatibility difference 必须为零；required test 不接受永久 skip；临时豁免须写明范围/依据/owner/Issue/到期条件/移除验证，且**不得覆盖数据损坏、线性一致性、安全或不可恢复风险**（system-stability-gate.md L188–L196）。
+
+---
+
+## 7. 路线图（M0–M10 摘要，来源 ROADMAP.md）
+
+| 里程碑 | 目标（摘要） | 关键退出门禁 |
+|---|---|---|
+| **M0** | 项目宪法、许可证与恢复机制（`.planning/*`、recovery 脚本）。 | 权威文档一致；热层“只设计禁实现”边界可恢复；恢复脚本 append-only 不改性 Git（L36–L56）。 |
+| **M1** | Redis 8.8.1 Cache OFF 兼容 Oracle（含 trusted provenance）。 | Oracle provenance 不可由 metadata+binary 拼接；双构建 hash 一致；正式证据来自 verifier rebuild；基础命令可重复 transcript（L58–L74）。 |
+| **M2** | RocksDB 权威状态与恢复正确性。 | Cache OFF 满足 Profile；崩溃恢复/格式兼容/故障注入证明 RocksDB 可独立恢复（L76–L90）。 |
+| **M3** | Redis 8.8.1 Cache OFF 核心语义闭环（String/Hash/List/Set/ZSet/Bitmap/HLL/Geo/Streams/Transaction/Lua/Pub-Sub/ACL/RESP3）。 | required profile 全绿；保留差异经显式批准，无未启用热层掩盖的正确性缺口（L92–L105）。 |
+| **M4** | 生产级单 Raft Group（`kiwi_redisraft_public_v1`、Linearizable Read、Membership、Snapshot）。 | 公开 Profile 100% 通过；3/5 节点正常/成员变更/恢复可重复；Cache OFF 无一致性绕行（L107–L122）。 |
+| **M5** | 分布式故障与一致性证明（partition/kill/disk fault/Jepsen/SUBMIT_UNKNOWN）。 | Election/Log Matching/State Machine Safety/线性一致/durability 均有机器可检查证据（L124–L139）。 |
+| **M6** | 系统稳定门禁（G1–G7）。 | 所有 P0/P1 清零；保留差异/豁免有 owner/期限/退出条件；Gate Review 绑定 exact commit（L141–L156）。 |
+| **[用户重新明确批准]** | 解冻热层生产实现的前置授权。 | 不自动授权（REQ-STABILITY-006）。 |
+| **M7** | Embedded Redis Hot Tier 资格验证与实现（**延期且冻结**）。 | 关闭/删除热层不影响正确性；热层失败不返回旧值；组合发行 Corresponding Source 检查通过（L158–L187）。 |
+| **M8** | Cache ON 正确性、故障与性能证明。 | Cache ON 与 Cache OFF 可观察结果一致；故障只降级性能；收益可重复且尾延迟/内存/恢复/写放大不越预算（L189–L202）。 |
+| **M9** | 生产发行门禁（CI/SBOM/回滚/运维手册）。 | 同版本可空环境部署/验证/备份/恢复/升级/回滚；发行包/源码/运行时身份完全对应（L204–L218）。 |
+| **M10** | Multi-Raft 与远期容量（启动条件：单 Group 门禁完成且有瓶颈证据）。 | 候选：Redis Cluster slot、Meta Group、S3 Snapshot、冷对象归档（L220–L232）。 |
+
+> 依赖顺序：M1/M2 可有限并行；M3 依赖二者；M4/M5 须 Cache OFF 为唯一 required 模式；M7 在 M6 通过 + 用户批准前保持冻结；M10 不得在单 Group 稳定性与故障证明完成前启动主线（ROADMAP L34）。
+
+---
+
+## 8. 待确认问题（未决项 / 开放问题）
+
+> 以下问题为**开放问题**，PRD 不预设结论，须由相应 owner / 用户澄清。
+
+1. **Hot Tier 批准状态**：M7 仍冻结。解冻须 M6（G1–G7 全 PASS）+ 用户在看到 Gate Review 后**重新明确批准**（PROJECT.md L13；ROADMAP M7 L160；REQ-STABILITY-001/005）。当前无批准记录。
+2. **PR `#383` 状态**：规划 PR `codex/redis-8.8.1-oracle-provenance-plan`，仅 15 个 planning/docs 路径，未带入实现。STATE.md 要求**实时查询 GitHub** 确认 state/Head/Base/checks，**不缓存**（STATE.md L7、L58、L105）。若仍 OPEN，六文件草稿保持冻结。
+3. **provenance 实现进度**：方案 A（D011）已批准，但实现**未在接受边界内开始**（STATE.md L59、L101）。当前 PR `#383` 只是“规划闭环”，不代表方案 A 已实现。
+4. **`arana-db/redis` 下游 baseline**：下游 exact commit、patch 清单、构建配置、产物 hash 尚未建立，当前不是 Kiwi 构建输入（PROJECT.md L28、L34）。
+5. **组合发行开源许可证专项复核**：首次公开发布含 Redis-derived native library 的组合发行前必须完成，当前未执行（REQ-LICENSE-008；D002）。
+6. **冻结六文件草稿处置**：`.worktrees/redis-8.8.1-stability-foundation` 存在六文件未提交草稿（frozen base `2507a0c…`），未由方案 A 接受；后续 implementation task 可只读参考但须逐项对照 D011、REQ-COMPAT-008~010 重新审计（STATE.md L63–L81）。
+7. **Multi-Raft 启动条件**：单 Group 兼容/持久化/一致性/故障/稳定门禁未完成，且无 Leader 吞吐/容量/隔离/故障域瓶颈证据 → M10 不启动（ROADMAP M10 L222）。
+8. **当前运行模式**：Cache OFF 为当前唯一 required 模式（ROADMAP L7；REQ-PERF-001）。Cache ON 测试与对比基线须 M7 获批后引入。
+
+---
+
+## 9. 许可证边界（Apache-2.0 vs 未来 AGPL-3.0-only）
+
+**当前（来源 PROJECT.md L6–L7、L84–L91；REQ-LICENSE-001；D002）**
+
+- **Kiwi 自有、可独立识别的源码**：Apache-2.0，保留现有版权与 SPDX 声明（REQ-LICENSE-001）。
+- **Redis 8.8.1 上游许可证选项**：RSALv2 / SSPLv1 / AGPLv3；选定 fork 许可证为 `AGPL-3.0-only`（PROJECT.md L22–L23）。
+
+**未来组合发行边界**
+
+- 未来 `arana-db/redis` 派生源码与原生动态库须选 `AGPL-3.0-only`，并完整保留 Redis 上游版权、许可证、修改记录（REQ-LICENSE-002/003）。
+- 若官方发行物包含 Redis-derived native library，**完整组合发行不得声明为 Apache-2.0-only**，必须履行 `AGPL-3.0-only` 适用义务（REQ-LICENSE-004）。
+- 组合发行须提供与二进制精确对应的 Kiwi 源码、Redis fork 源码、全部修改、ABI 头、绑定生成方式、构建脚本、版本清单、许可证、第三方通知和 SBOM（REQ-LICENSE-005）。
+- 远程用户对应源码入口、发行文案、打包方式须在公开发布前通过开源许可证专项复核（REQ-LICENSE-008）。
+- 拆分仓库、动态链接、运行时加载只用于**工程隔离**，不得被描述为规避组合发行许可证义务（REQ-LICENSE-007；D002 限定）。
+
+**关键不变量**：Kiwi 当前以 Apache-2.0 开发的源码与未来组合发行的 AGPL-3.0-only 义务彼此独立；组合发行的义务仅因纳入 Redis-derived native library 而触发，且不可通过工程拆分规避（PROJECT.md 不可妥协原则 #9）。

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -115,8 +115,14 @@ else
     # Check and setup sccache if available (normal builds)
     if command -v sccache &> /dev/null; then
         export RUSTC_WRAPPER=sccache
-        export CC="sccache cc"
-        export CXX="sccache c++"
+        case "$(uname -s 2>/dev/null || true)" in
+            MINGW*|MSYS*|CYGWIN*)
+                ;;
+            *)
+                export CC="${CC:-sccache cc}"
+                export CXX="${CXX:-sccache c++}"
+                ;;
+        esac
         # sccache doesn't support incremental compilation, so disable it
         export CARGO_INCREMENTAL=0
         unset CARGO_CACHE_RUSTC_INFO

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -115,6 +115,8 @@ else
     # Check and setup sccache if available (normal builds)
     if command -v sccache &> /dev/null; then
         export RUSTC_WRAPPER=sccache
+        export CC="sccache cc"
+        export CXX="sccache c++"
         # sccache doesn't support incremental compilation, so disable it
         export CARGO_INCREMENTAL=0
         unset CARGO_CACHE_RUSTC_INFO

--- a/scripts/tests/test-dev-sccache-env.sh
+++ b/scripts/tests/test-dev-sccache-env.sh
@@ -2,11 +2,14 @@
 
 # Copyright (c) 2024-present, arana-db Community.  All rights reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/scripts/tests/test-dev-sccache-env.sh
+++ b/scripts/tests/test-dev-sccache-env.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Regression coverage for PR #388: Git Bash must preserve MSVC compiler selection.
+
+case "${DEV_SCCACHE_TEST_HELPER:-}:$(basename "$0")" in
+    1:cargo)
+        printf '__TEST_CC__=%s\n' "${CC-<unset>}"
+        printf '__TEST_CXX__=%s\n' "${CXX-<unset>}"
+        exit 0
+        ;;
+    1:nproc)
+        printf '2\n'
+        exit 0
+        ;;
+    1:sccache)
+        exit 0
+        ;;
+    1:uname)
+        printf '%s\n' "$DEV_SCCACHE_TEST_UNAME"
+        exit 0
+        ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FAKE_BIN="$(mktemp -d)"
+trap 'rm -rf "$FAKE_BIN"' EXIT
+
+for command_name in cargo nproc sccache uname; do
+    ln -s "$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")" "$FAKE_BIN/$command_name"
+done
+
+run_case() {
+    local name=$1
+    local uname_value=$2
+    local initial_cc=$3
+    local initial_cxx=$4
+    local expected_cc=$5
+    local expected_cxx=$6
+    local output actual_cc actual_cxx
+
+    output=$(
+        if [[ $initial_cc == '<unset>' ]]; then
+            unset CC CXX
+        else
+            export CC="$initial_cc"
+            export CXX="$initial_cxx"
+        fi
+        export DEV_SCCACHE_TEST_HELPER=1
+        export DEV_SCCACHE_TEST_UNAME="$uname_value"
+        export PATH="$FAKE_BIN:$PATH"
+        cd "$REPO_ROOT"
+        sed 's/\r$//' scripts/dev.sh | bash -s -- check
+    )
+
+    actual_cc=$(printf '%s\n' "$output" | sed -n 's/^__TEST_CC__=//p')
+    actual_cxx=$(printf '%s\n' "$output" | sed -n 's/^__TEST_CXX__=//p')
+
+    if [[ $actual_cc != "$expected_cc" || $actual_cxx != "$expected_cxx" ]]; then
+        printf 'FAIL %s: expected CC=%s CXX=%s, got CC=%s CXX=%s\n' \
+            "$name" "$expected_cc" "$expected_cxx" "$actual_cc" "$actual_cxx" >&2
+        return 1
+    fi
+
+    printf 'PASS %s\n' "$name"
+}
+
+run_case mingw_does_not_force_gnu_compilers MINGW64_NT-10.0 '<unset>' '<unset>' '<unset>' '<unset>'
+run_case msys_does_not_force_gnu_compilers MSYS_NT-10.0 '<unset>' '<unset>' '<unset>' '<unset>'
+run_case cygwin_does_not_force_gnu_compilers CYGWIN_NT-10.0 '<unset>' '<unset>' '<unset>' '<unset>'
+run_case linux_wraps_default_compilers Linux '<unset>' '<unset>' 'sccache cc' 'sccache c++'
+run_case macos_wraps_default_compilers Darwin '<unset>' '<unset>' 'sccache cc' 'sccache c++'
+run_case linux_preserves_explicit_compilers Linux clang-18 clang++-18 clang-18 clang++-18
+run_case existing_wrappers_are_not_nested Linux 'sccache clang-18' 'sccache clang++-18' 'sccache clang-18' 'sccache clang++-18'


### PR DESCRIPTION
## 背景
审计发现 sccache 此前只包 rustc，而真正耗时的 librocksdb-sys C++ 编译经 cc crate 直调 gcc/clang，绕过了 RUSTC_WRAPPER，首编约 18 分钟无任何缓存。

## 改动
- **CI**：cargo-clippy 与 build-and-test 两 job 均新增 `Configure C/C++ compiler caching`（`CC=sccache cc` / `CXX=sccache c++`，Windows 跳过）；并把 `target/` 加入 Cargo 缓存 path。
- **dev.sh**：sccache 分支内追加 `CC`/`CXX` 包裹，本地开发同享加速。
- **docs**：新增 `prd.md` 与 `personas-and-user-stories.md`，由 `.planning/` 治理文档综合生成，补齐此前缺失的 PRD 单文档与用户画像。

## 验证
- `yaml.safe_load(ci.yml)` 合法；`bash -n dev.sh` 语法 OK。
- 待 CI 真编译确认 sccache 对 C/C++ 的命中率提升。

## 注意
- `kiwi-github/` 下存在与本项目无关的 C++ "quantclaw" CI，建议另行清理（治理噪音）。
- Windows 仍走 MSVC，未启用 sccache C/C++ 缓存（保持原行为）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive product requirements document covering goals, requirements, scope, acceptance criteria, milestones, and licensing boundaries.
  - Documented key terminal-user personas, user stories, requirement mappings, and stability gates.

- **Developer Experience**
  - Added compiler caching support to local development workflows and automated builds, helping reduce repeated build times when supported.

- **Chores**
  - Improved build-cache persistence for Rust compilation artifacts in continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->