### PR TITLE
feat(runtime-baseline): add frozen threshold module + verifier (#390)

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -39,7 +39,7 @@ header:
 
   paths-ignore:
     - '**/*.md'
-    - '*.json'
+    - '**/*.json'
     - 'LICENSE'
     - 'NOTICE'
     - 'Cargo.lock'

--- a/docs/performance/storage-runtime-baseline.md
+++ b/docs/performance/storage-runtime-baseline.md
@@ -1,0 +1,57 @@
+# Storage Runtime Baseline Harness
+
+本目录与 `tools/runtime-baseline` 一起，提供 kiwi storage 执行链路的性能与背压基线
+（对应 epic #347 → #350 → #351 → #352）。
+
+## 设计约束（必须守）
+
+- **冻结阈值只能来自固定 Linux/WSL 主机。** 设计规格明确禁止用 Windows / GitHub
+  hosted runner 的跑分数字冻结阈值——矩阵的可重现性依赖固定的内核、文件系统与
+  CPU 拓扑。因此本仓的 CI 只在固定 Linux 环境执行完整矩阵；本地/Windows 仅用于
+  开发迭代与 `cargo check` / `clippy` / `cargo test`。
+- **不在基线未稳前伪造数字。** `tools/runtime-baseline/src/thresholds.rs` 中的常量
+  当前为占位哨兵值（`f64::NAN` / `usize::MAX` / `u64::MAX` / `i64::MAX`），并标注
+  `TODO(#351)`。只要任一仍为占位值，`thresholds::all_frozen()` 返回 `false`，
+  `verify_outcome` 会据此把任何 case 判为 `NonPublishable`，杜绝「用占位值假装通过」。
+
+## 本次 PR 交付了什么（#390）
+
+建立 #351 量化验收门禁的**阈值冻结机制**本身：
+
+| 文件 | 作用 |
+|------|------|
+| `tools/runtime-baseline/src/thresholds.rs` | #351 验收所需的冻结基线阈值常量 + `all_frozen()` 哨兵检测 |
+| `tools/runtime-baseline/src/verify.rs` | `Outcome` 比对器：`verify_outcome` / `verify_outcome_path`，返回 `Publishable` / `NonPublishable` / `Fail` |
+| `tools/runtime-baseline/schema/outcome.schema.json` | verifier 期望的 outcome JSON 结构 |
+| 本文件 | 方法论与回填流程说明 |
+
+`verify.rs` 的单元测试 `placeholder_thresholds_make_every_case_non_publishable` 是「不伪造
+数字」的硬保证：占位状态下任何真实数值都判 `NonPublishable`。
+
+## 为什么 observer 接线与真实数字是 follow-up
+
+- **Wiring & Smoke（Tasks 6–12）**：把 `baseline` observer 状态机接入 `runtime` crate 的
+  `manager` / `message` / `storage_server` 生产路径，并实现 harness 运行时、控制面、Python
+  控制器与 `cases.yaml`。这部分改动进入 `src/common/runtime/`，会拉入 `storage` → `rocksdb`，
+  必须在能编译/运行 RocksDB 的环境验证——因此作为独立 PR 在 Linux 主机推进。
+- **Baseline Results（真实数字冻结）**：在固定 Linux/WSL 主机按版本化 `cases.yaml` 跑完整
+  矩阵后，把真实数值回填进 `thresholds.rs`，再让 verifier 全量判 `Publishable`。仅此 PR 验收
+  通过后才关闭 #350。
+
+## 未来回填流程
+
+1. 固定 Linux/WSL 主机，按版本化 `cases.yaml` 跑完整矩阵（基础吞吐 + value 变体 + 单因素扫描
+   + offered-load 4 档 + lifecycle 3 类；每 case 重复 5 次、CV<=5%）。
+2. 将实测值回填 `thresholds.rs`（替换 `TODO(#351)` 占位）。
+3. `python3 tools/runtime-baseline/run_baseline.py verify ...` 跑 `verify_outcome` 全量
+   判 `Publishable`。
+4. 提交原始 JSON/CSV + 环境清单（内核、CPU、文件系统）+ 摘要；冻结 #351 量化验收阈值。
+5. 关闭 #350。
+
+## 本地验证（不依赖 RocksDB）
+
+```bash
+cargo check   -p runtime-baseline
+cargo test    -p runtime-baseline
+cargo clippy  -p runtime-baseline --all-targets -- -D warnings -D clippy::unwrap_used
+```

--- a/docs/performance/storage-runtime-baseline.md
+++ b/docs/performance/storage-runtime-baseline.md
@@ -7,26 +7,27 @@
 
 - **冻结阈值只能来自固定 Linux/WSL 主机。** 设计规格明确禁止用 Windows / GitHub
   hosted runner 的跑分数字冻结阈值——矩阵的可重现性依赖固定的内核、文件系统与
-  CPU 拓扑。因此本仓的 CI 只在固定 Linux 环境执行完整矩阵；本地/Windows 仅用于
-  开发迭代与 `cargo check` / `clippy` / `cargo test`。
+  CPU 拓扑。当前 hosted CI 只编译 harness 并执行代码检查；完整矩阵未来只能通过
+  `workflow_dispatch` 在固定环境运行，或由维护者在规定的固定 Linux/WSL 主机执行。
 - **不在基线未稳前伪造数字。** `tools/runtime-baseline/src/thresholds.rs` 中的常量
   当前为占位哨兵值（`f64::NAN` / `usize::MAX` / `u64::MAX` / `i64::MAX`），并标注
   `TODO(#351)`。只要任一仍为占位值，`thresholds::all_frozen()` 返回 `false`，
-  `verify_outcome` 会据此把任何 case 判为 `NonPublishable`，杜绝「用占位值假装通过」。
+  `verify_outcome` 会据此返回 `PolicyUnavailable`，杜绝「用占位值假装通过」。
 
-## 本次 PR 交付了什么（#390）
+## 本次 PR 的准备工作（Refs #390）
 
 建立 #351 量化验收门禁的**阈值冻结机制**本身：
 
 | 文件 | 作用 |
 |------|------|
 | `tools/runtime-baseline/src/thresholds.rs` | #351 验收所需的冻结基线阈值常量 + `all_frozen()` 哨兵检测 |
-| `tools/runtime-baseline/src/verify.rs` | `Outcome` 比对器：`verify_outcome` / `verify_outcome_path`，返回 `Publishable` / `NonPublishable` / `Fail` |
-| `tools/runtime-baseline/schema/outcome.schema.json` | verifier 期望的 outcome JSON 结构 |
+| `tools/runtime-baseline/src/verify.rs` | 严格的单 case threshold checker；返回 `Pass` / `PolicyUnavailable` / `Fail` |
+| `tools/runtime-baseline/schema/outcome.schema.json` | 单 case threshold input 的 JSON Schema 2020-12 合同 |
 | 本文件 | 方法论与回填流程说明 |
 
-`verify.rs` 的单元测试 `placeholder_thresholds_make_every_case_non_publishable` 是「不伪造
-数字」的硬保证：占位状态下任何真实数值都判 `NonPublishable`。
+单 case 的 `Pass` 只证明该 case 满足冻结阈值，不代表完整 baseline run 可发布。最终发布
+结论还必须由 controller verifier 核对 manifest case 集守恒、重复轮次、CV、来源身份和
+完整 run outcome。占位状态下 checker 只返回 `PolicyUnavailable`。
 
 ## 为什么 observer 接线与真实数字是 follow-up
 
@@ -35,18 +36,19 @@
   控制器与 `cases.yaml`。这部分改动进入 `src/common/runtime/`，会拉入 `storage` → `rocksdb`，
   必须在能编译/运行 RocksDB 的环境验证——因此作为独立 PR 在 Linux 主机推进。
 - **Baseline Results（真实数字冻结）**：在固定 Linux/WSL 主机按版本化 `cases.yaml` 跑完整
-  矩阵后，把真实数值回填进 `thresholds.rs`，再让 verifier 全量判 `Publishable`。仅此 PR 验收
-  通过后才关闭 #350。
+  矩阵后，把真实数值回填进 `thresholds.rs`，再由完整 verifier 聚合全部 case、稳定性和
+  provenance 证据。只有原始结果、报告和真实阈值满足 #390 Acceptance 后才关闭 #390。
 
 ## 未来回填流程
 
 1. 固定 Linux/WSL 主机，按版本化 `cases.yaml` 跑完整矩阵（基础吞吐 + value 变体 + 单因素扫描
-   + offered-load 4 档 + lifecycle 3 类；每 case 重复 5 次、CV<=5%）。
+   + offered-load 4 档 + lifecycle 3 类；性能 case 重复 5 次、lifecycle case 重复 3 次，
+   CV<=5%）。
 2. 将实测值回填 `thresholds.rs`（替换 `TODO(#351)` 占位）。
-3. `python3 tools/runtime-baseline/run_baseline.py verify ...` 跑 `verify_outcome` 全量
-   判 `Publishable`。
+3. 由后续 `run_baseline.py verify` 对每个 case 执行 threshold check，并核对完整 case 集、
+   重复轮次、CV 和来源身份后产生 run 级发布结论。
 4. 提交原始 JSON/CSV + 环境清单（内核、CPU、文件系统）+ 摘要；冻结 #351 量化验收阈值。
-5. 关闭 #350。
+5. 满足 #390 Acceptance 后关闭 #390，并在 #350 / #351 中引用结果。
 
 ## 本地验证（不依赖 RocksDB）
 

--- a/tools/runtime-baseline/schema/outcome.schema.json
+++ b/tools/runtime-baseline/schema/outcome.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "Baseline Results PR 回填真实数字、且 thresholds.rs 全部常量脱离占位哨兵值后，outcome 才可 publishable。本 schema 描述 verifier (src/verify.rs) 期望的 outcome 结构；verifier 使用 serde 反序列化，容忍未知字段以便前向兼容。",
+  "title": "BaselineOutcome",
+  "type": "object",
+  "required": [
+    "case_id",
+    "qps",
+    "p99_ms",
+    "max_latency_ms",
+    "error_rate",
+    "queued_plus_running_max"
+  ],
+  "properties": {
+    "case_id": { "type": "string" },
+    "qps": { "type": "number" },
+    "p99_ms": { "type": "number" },
+    "max_latency_ms": { "type": "number" },
+    "error_rate": { "type": "number" },
+    "overload_120pct_error_rate": { "type": "number" },
+    "queued_plus_running_max": { "type": "integer" },
+    "storage_gate_pause_ms": { "type": "integer" },
+    "storage_gate_resume_drain_ms": { "type": "integer" },
+    "shutdown_drain_ms": { "type": "integer" },
+    "slow_storage_new_conn_ms": { "type": "integer" },
+    "slow_storage_ping_ms": { "type": "integer" },
+    "cpu_change_ratio": { "type": "number" },
+    "rss_change_ratio": { "type": "number" },
+    "threads_delta": { "type": "integer" }
+  }
+}

--- a/tools/runtime-baseline/schema/outcome.schema.json
+++ b/tools/runtime-baseline/schema/outcome.schema.json
@@ -1,31 +1,173 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$comment": "Baseline Results PR 回填真实数字、且 thresholds.rs 全部常量脱离占位哨兵值后，outcome 才可 publishable。本 schema 描述 verifier (src/verify.rs) 期望的 outcome 结构；verifier 使用 serde 反序列化，容忍未知字段以便前向兼容。",
-  "title": "BaselineOutcome",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://arana-db.github.io/kiwi/schemas/runtime-baseline/threshold-outcome.schema.json",
+  "title": "RuntimeBaselineThresholdOutcome",
+  "description": "Strict input for one case threshold check. A passing case is not a publishable baseline run.",
   "type": "object",
+  "additionalProperties": false,
   "required": [
     "case_id",
     "qps",
     "p99_ms",
     "max_latency_ms",
     "error_rate",
-    "queued_plus_running_max"
+    "queued_plus_running_max",
+    "cpu_change_ratio",
+    "rss_change_ratio",
+    "threads_delta",
+    "case"
   ],
   "properties": {
-    "case_id": { "type": "string" },
-    "qps": { "type": "number" },
-    "p99_ms": { "type": "number" },
-    "max_latency_ms": { "type": "number" },
-    "error_rate": { "type": "number" },
-    "overload_120pct_error_rate": { "type": "number" },
-    "queued_plus_running_max": { "type": "integer" },
-    "storage_gate_pause_ms": { "type": "integer" },
-    "storage_gate_resume_drain_ms": { "type": "integer" },
-    "shutdown_drain_ms": { "type": "integer" },
-    "slow_storage_new_conn_ms": { "type": "integer" },
-    "slow_storage_ping_ms": { "type": "integer" },
-    "cpu_change_ratio": { "type": "number" },
-    "rss_change_ratio": { "type": "number" },
-    "threads_delta": { "type": "integer" }
+    "case_id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": ".*\\S.*"
+    },
+    "qps": {
+      "type": "number",
+      "minimum": 0
+    },
+    "p99_ms": {
+      "type": "number",
+      "minimum": 0
+    },
+    "max_latency_ms": {
+      "type": "number",
+      "minimum": 0
+    },
+    "error_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "queued_plus_running_max": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "cpu_change_ratio": {
+      "type": "number",
+      "minimum": -1
+    },
+    "rss_change_ratio": {
+      "type": "number",
+      "minimum": -1
+    },
+    "threads_delta": {
+      "type": "integer"
+    },
+    "case": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "anchor_qps",
+            "anchor_p99_ms",
+            "anchor_max_latency_ms"
+          ],
+          "properties": {
+            "kind": {
+              "const": "normal_load"
+            },
+            "anchor_qps": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "anchor_p99_ms": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "anchor_max_latency_ms": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "error_kinds"
+          ],
+          "properties": {
+            "kind": {
+              "const": "overload_120pct"
+            },
+            "error_kinds": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^\\S(?:.*\\S)?$"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "pause_ms",
+            "resume_drain_ms"
+          ],
+          "properties": {
+            "kind": {
+              "const": "storage_gate"
+            },
+            "pause_ms": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "resume_drain_ms": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "drain_ms"
+          ],
+          "properties": {
+            "kind": {
+              "const": "shutdown"
+            },
+            "drain_ms": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "new_conn_ms",
+            "ping_ms"
+          ],
+          "properties": {
+            "kind": {
+              "const": "slow_storage"
+            },
+            "new_conn_ms": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "ping_ms": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        }
+      ]
+    }
   }
 }

--- a/tools/runtime-baseline/src/lib.rs
+++ b/tools/runtime-baseline/src/lib.rs
@@ -18,3 +18,5 @@
 pub mod cli;
 pub mod schema;
 pub mod startup;
+pub mod thresholds;
+pub mod verify;

--- a/tools/runtime-baseline/src/thresholds.rs
+++ b/tools/runtime-baseline/src/thresholds.rs
@@ -18,15 +18,16 @@
 //! 冻结基线阈值（#351 量化验收）。
 //!
 //! 本模块当前为「方法论冻结 + 占位」。真实数值只能在固定 Linux/WSL 主机上，
-//! 按版本化的 `cases.yaml` 跑完整测量矩阵（每 case 重复 5 次、CV<=5%）后回填。
+//! 按版本化的 `cases.yaml` 跑完整测量矩阵（性能 case 重复 5 次、lifecycle case 重复
+//! 3 次、CV<=5%）后回填。
 //!
 //! **严禁在本文件硬编码猜测值。** 设计规格明确禁止用 Windows / GitHub hosted
-//! runner 的数字冻结阈值——本仓库的 CI 也只应在固定 Linux 环境执行完整矩阵。
+//! runner 的数字冻结阈值——完整矩阵未来也只能在固定 Linux 环境执行。
 //! 任一常量仍处于占位哨兵值（`f64::NAN` / `usize::MAX` / `u64::MAX` / `i64::MAX`）
-//! 时，`all_frozen()` 返回 false，verifier 会据此判该 case 为 `NonPublishable`，
-//! 从而杜绝「用占位值假装通过」。
+//! 时，`all_frozen()` 返回 false，checker 会据此返回 `PolicyUnavailable`，从而杜绝
+//! 「用占位值假装通过」。
 
-#![allow(dead_code)]
+use std::collections::BTreeSet;
 
 /// 正常负载吞吐允许回退比例（相对 anchor case，例如 0.10 = 允许回退 10%）。
 pub const NORMAL_LOAD_THROUGHPUT_MAX_REGRESSION_RATIO: f64 = f64::NAN; // TODO(#351): 固定 Linux 实测回填
@@ -40,7 +41,7 @@ pub const NORMAL_LOAD_MAX_ERROR_RATE: f64 = f64::NAN; // TODO(#351)
 
 /// 120% offered load 下允许的错误率上限与允许的错误类别。
 pub const OVERLOAD_120PCT_MAX_ERROR_RATE: f64 = f64::NAN; // TODO(#351)
-pub const OVERLOAD_120PCT_ALLOWED_ERROR_KINDS: &[&str] = &["command_error"]; // TODO(#351): 实测确认
+pub const OVERLOAD_120PCT_ALLOWED_ERROR_KINDS: &[&str] = &[]; // TODO(#351): 实测确认
 
 /// queued + running 最大允许值（“最大 pending 阈值”，与 HealthThresholds.max_pending_requests 不同）。
 pub const MAX_QUEUED_PLUS_RUNNING: usize = usize::MAX; // TODO(#351): 固定 Linux 实测回填
@@ -59,23 +60,164 @@ pub const CPU_ALLOWED_CHANGE_RATIO: f64 = f64::NAN; // TODO(#351)
 pub const RSS_ALLOWED_CHANGE_RATIO: f64 = f64::NAN; // TODO(#351)
 pub const THREADS_ALLOWED_DELTA: i64 = i64::MAX; // TODO(#351)
 
+/// 一组已经冻结且通过范围校验的单 case 阈值。
+#[derive(Debug, Clone, PartialEq)]
+pub struct ThresholdPolicy {
+    pub normal_load_throughput_max_regression_ratio: f64,
+    pub p99_max_latency_allowed_change_ratio: f64,
+    pub max_latency_allowed_change_ratio: f64,
+    pub normal_load_max_error_rate: f64,
+    pub overload_120pct_max_error_rate: f64,
+    pub overload_120pct_allowed_error_kinds: Vec<String>,
+    pub max_queued_plus_running: usize,
+    pub storage_gate_pause_max_ms: u64,
+    pub storage_gate_resume_drain_max_ms: u64,
+    pub shutdown_drain_max_ms: u64,
+    pub slow_storage_new_conn_max_ms: u64,
+    pub slow_storage_ping_max_ms: u64,
+    pub cpu_allowed_change_ratio: f64,
+    pub rss_allowed_change_ratio: f64,
+    pub threads_allowed_delta: i64,
+}
+
+impl ThresholdPolicy {
+    /// 从编译期常量构造策略；占位值或无效范围都会阻止策略可用。
+    pub fn from_frozen_constants() -> Result<Self, Vec<String>> {
+        let policy = Self {
+            normal_load_throughput_max_regression_ratio:
+                NORMAL_LOAD_THROUGHPUT_MAX_REGRESSION_RATIO,
+            p99_max_latency_allowed_change_ratio: P99_MAX_LATENCY_ALLOWED_CHANGE_RATIO,
+            max_latency_allowed_change_ratio: MAX_LATENCY_ALLOWED_CHANGE_RATIO,
+            normal_load_max_error_rate: NORMAL_LOAD_MAX_ERROR_RATE,
+            overload_120pct_max_error_rate: OVERLOAD_120PCT_MAX_ERROR_RATE,
+            overload_120pct_allowed_error_kinds: OVERLOAD_120PCT_ALLOWED_ERROR_KINDS
+                .iter()
+                .map(|kind| (*kind).to_string())
+                .collect(),
+            max_queued_plus_running: MAX_QUEUED_PLUS_RUNNING,
+            storage_gate_pause_max_ms: STORAGE_GATE_PAUSE_MAX_MS,
+            storage_gate_resume_drain_max_ms: STORAGE_GATE_RESUME_DRAIN_MAX_MS,
+            shutdown_drain_max_ms: SHUTDOWN_DRAIN_MAX_MS,
+            slow_storage_new_conn_max_ms: SLOW_STORAGE_NEW_CONN_MAX_MS,
+            slow_storage_ping_max_ms: SLOW_STORAGE_PING_MAX_MS,
+            cpu_allowed_change_ratio: CPU_ALLOWED_CHANGE_RATIO,
+            rss_allowed_change_ratio: RSS_ALLOWED_CHANGE_RATIO,
+            threads_allowed_delta: THREADS_ALLOWED_DELTA,
+        };
+        policy.validate()?;
+        Ok(policy)
+    }
+
+    /// 拒绝哨兵、非有限数、负阈值、非法错误率和未冻结的错误类别。
+    pub fn validate(&self) -> Result<(), Vec<String>> {
+        let mut reasons = Vec::new();
+        validate_ratio(
+            "normal_load_throughput_max_regression_ratio",
+            self.normal_load_throughput_max_regression_ratio,
+            Some(1.0),
+            &mut reasons,
+        );
+        validate_ratio(
+            "p99_max_latency_allowed_change_ratio",
+            self.p99_max_latency_allowed_change_ratio,
+            None,
+            &mut reasons,
+        );
+        validate_ratio(
+            "max_latency_allowed_change_ratio",
+            self.max_latency_allowed_change_ratio,
+            None,
+            &mut reasons,
+        );
+        validate_ratio(
+            "normal_load_max_error_rate",
+            self.normal_load_max_error_rate,
+            Some(1.0),
+            &mut reasons,
+        );
+        validate_ratio(
+            "overload_120pct_max_error_rate",
+            self.overload_120pct_max_error_rate,
+            Some(1.0),
+            &mut reasons,
+        );
+        validate_ratio(
+            "cpu_allowed_change_ratio",
+            self.cpu_allowed_change_ratio,
+            None,
+            &mut reasons,
+        );
+        validate_ratio(
+            "rss_allowed_change_ratio",
+            self.rss_allowed_change_ratio,
+            None,
+            &mut reasons,
+        );
+
+        if self.max_queued_plus_running == usize::MAX {
+            reasons.push("max_queued_plus_running is still a placeholder".to_string());
+        }
+        for (name, value) in [
+            ("storage_gate_pause_max_ms", self.storage_gate_pause_max_ms),
+            (
+                "storage_gate_resume_drain_max_ms",
+                self.storage_gate_resume_drain_max_ms,
+            ),
+            ("shutdown_drain_max_ms", self.shutdown_drain_max_ms),
+            (
+                "slow_storage_new_conn_max_ms",
+                self.slow_storage_new_conn_max_ms,
+            ),
+            ("slow_storage_ping_max_ms", self.slow_storage_ping_max_ms),
+        ] {
+            if value == u64::MAX {
+                reasons.push(format!("{name} is still a placeholder"));
+            }
+        }
+        if self.threads_allowed_delta < 0 || self.threads_allowed_delta == i64::MAX {
+            reasons.push("threads_allowed_delta must be frozen and non-negative".to_string());
+        }
+
+        if self.overload_120pct_allowed_error_kinds.is_empty() {
+            reasons.push("overload_120pct_allowed_error_kinds is not frozen".to_string());
+        } else {
+            let mut unique = BTreeSet::new();
+            for kind in &self.overload_120pct_allowed_error_kinds {
+                let normalized = kind.trim();
+                if normalized.is_empty() {
+                    reasons
+                        .push("overload error kinds must not contain an empty value".to_string());
+                } else if normalized != kind {
+                    reasons.push(
+                        "overload error kinds must not contain leading or trailing whitespace"
+                            .to_string(),
+                    );
+                } else if !unique.insert(normalized) {
+                    reasons.push(format!("duplicate overload error kind: {normalized}"));
+                }
+            }
+        }
+
+        if reasons.is_empty() {
+            Ok(())
+        } else {
+            Err(reasons)
+        }
+    }
+}
+
+fn validate_ratio(name: &str, value: f64, maximum: Option<f64>, reasons: &mut Vec<String>) {
+    if !value.is_finite() || value < 0.0 {
+        reasons.push(format!("{name} must be finite and non-negative"));
+    } else if let Some(limit) = maximum.filter(|limit| value > *limit) {
+        reasons.push(format!("{name} must not exceed {limit}"));
+    }
+}
+
 /// 所有阈值均已回填（非占位）才返回 true；任一仍为占位哨兵值则 false。
 ///
-/// verifier 依赖此函数判断「当前是否具备可发布的真实基线」——只要还有占位值，
-/// 任何 case 都应判为 `NonPublishable`，防止用哨兵值假装通过。
+/// checker 依赖此函数判断「当前是否具备可比较的真实阈值」；只要还有占位值，
+/// 策略就不可用，防止用哨兵值假装通过。
 pub fn all_frozen() -> bool {
-    MAX_QUEUED_PLUS_RUNNING != usize::MAX
-        && STORAGE_GATE_PAUSE_MAX_MS != u64::MAX
-        && STORAGE_GATE_RESUME_DRAIN_MAX_MS != u64::MAX
-        && SHUTDOWN_DRAIN_MAX_MS != u64::MAX
-        && SLOW_STORAGE_NEW_CONN_MAX_MS != u64::MAX
-        && SLOW_STORAGE_PING_MAX_MS != u64::MAX
-        && THREADS_ALLOWED_DELTA != i64::MAX
-        && !NORMAL_LOAD_THROUGHPUT_MAX_REGRESSION_RATIO.is_nan()
-        && !P99_MAX_LATENCY_ALLOWED_CHANGE_RATIO.is_nan()
-        && !MAX_LATENCY_ALLOWED_CHANGE_RATIO.is_nan()
-        && !NORMAL_LOAD_MAX_ERROR_RATE.is_nan()
-        && !OVERLOAD_120PCT_MAX_ERROR_RATE.is_nan()
-        && !CPU_ALLOWED_CHANGE_RATIO.is_nan()
-        && !RSS_ALLOWED_CHANGE_RATIO.is_nan()
+    ThresholdPolicy::from_frozen_constants().is_ok()
 }

--- a/tools/runtime-baseline/src/thresholds.rs
+++ b/tools/runtime-baseline/src/thresholds.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! 冻结基线阈值（#351 量化验收）。
+//!
+//! 本模块当前为「方法论冻结 + 占位」。真实数值只能在固定 Linux/WSL 主机上，
+//! 按版本化的 `cases.yaml` 跑完整测量矩阵（每 case 重复 5 次、CV<=5%）后回填。
+//!
+//! **严禁在本文件硬编码猜测值。** 设计规格明确禁止用 Windows / GitHub hosted
+//! runner 的数字冻结阈值——本仓库的 CI 也只应在固定 Linux 环境执行完整矩阵。
+//! 任一常量仍处于占位哨兵值（`f64::NAN` / `usize::MAX` / `u64::MAX` / `i64::MAX`）
+//! 时，`all_frozen()` 返回 false，verifier 会据此判该 case 为 `NonPublishable`，
+//! 从而杜绝「用占位值假装通过」。
+
+#![allow(dead_code)]
+
+/// 正常负载吞吐允许回退比例（相对 anchor case，例如 0.10 = 允许回退 10%）。
+pub const NORMAL_LOAD_THROUGHPUT_MAX_REGRESSION_RATIO: f64 = f64::NAN; // TODO(#351): 固定 Linux 实测回填
+
+/// P99 与 max latency 允许变化（相对 anchor，比例）。
+pub const P99_MAX_LATENCY_ALLOWED_CHANGE_RATIO: f64 = f64::NAN; // TODO(#351)
+pub const MAX_LATENCY_ALLOWED_CHANGE_RATIO: f64 = f64::NAN; // TODO(#351)
+
+/// 正常负载错误率上限（小数，例如 0.001 = 0.1%）。
+pub const NORMAL_LOAD_MAX_ERROR_RATE: f64 = f64::NAN; // TODO(#351)
+
+/// 120% offered load 下允许的错误率上限与允许的错误类别。
+pub const OVERLOAD_120PCT_MAX_ERROR_RATE: f64 = f64::NAN; // TODO(#351)
+pub const OVERLOAD_120PCT_ALLOWED_ERROR_KINDS: &[&str] = &["command_error"]; // TODO(#351): 实测确认
+
+/// queued + running 最大允许值（“最大 pending 阈值”，与 HealthThresholds.max_pending_requests 不同）。
+pub const MAX_QUEUED_PLUS_RUNNING: usize = usize::MAX; // TODO(#351): 固定 Linux 实测回填
+
+/// storage-gate pause/drain 与 shutdown 最大耗时（毫秒）。
+pub const STORAGE_GATE_PAUSE_MAX_MS: u64 = u64::MAX; // TODO(#351)
+pub const STORAGE_GATE_RESUME_DRAIN_MAX_MS: u64 = u64::MAX; // TODO(#351)
+pub const SHUTDOWN_DRAIN_MAX_MS: u64 = u64::MAX; // TODO(#351)
+
+/// 慢存储时新连接建立与 PING 的最大延迟（毫秒）。
+pub const SLOW_STORAGE_NEW_CONN_MAX_MS: u64 = u64::MAX; // TODO(#351)
+pub const SLOW_STORAGE_PING_MAX_MS: u64 = u64::MAX; // TODO(#351)
+
+/// 资源允许变化（绝对值或比例，按实测约定）。
+pub const CPU_ALLOWED_CHANGE_RATIO: f64 = f64::NAN; // TODO(#351)
+pub const RSS_ALLOWED_CHANGE_RATIO: f64 = f64::NAN; // TODO(#351)
+pub const THREADS_ALLOWED_DELTA: i64 = i64::MAX; // TODO(#351)
+
+/// 所有阈值均已回填（非占位）才返回 true；任一仍为占位哨兵值则 false。
+///
+/// verifier 依赖此函数判断「当前是否具备可发布的真实基线」——只要还有占位值，
+/// 任何 case 都应判为 `NonPublishable`，防止用哨兵值假装通过。
+pub fn all_frozen() -> bool {
+    MAX_QUEUED_PLUS_RUNNING != usize::MAX
+        && STORAGE_GATE_PAUSE_MAX_MS != u64::MAX
+        && STORAGE_GATE_RESUME_DRAIN_MAX_MS != u64::MAX
+        && SHUTDOWN_DRAIN_MAX_MS != u64::MAX
+        && SLOW_STORAGE_NEW_CONN_MAX_MS != u64::MAX
+        && SLOW_STORAGE_PING_MAX_MS != u64::MAX
+        && THREADS_ALLOWED_DELTA != i64::MAX
+        && !NORMAL_LOAD_THROUGHPUT_MAX_REGRESSION_RATIO.is_nan()
+        && !P99_MAX_LATENCY_ALLOWED_CHANGE_RATIO.is_nan()
+        && !MAX_LATENCY_ALLOWED_CHANGE_RATIO.is_nan()
+        && !NORMAL_LOAD_MAX_ERROR_RATE.is_nan()
+        && !OVERLOAD_120PCT_MAX_ERROR_RATE.is_nan()
+        && !CPU_ALLOWED_CHANGE_RATIO.is_nan()
+        && !RSS_ALLOWED_CHANGE_RATIO.is_nan()
+}

--- a/tools/runtime-baseline/src/verify.rs
+++ b/tools/runtime-baseline/src/verify.rs
@@ -15,186 +15,632 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Outcome 比对器：把单次基线测量结果与 [`crate::thresholds`] 中冻结的阈值逐一对比，
-//! 判定该 case 是否 `Publishable` / `NonPublishable` / `Fail`。
+//! 单 case 阈值检查器：把一次基线测量与 [`crate::thresholds`] 中的冻结策略逐项对比。
 //!
-//! 在阈值尚未回填（仍为占位哨兵值）时，任何 case 都判为 `NonPublishable`——
-//! 这是「不伪造数字」的硬保证：占位值绝不能被当成通过阈值。
+//! `Pass` 只表示该 case 满足阈值；完整 run 的 case 守恒、重复轮次、CV 和来源身份必须
+//! 由后续 controller verifier 组合后才能产生发布结论。阈值仍为占位值时策略不可用。
 
-use std::path::Path;
+use std::{collections::BTreeSet, path::Path};
 
 use anyhow::Context as _;
 use serde::Deserialize;
 
-use crate::thresholds;
+use crate::thresholds::ThresholdPolicy;
+
+/// 面向外部结果生产者的单 case JSON Schema。
+pub const OUTCOME_SCHEMA: &str = include_str!("../schema/outcome.schema.json");
 
 /// 单次基线场景的测量结果（由控制器在固定 Linux/WSL 主机上采集后写出）。
 ///
-/// 字段允许前向兼容（不强制 `deny_unknown_fields`），未来扩展指标时旧 verifier 仍可解析。
+/// 本类型只描述阈值检查输入，不代表完整 baseline run 的发布合同。
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Outcome {
     pub case_id: String,
     pub qps: f64,
     pub p99_ms: f64,
     pub max_latency_ms: f64,
     pub error_rate: f64,
-    #[serde(default)]
-    pub overload_120pct_error_rate: Option<f64>,
     pub queued_plus_running_max: usize,
-    #[serde(default)]
-    pub storage_gate_pause_ms: Option<u64>,
-    #[serde(default)]
-    pub storage_gate_resume_drain_ms: Option<u64>,
-    #[serde(default)]
-    pub shutdown_drain_ms: Option<u64>,
-    #[serde(default)]
-    pub slow_storage_new_conn_ms: Option<u64>,
-    #[serde(default)]
-    pub slow_storage_ping_ms: Option<u64>,
-    #[serde(default)]
-    pub cpu_change_ratio: Option<f64>,
-    #[serde(default)]
-    pub rss_change_ratio: Option<f64>,
-    #[serde(default)]
-    pub threads_delta: Option<i64>,
+    pub cpu_change_ratio: f64,
+    pub rss_change_ratio: f64,
+    pub threads_delta: i64,
+    pub case: CaseMetrics,
 }
 
-/// 单个 case 的验证结论。
+/// 每类 case 必须提供的专属指标。
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum CaseMetrics {
+    NormalLoad {
+        anchor_qps: f64,
+        anchor_p99_ms: f64,
+        anchor_max_latency_ms: f64,
+    },
+    #[serde(rename = "overload_120pct")]
+    Overload120pct {
+        error_kinds: Vec<String>,
+    },
+    StorageGate {
+        pause_ms: u64,
+        resume_drain_ms: u64,
+    },
+    Shutdown {
+        drain_ms: u64,
+    },
+    SlowStorage {
+        new_conn_ms: u64,
+        ping_ms: u64,
+    },
+}
+
+/// 单 case 阈值检查结果；`Pass` 不代表完整 baseline run 可发布。
 #[derive(Debug, PartialEq, Eq)]
-pub enum VerifyStatus {
-    /// 阈值已全部回填且本 case 满足全部阈值。
-    Publishable,
-    /// 阈值尚未回填（仍是占位哨兵值），本 case 不可发布。
-    NonPublishable,
-    /// 阈值已回填，但本 case 超出某项阈值。
-    Fail(String),
+pub enum ThresholdCheck {
+    Pass,
+    PolicyUnavailable(Vec<String>),
+    Fail(Vec<String>),
 }
 
-/// 把占位哨兵值归一为 `None`：只有真正回填的阈值才参与判定。
-fn frozen_u64(v: u64) -> Option<u64> {
-    if v == u64::MAX {
-        None
+/// 使用编译期冻结策略检查单个 case。
+pub fn verify_outcome(outcome: &Outcome) -> ThresholdCheck {
+    let input_reasons = validate_outcome(outcome);
+    if !input_reasons.is_empty() {
+        return ThresholdCheck::Fail(input_reasons);
+    }
+
+    match ThresholdPolicy::from_frozen_constants() {
+        Ok(policy) => verify_outcome_with_policy(outcome, &policy),
+        Err(reasons) => ThresholdCheck::PolicyUnavailable(reasons),
+    }
+}
+
+/// 使用显式策略检查单个 case，供测试和后续 controller 组合使用。
+pub fn verify_outcome_with_policy(outcome: &Outcome, policy: &ThresholdPolicy) -> ThresholdCheck {
+    let input_reasons = validate_outcome(outcome);
+    if !input_reasons.is_empty() {
+        return ThresholdCheck::Fail(input_reasons);
+    }
+
+    if let Err(reasons) = policy.validate() {
+        return ThresholdCheck::PolicyUnavailable(reasons);
+    }
+
+    let mut reasons = Vec::new();
+    if outcome.queued_plus_running_max > policy.max_queued_plus_running {
+        reasons.push(format!(
+            "queued plus running {} exceeds {}",
+            outcome.queued_plus_running_max, policy.max_queued_plus_running
+        ));
+    }
+    if outcome.cpu_change_ratio.abs() > policy.cpu_allowed_change_ratio {
+        reasons.push(format!(
+            "CPU change {} exceeds +/-{}",
+            outcome.cpu_change_ratio, policy.cpu_allowed_change_ratio
+        ));
+    }
+    if outcome.rss_change_ratio.abs() > policy.rss_allowed_change_ratio {
+        reasons.push(format!(
+            "RSS change {} exceeds +/-{}",
+            outcome.rss_change_ratio, policy.rss_allowed_change_ratio
+        ));
+    }
+    if outcome.threads_delta.unsigned_abs() > policy.threads_allowed_delta as u64 {
+        reasons.push(format!(
+            "thread delta {} exceeds +/-{}",
+            outcome.threads_delta, policy.threads_allowed_delta
+        ));
+    }
+
+    match &outcome.case {
+        CaseMetrics::NormalLoad {
+            anchor_qps,
+            anchor_p99_ms,
+            anchor_max_latency_ms,
+        } => {
+            let throughput_regression = (anchor_qps - outcome.qps) / anchor_qps;
+            if throughput_regression > policy.normal_load_throughput_max_regression_ratio {
+                reasons.push(format!(
+                    "throughput regression {throughput_regression} exceeds {}",
+                    policy.normal_load_throughput_max_regression_ratio
+                ));
+            }
+            let p99_change = (outcome.p99_ms - anchor_p99_ms) / anchor_p99_ms;
+            if p99_change > policy.p99_max_latency_allowed_change_ratio {
+                reasons.push(format!(
+                    "p99 change {p99_change} exceeds {}",
+                    policy.p99_max_latency_allowed_change_ratio
+                ));
+            }
+            let max_latency_change =
+                (outcome.max_latency_ms - anchor_max_latency_ms) / anchor_max_latency_ms;
+            if max_latency_change > policy.max_latency_allowed_change_ratio {
+                reasons.push(format!(
+                    "max latency change {max_latency_change} exceeds {}",
+                    policy.max_latency_allowed_change_ratio
+                ));
+            }
+            if outcome.error_rate > policy.normal_load_max_error_rate {
+                reasons.push(format!(
+                    "normal error rate {} exceeds {}",
+                    outcome.error_rate, policy.normal_load_max_error_rate
+                ));
+            }
+        }
+        CaseMetrics::Overload120pct { error_kinds } => {
+            if outcome.error_rate > policy.overload_120pct_max_error_rate {
+                reasons.push(format!(
+                    "overload error rate {} exceeds {}",
+                    outcome.error_rate, policy.overload_120pct_max_error_rate
+                ));
+            }
+            for kind in error_kinds {
+                if !policy
+                    .overload_120pct_allowed_error_kinds
+                    .iter()
+                    .any(|allowed| allowed == kind)
+                {
+                    reasons.push(format!("error kind {kind:?} is not allowed under overload"));
+                }
+            }
+        }
+        CaseMetrics::StorageGate {
+            pause_ms,
+            resume_drain_ms,
+        } => {
+            if *pause_ms > policy.storage_gate_pause_max_ms {
+                reasons.push(format!(
+                    "storage gate pause {pause_ms} ms exceeds {} ms",
+                    policy.storage_gate_pause_max_ms
+                ));
+            }
+            if *resume_drain_ms > policy.storage_gate_resume_drain_max_ms {
+                reasons.push(format!(
+                    "storage gate resume drain {resume_drain_ms} ms exceeds {} ms",
+                    policy.storage_gate_resume_drain_max_ms
+                ));
+            }
+        }
+        CaseMetrics::Shutdown { drain_ms } => {
+            if *drain_ms > policy.shutdown_drain_max_ms {
+                reasons.push(format!(
+                    "shutdown drain {drain_ms} ms exceeds {} ms",
+                    policy.shutdown_drain_max_ms
+                ));
+            }
+        }
+        CaseMetrics::SlowStorage {
+            new_conn_ms,
+            ping_ms,
+        } => {
+            if *new_conn_ms > policy.slow_storage_new_conn_max_ms {
+                reasons.push(format!(
+                    "slow storage new connection {new_conn_ms} ms exceeds {} ms",
+                    policy.slow_storage_new_conn_max_ms
+                ));
+            }
+            if *ping_ms > policy.slow_storage_ping_max_ms {
+                reasons.push(format!(
+                    "slow storage PING {ping_ms} ms exceeds {} ms",
+                    policy.slow_storage_ping_max_ms
+                ));
+            }
+        }
+    }
+
+    if reasons.is_empty() {
+        ThresholdCheck::Pass
     } else {
-        Some(v)
+        ThresholdCheck::Fail(reasons)
     }
 }
 
-/// 把占位哨兵值归一为 `None`：只有真正回填的阈值才参与判定。
-fn frozen_usize(v: usize) -> Option<usize> {
-    if v == usize::MAX {
-        None
-    } else {
-        Some(v)
+fn validate_outcome(outcome: &Outcome) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if outcome.case_id.trim().is_empty() {
+        reasons.push("case_id must not be empty".to_string());
+    }
+    validate_nonnegative("qps", outcome.qps, &mut reasons);
+    validate_nonnegative("p99_ms", outcome.p99_ms, &mut reasons);
+    validate_nonnegative("max_latency_ms", outcome.max_latency_ms, &mut reasons);
+    if outcome.max_latency_ms < outcome.p99_ms {
+        reasons.push("max_latency_ms must be greater than or equal to p99_ms".to_string());
+    }
+    if !outcome.error_rate.is_finite() || !(0.0..=1.0).contains(&outcome.error_rate) {
+        reasons.push("error_rate must be finite and within [0, 1]".to_string());
+    }
+    validate_change_ratio("cpu_change_ratio", outcome.cpu_change_ratio, &mut reasons);
+    validate_change_ratio("rss_change_ratio", outcome.rss_change_ratio, &mut reasons);
+
+    match &outcome.case {
+        CaseMetrics::NormalLoad {
+            anchor_qps,
+            anchor_p99_ms,
+            anchor_max_latency_ms,
+        } => {
+            validate_positive("anchor_qps", *anchor_qps, &mut reasons);
+            validate_positive("anchor_p99_ms", *anchor_p99_ms, &mut reasons);
+            validate_positive(
+                "anchor_max_latency_ms",
+                *anchor_max_latency_ms,
+                &mut reasons,
+            );
+            if anchor_max_latency_ms < anchor_p99_ms {
+                reasons.push(
+                    "anchor_max_latency_ms must be greater than or equal to anchor_p99_ms"
+                        .to_string(),
+                );
+            }
+        }
+        CaseMetrics::Overload120pct { error_kinds } => {
+            if outcome.error_rate > 0.0 && error_kinds.is_empty() {
+                reasons
+                    .push("overload error_kinds must be present when errors occurred".to_string());
+            }
+            let mut unique = BTreeSet::new();
+            for kind in error_kinds {
+                let normalized = kind.trim();
+                if normalized.is_empty() {
+                    reasons
+                        .push("overload error_kinds must not contain an empty value".to_string());
+                } else if normalized != kind {
+                    reasons.push(
+                        "overload error_kinds must not contain leading or trailing whitespace"
+                            .to_string(),
+                    );
+                } else if !unique.insert(normalized) {
+                    reasons.push(format!("duplicate overload error kind: {normalized}"));
+                }
+            }
+        }
+        CaseMetrics::StorageGate { .. }
+        | CaseMetrics::Shutdown { .. }
+        | CaseMetrics::SlowStorage { .. } => {}
+    }
+
+    reasons
+}
+
+fn validate_nonnegative(name: &str, value: f64, reasons: &mut Vec<String>) {
+    if !value.is_finite() || value < 0.0 {
+        reasons.push(format!("{name} must be finite and non-negative"));
     }
 }
 
-/// 把占位哨兵值（NaN）归一为 `None`：只有真正回填的阈值才参与判定。
-fn frozen_f64(v: f64) -> Option<f64> {
-    if v.is_nan() {
-        None
-    } else {
-        Some(v)
+fn validate_positive(name: &str, value: f64, reasons: &mut Vec<String>) {
+    if !value.is_finite() || value <= 0.0 {
+        reasons.push(format!("{name} must be finite and greater than zero"));
     }
 }
 
-/// 对比单个 [`Outcome`] 与冻结阈值。
-pub fn verify_outcome(o: &Outcome) -> VerifyStatus {
-    if !thresholds::all_frozen() {
-        return VerifyStatus::NonPublishable;
+fn validate_change_ratio(name: &str, value: f64, reasons: &mut Vec<String>) {
+    if !value.is_finite() || value < -1.0 {
+        reasons.push(format!("{name} must be finite and no less than -1"));
     }
-    // TODO(#351): 真实比对方式需结合 anchor case（吞吐/延迟的相对变化）与 offered-load 维度；
-    // 此处先给出与绝对值阈值的可扩展骨架，回填真实阈值后补充相对变化计算。
-    // 由于 `all_frozen()` 已为真，下方 `frozen_*` 都返回 `Some`，比较的是真实阈值。
-    if let Some(limit) = frozen_f64(thresholds::NORMAL_LOAD_MAX_ERROR_RATE)
-        && o.error_rate > limit
-    {
-        return VerifyStatus::Fail(format!(
-            "{}: error_rate {} > NORMAL_LOAD_MAX_ERROR_RATE {}",
-            o.case_id, o.error_rate, limit
-        ));
-    }
-    if let Some(limit) = frozen_usize(thresholds::MAX_QUEUED_PLUS_RUNNING)
-        && o.queued_plus_running_max > limit
-    {
-        return VerifyStatus::Fail(format!(
-            "{}: queued_plus_running_max {} > MAX_QUEUED_PLUS_RUNNING {}",
-            o.case_id, o.queued_plus_running_max, limit
-        ));
-    }
-    if let (Some(limit), Some(v)) = (
-        frozen_f64(thresholds::OVERLOAD_120PCT_MAX_ERROR_RATE),
-        o.overload_120pct_error_rate,
-    ) && v > limit
-    {
-        return VerifyStatus::Fail(format!(
-            "{}: overload_120pct_error_rate {} > OVERLOAD_120PCT_MAX_ERROR_RATE {}",
-            o.case_id, v, limit
-        ));
-    }
-    if let (Some(limit), Some(v)) = (
-        frozen_u64(thresholds::STORAGE_GATE_PAUSE_MAX_MS),
-        o.storage_gate_pause_ms,
-    ) && v > limit
-    {
-        return VerifyStatus::Fail(format!(
-            "{}: storage_gate_pause_ms {} > STORAGE_GATE_PAUSE_MAX_MS {}",
-            o.case_id, v, limit
-        ));
-    }
-    if let (Some(limit), Some(v)) = (frozen_u64(thresholds::SHUTDOWN_DRAIN_MAX_MS), o.shutdown_drain_ms)
-        && v > limit
-    {
-        return VerifyStatus::Fail(format!(
-            "{}: shutdown_drain_ms {} > SHUTDOWN_DRAIN_MAX_MS {}",
-            o.case_id, v, limit
-        ));
-    }
-    VerifyStatus::Publishable
 }
 
 /// 从文件读取 [`Outcome`] 并验证。
-pub fn verify_outcome_path(path: &Path) -> anyhow::Result<VerifyStatus> {
+pub fn verify_outcome_path(path: &Path) -> anyhow::Result<ThresholdCheck> {
     let raw = std::fs::read_to_string(path)
         .with_context(|| format!("read outcome file {}", path.display()))?;
-    let outcome: Outcome =
-        serde_json::from_str(&raw).with_context(|| format!("parse outcome json {}", path.display()))?;
+    let outcome: Outcome = serde_json::from_str(&raw)
+        .with_context(|| format!("parse outcome json {}", path.display()))?;
     Ok(verify_outcome(&outcome))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::{Value, json};
 
-    fn sample() -> Outcome {
-        Outcome {
-            case_id: "smoke-get-c1-p1-batch-off".to_string(),
-            qps: 120_000.0,
-            p99_ms: 3.2,
-            max_latency_ms: 9.5,
-            error_rate: 0.0,
-            overload_120pct_error_rate: Some(0.0),
-            queued_plus_running_max: 64,
-            storage_gate_pause_ms: Some(5),
-            storage_gate_resume_drain_ms: Some(8),
-            shutdown_drain_ms: Some(12),
-            slow_storage_new_conn_ms: Some(20),
-            slow_storage_ping_ms: Some(2),
-            cpu_change_ratio: Some(0.01),
-            rss_change_ratio: Some(0.02),
-            threads_delta: Some(0),
+    use crate::thresholds::ThresholdPolicy;
+
+    fn frozen_policy() -> ThresholdPolicy {
+        ThresholdPolicy {
+            normal_load_throughput_max_regression_ratio: 0.10,
+            p99_max_latency_allowed_change_ratio: 0.10,
+            max_latency_allowed_change_ratio: 0.20,
+            normal_load_max_error_rate: 0.01,
+            overload_120pct_max_error_rate: 0.10,
+            overload_120pct_allowed_error_kinds: vec!["command_error".to_string()],
+            max_queued_plus_running: 100,
+            storage_gate_pause_max_ms: 10,
+            storage_gate_resume_drain_max_ms: 20,
+            shutdown_drain_max_ms: 30,
+            slow_storage_new_conn_max_ms: 50,
+            slow_storage_ping_max_ms: 10,
+            cpu_allowed_change_ratio: 0.20,
+            rss_allowed_change_ratio: 0.20,
+            threads_allowed_delta: 2,
+        }
+    }
+
+    fn common(case: Value) -> Value {
+        json!({
+            "case_id": "normal-get-c16-p16",
+            "qps": 90.0,
+            "p99_ms": 11.0,
+            "max_latency_ms": 12.0,
+            "error_rate": 0.01,
+            "queued_plus_running_max": 100,
+            "cpu_change_ratio": 0.20,
+            "rss_change_ratio": -0.20,
+            "threads_delta": -2,
+            "case": case
+        })
+    }
+
+    fn normal_value() -> Value {
+        common(json!({
+            "kind": "normal_load",
+            "anchor_qps": 100.0,
+            "anchor_p99_ms": 10.0,
+            "anchor_max_latency_ms": 10.0
+        }))
+    }
+
+    fn parse(value: Value) -> Outcome {
+        serde_json::from_value(value).expect("valid threshold outcome")
+    }
+
+    fn assert_failed(value: Value, reason: &str) {
+        let outcome = parse(value);
+        let ThresholdCheck::Fail(reasons) = verify_outcome_with_policy(&outcome, &frozen_policy())
+        else {
+            panic!("outcome must fail threshold checking");
+        };
+        assert!(
+            reasons.iter().any(|candidate| candidate.contains(reason)),
+            "missing reason {reason:?} in {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn placeholder_thresholds_make_policy_unavailable() {
+        assert!(matches!(
+            verify_outcome(&parse(normal_value())),
+            ThresholdCheck::PolicyUnavailable(_)
+        ));
+    }
+
+    #[test]
+    fn invalid_input_fails_before_policy_availability() {
+        let mut value = normal_value();
+        value["case_id"] = json!("  ");
+
+        let ThresholdCheck::Fail(reasons) = verify_outcome(&parse(value)) else {
+            panic!("invalid input must fail even while frozen policy is unavailable");
+        };
+        assert!(
+            reasons.iter().any(|reason| reason.contains("case_id")),
+            "unexpected input reasons: {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn normal_load_accepts_exact_threshold_boundaries() {
+        assert_eq!(
+            verify_outcome_with_policy(&parse(normal_value()), &frozen_policy()),
+            ThresholdCheck::Pass
+        );
+    }
+
+    #[test]
+    fn normal_load_checks_every_common_and_relative_threshold() {
+        let cases = [
+            ("qps", json!(89.0), "throughput regression"),
+            ("p99_ms", json!(11.1), "p99 change"),
+            ("max_latency_ms", json!(12.1), "max latency change"),
+            ("error_rate", json!(0.011), "normal error rate"),
+            ("queued_plus_running_max", json!(101), "queued plus running"),
+            ("cpu_change_ratio", json!(0.21), "CPU change"),
+            ("rss_change_ratio", json!(-0.21), "RSS change"),
+            ("threads_delta", json!(-3), "thread delta"),
+        ];
+        for (field, replacement, reason) in cases {
+            let mut value = normal_value();
+            value[field] = replacement;
+            assert_failed(value, reason);
         }
     }
 
     #[test]
-    fn placeholder_thresholds_make_every_case_non_publishable() -> anyhow::Result<()> {
-        // 硬保证：在阈值回填前，任何真实数值都不得被判 Publishable。
-        let status = verify_outcome(&sample());
-        assert_eq!(
-            status,
-            VerifyStatus::NonPublishable,
-            "占位阈值必须判 NonPublishable"
+    fn case_specific_metrics_accept_exact_threshold_boundaries() {
+        let passing = [
+            common(json!({
+                "kind": "overload_120pct",
+                "error_kinds": ["command_error"]
+            })),
+            common(json!({
+                "kind": "storage_gate",
+                "pause_ms": 10,
+                "resume_drain_ms": 20
+            })),
+            common(json!({ "kind": "shutdown", "drain_ms": 30 })),
+            common(json!({
+                "kind": "slow_storage",
+                "new_conn_ms": 50,
+                "ping_ms": 10
+            })),
+        ];
+        for value in passing {
+            assert_eq!(
+                verify_outcome_with_policy(&parse(value), &frozen_policy()),
+                ThresholdCheck::Pass
+            );
+        }
+    }
+
+    #[test]
+    fn overload_checks_error_rate_threshold() {
+        let mut overload_rate = common(json!({
+            "kind": "overload_120pct",
+            "error_kinds": ["command_error"]
+        }));
+        overload_rate["error_rate"] = json!(0.101);
+        assert_failed(overload_rate, "overload error rate");
+    }
+
+    #[test]
+    fn overload_rejects_error_kind_outside_policy() {
+        assert_failed(
+            common(json!({
+                "kind": "overload_120pct",
+                "error_kinds": ["timeout"]
+            })),
+            "error kind",
         );
-        Ok(())
+    }
+
+    #[test]
+    fn storage_gate_checks_each_duration_threshold() {
+        assert_failed(
+            common(json!({
+                "kind": "storage_gate",
+                "pause_ms": 11,
+                "resume_drain_ms": 20
+            })),
+            "storage gate pause",
+        );
+        assert_failed(
+            common(json!({
+                "kind": "storage_gate",
+                "pause_ms": 10,
+                "resume_drain_ms": 21
+            })),
+            "storage gate resume drain",
+        );
+    }
+
+    #[test]
+    fn shutdown_checks_drain_threshold() {
+        assert_failed(
+            common(json!({ "kind": "shutdown", "drain_ms": 31 })),
+            "shutdown drain",
+        );
+    }
+
+    #[test]
+    fn slow_storage_checks_each_latency_threshold() {
+        assert_failed(
+            common(json!({
+                "kind": "slow_storage",
+                "new_conn_ms": 51,
+                "ping_ms": 10
+            })),
+            "slow storage new connection",
+        );
+        assert_failed(
+            common(json!({
+                "kind": "slow_storage",
+                "new_conn_ms": 50,
+                "ping_ms": 11
+            })),
+            "slow storage PING",
+        );
+    }
+
+    #[test]
+    fn invalid_policy_is_unavailable() {
+        let mut policy = frozen_policy();
+        policy.overload_120pct_allowed_error_kinds = vec![" command_error".to_string()];
+
+        let ThresholdCheck::PolicyUnavailable(reasons) =
+            verify_outcome_with_policy(&parse(normal_value()), &policy)
+        else {
+            panic!("invalid policy must be unavailable");
+        };
+        assert!(
+            reasons
+                .iter()
+                .any(|reason| reason.contains("leading or trailing whitespace")),
+            "unexpected policy reasons: {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn invalid_or_incomplete_input_fails_closed() {
+        let mut empty_id = normal_value();
+        empty_id["case_id"] = json!("  ");
+        assert_failed(empty_id, "case_id");
+
+        let mut negative_qps = normal_value();
+        negative_qps["qps"] = json!(-1.0);
+        assert_failed(negative_qps, "qps");
+
+        let mut invalid_rate = normal_value();
+        invalid_rate["error_rate"] = json!(1.1);
+        assert_failed(invalid_rate, "error_rate");
+
+        let mut unknown = normal_value();
+        unknown["unexpected"] = json!(true);
+        assert!(serde_json::from_value::<Outcome>(unknown).is_err());
+
+        let missing_case_metric = common(json!({ "kind": "shutdown" }));
+        assert!(serde_json::from_value::<Outcome>(missing_case_metric).is_err());
+
+        let unknown_case = common(json!({ "kind": "not-a-case" }));
+        assert!(serde_json::from_value::<Outcome>(unknown_case).is_err());
+
+        assert_failed(
+            common(json!({
+                "kind": "overload_120pct",
+                "error_kinds": [" command_error"]
+            })),
+            "leading or trailing whitespace",
+        );
+    }
+
+    #[test]
+    fn schema_is_strict_2020_12_threshold_contract() {
+        let schema: Value = serde_json::from_str(OUTCOME_SCHEMA).expect("schema is JSON");
+        assert_eq!(
+            schema["$schema"],
+            json!("https://json-schema.org/draft/2020-12/schema")
+        );
+        assert_eq!(schema["additionalProperties"], json!(false));
+
+        let required = schema["required"]
+            .as_array()
+            .expect("top-level required fields");
+        for field in [
+            "case_id",
+            "qps",
+            "p99_ms",
+            "max_latency_ms",
+            "error_rate",
+            "queued_plus_running_max",
+            "cpu_change_ratio",
+            "rss_change_ratio",
+            "threads_delta",
+            "case",
+        ] {
+            assert!(required.contains(&json!(field)), "missing required {field}");
+        }
+
+        let variants = schema["properties"]["case"]["oneOf"]
+            .as_array()
+            .expect("case variants");
+        let mut kinds = variants
+            .iter()
+            .map(|variant| {
+                assert_eq!(variant["additionalProperties"], json!(false));
+                variant["properties"]["kind"]["const"]
+                    .as_str()
+                    .expect("case kind")
+            })
+            .collect::<Vec<_>>();
+        kinds.sort_unstable();
+        assert_eq!(
+            kinds,
+            [
+                "normal_load",
+                "overload_120pct",
+                "shutdown",
+                "slow_storage",
+                "storage_gate",
+            ]
+        );
     }
 
     #[test]

--- a/tools/runtime-baseline/src/verify.rs
+++ b/tools/runtime-baseline/src/verify.rs
@@ -1,0 +1,207 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Outcome 比对器：把单次基线测量结果与 [`crate::thresholds`] 中冻结的阈值逐一对比，
+//! 判定该 case 是否 `Publishable` / `NonPublishable` / `Fail`。
+//!
+//! 在阈值尚未回填（仍为占位哨兵值）时，任何 case 都判为 `NonPublishable`——
+//! 这是「不伪造数字」的硬保证：占位值绝不能被当成通过阈值。
+
+use std::path::Path;
+
+use anyhow::Context as _;
+use serde::Deserialize;
+
+use crate::thresholds;
+
+/// 单次基线场景的测量结果（由控制器在固定 Linux/WSL 主机上采集后写出）。
+///
+/// 字段允许前向兼容（不强制 `deny_unknown_fields`），未来扩展指标时旧 verifier 仍可解析。
+#[derive(Debug, Deserialize)]
+pub struct Outcome {
+    pub case_id: String,
+    pub qps: f64,
+    pub p99_ms: f64,
+    pub max_latency_ms: f64,
+    pub error_rate: f64,
+    #[serde(default)]
+    pub overload_120pct_error_rate: Option<f64>,
+    pub queued_plus_running_max: usize,
+    #[serde(default)]
+    pub storage_gate_pause_ms: Option<u64>,
+    #[serde(default)]
+    pub storage_gate_resume_drain_ms: Option<u64>,
+    #[serde(default)]
+    pub shutdown_drain_ms: Option<u64>,
+    #[serde(default)]
+    pub slow_storage_new_conn_ms: Option<u64>,
+    #[serde(default)]
+    pub slow_storage_ping_ms: Option<u64>,
+    #[serde(default)]
+    pub cpu_change_ratio: Option<f64>,
+    #[serde(default)]
+    pub rss_change_ratio: Option<f64>,
+    #[serde(default)]
+    pub threads_delta: Option<i64>,
+}
+
+/// 单个 case 的验证结论。
+#[derive(Debug, PartialEq, Eq)]
+pub enum VerifyStatus {
+    /// 阈值已全部回填且本 case 满足全部阈值。
+    Publishable,
+    /// 阈值尚未回填（仍是占位哨兵值），本 case 不可发布。
+    NonPublishable,
+    /// 阈值已回填，但本 case 超出某项阈值。
+    Fail(String),
+}
+
+/// 把占位哨兵值归一为 `None`：只有真正回填的阈值才参与判定。
+fn frozen_u64(v: u64) -> Option<u64> {
+    if v == u64::MAX {
+        None
+    } else {
+        Some(v)
+    }
+}
+
+/// 把占位哨兵值归一为 `None`：只有真正回填的阈值才参与判定。
+fn frozen_usize(v: usize) -> Option<usize> {
+    if v == usize::MAX {
+        None
+    } else {
+        Some(v)
+    }
+}
+
+/// 把占位哨兵值（NaN）归一为 `None`：只有真正回填的阈值才参与判定。
+fn frozen_f64(v: f64) -> Option<f64> {
+    if v.is_nan() {
+        None
+    } else {
+        Some(v)
+    }
+}
+
+/// 对比单个 [`Outcome`] 与冻结阈值。
+pub fn verify_outcome(o: &Outcome) -> VerifyStatus {
+    if !thresholds::all_frozen() {
+        return VerifyStatus::NonPublishable;
+    }
+    // TODO(#351): 真实比对方式需结合 anchor case（吞吐/延迟的相对变化）与 offered-load 维度；
+    // 此处先给出与绝对值阈值的可扩展骨架，回填真实阈值后补充相对变化计算。
+    // 由于 `all_frozen()` 已为真，下方 `frozen_*` 都返回 `Some`，比较的是真实阈值。
+    if let Some(limit) = frozen_f64(thresholds::NORMAL_LOAD_MAX_ERROR_RATE)
+        && o.error_rate > limit
+    {
+        return VerifyStatus::Fail(format!(
+            "{}: error_rate {} > NORMAL_LOAD_MAX_ERROR_RATE {}",
+            o.case_id, o.error_rate, limit
+        ));
+    }
+    if let Some(limit) = frozen_usize(thresholds::MAX_QUEUED_PLUS_RUNNING)
+        && o.queued_plus_running_max > limit
+    {
+        return VerifyStatus::Fail(format!(
+            "{}: queued_plus_running_max {} > MAX_QUEUED_PLUS_RUNNING {}",
+            o.case_id, o.queued_plus_running_max, limit
+        ));
+    }
+    if let (Some(limit), Some(v)) = (
+        frozen_f64(thresholds::OVERLOAD_120PCT_MAX_ERROR_RATE),
+        o.overload_120pct_error_rate,
+    ) && v > limit
+    {
+        return VerifyStatus::Fail(format!(
+            "{}: overload_120pct_error_rate {} > OVERLOAD_120PCT_MAX_ERROR_RATE {}",
+            o.case_id, v, limit
+        ));
+    }
+    if let (Some(limit), Some(v)) = (
+        frozen_u64(thresholds::STORAGE_GATE_PAUSE_MAX_MS),
+        o.storage_gate_pause_ms,
+    ) && v > limit
+    {
+        return VerifyStatus::Fail(format!(
+            "{}: storage_gate_pause_ms {} > STORAGE_GATE_PAUSE_MAX_MS {}",
+            o.case_id, v, limit
+        ));
+    }
+    if let (Some(limit), Some(v)) = (frozen_u64(thresholds::SHUTDOWN_DRAIN_MAX_MS), o.shutdown_drain_ms)
+        && v > limit
+    {
+        return VerifyStatus::Fail(format!(
+            "{}: shutdown_drain_ms {} > SHUTDOWN_DRAIN_MAX_MS {}",
+            o.case_id, v, limit
+        ));
+    }
+    VerifyStatus::Publishable
+}
+
+/// 从文件读取 [`Outcome`] 并验证。
+pub fn verify_outcome_path(path: &Path) -> anyhow::Result<VerifyStatus> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("read outcome file {}", path.display()))?;
+    let outcome: Outcome =
+        serde_json::from_str(&raw).with_context(|| format!("parse outcome json {}", path.display()))?;
+    Ok(verify_outcome(&outcome))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Outcome {
+        Outcome {
+            case_id: "smoke-get-c1-p1-batch-off".to_string(),
+            qps: 120_000.0,
+            p99_ms: 3.2,
+            max_latency_ms: 9.5,
+            error_rate: 0.0,
+            overload_120pct_error_rate: Some(0.0),
+            queued_plus_running_max: 64,
+            storage_gate_pause_ms: Some(5),
+            storage_gate_resume_drain_ms: Some(8),
+            shutdown_drain_ms: Some(12),
+            slow_storage_new_conn_ms: Some(20),
+            slow_storage_ping_ms: Some(2),
+            cpu_change_ratio: Some(0.01),
+            rss_change_ratio: Some(0.02),
+            threads_delta: Some(0),
+        }
+    }
+
+    #[test]
+    fn placeholder_thresholds_make_every_case_non_publishable() -> anyhow::Result<()> {
+        // 硬保证：在阈值回填前，任何真实数值都不得被判 Publishable。
+        let status = verify_outcome(&sample());
+        assert_eq!(
+            status,
+            VerifyStatus::NonPublishable,
+            "占位阈值必须判 NonPublishable"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn verify_outcome_path_rejects_missing_file() -> anyhow::Result<()> {
+        let p = Path::new("/nonexistent/outcome.json");
+        let res = verify_outcome_path(p);
+        assert!(res.is_err(), "缺失文件应返回错误");
+        Ok(())
+    }
+}

--- a/tools/runtime-baseline/tests/build_identity_test.rs
+++ b/tools/runtime-baseline/tests/build_identity_test.rs
@@ -387,16 +387,30 @@ unknown_lints = "deny"
     let source_crate = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let fixture_crate = root.join("tools/runtime-baseline");
     fs::create_dir_all(fixture_crate.join("src/bin")).expect("fixture crate directory");
+    fs::create_dir_all(fixture_crate.join("schema")).expect("fixture schema directory");
     for file in ["Cargo.toml", "build.rs", "build_support.rs"] {
         fs::copy(source_crate.join(file), fixture_crate.join(file)).expect("fixture build input");
     }
-    for file in ["cli.rs", "lib.rs", "main.rs", "schema.rs", "startup.rs"] {
+    for file in [
+        "cli.rs",
+        "lib.rs",
+        "main.rs",
+        "schema.rs",
+        "startup.rs",
+        "thresholds.rs",
+        "verify.rs",
+    ] {
         fs::copy(
             source_crate.join("src").join(file),
             fixture_crate.join("src").join(file),
         )
         .expect("fixture crate source");
     }
+    fs::copy(
+        source_crate.join("schema/outcome.schema.json"),
+        fixture_crate.join("schema/outcome.schema.json"),
+    )
+    .expect("fixture outcome schema");
     fs::write(
         fixture_crate.join("src/bin/identity.rs"),
         r#"use runtime_baseline::schema::{Publishability, source_dirty};


### PR DESCRIPTION
## Summary

#390 / #350 follow-up: establish the threshold-freezing mechanism for the #351 quantitative acceptance gate without inventing benchmark numbers.

This PR now provides:

- `tools/runtime-baseline/src/thresholds.rs`: placeholder constants plus a validated `ThresholdPolicy`; any placeholder or invalid policy returns `PolicyUnavailable`.
- `tools/runtime-baseline/src/verify.rs`: a strict single-case threshold checker returning `Pass`, `PolicyUnavailable`, or `Fail`.
- `tools/runtime-baseline/schema/outcome.schema.json`: a strict JSON Schema 2020-12 contract with required common fields and tagged case-specific metrics.
- `tools/runtime-baseline/tests/build_identity_test.rs`: fixture coverage for the new source modules and embedded schema.
- `docs/performance/storage-runtime-baseline.md`: the fixed-host measurement and follow-up contract.

A single-case `Pass` is not a publishable baseline-run decision. The later controller verifier must still prove manifest case-set conservation, required repetitions, CV, source identity, and provenance before publishing a complete run.

## Why placeholders, not real numbers

The design prohibits freezing thresholds from Windows or GitHub-hosted runner measurements. The complete matrix must run on the designated fixed Linux/WSL host with the versioned case definition.

Until real measurements replace every placeholder, `ThresholdPolicy::from_frozen_constants()` fails closed and the checker returns `PolicyUnavailable` for otherwise valid input. Invalid input returns `Fail` even while the policy is unavailable.

## Deferred follow-ups

- **Wiring and Smoke (Tasks 6-12):** connect the baseline observer to the runtime production path, harness, controller, and versioned case manifest in a separately validated PR.
- **Baseline Results:** run the complete fixed-host matrix, publish raw results and the report, freeze the measured thresholds, and implement the run-level controller verifier.

## Validation

- `cargo test -p runtime-baseline --all-targets` in WSL/Linux: 49 passed, 0 failed.
- `cargo clippy -p runtime-baseline --all-targets -- -D warnings -D clippy::unwrap_used`: passed.
- `cargo fmt --all -- --check`: passed.
- SkyWalking Eyes header check: 462 checked, 0 invalid.
- `git diff --check`: passed.
- Isolated mutation probe: removing the resume-drain and slow-storage PING comparisons makes both targeted boundary tests fail.

## Refs

Refs #390. Refs #350 #378 #351 #347.
