### PR TITLE
feat(storage,runtime): add request-local storage stats collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,7 @@ dependencies = [
  "async-trait",
  "parking_lot",
  "resp",
+ "serde",
  "tokio",
 ]
 
@@ -2643,6 +2644,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
+ "client",
  "common-macro",
  "conf",
  "crc16",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,7 @@ dependencies = [
  "parking_lot",
  "resp",
  "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -11,4 +11,5 @@ rust-version.workspace = true
 async-trait = "0.1"
 resp = { path = "../resp" }
 parking_lot = { workspace = true }
-tokio = { version = "1.50", features = ["sync"] }
+serde = { workspace = true, features = ["derive"] }
+tokio = { version = "1.50", features = ["sync", "rt"] }

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -13,3 +13,6 @@ resp = { path = "../resp" }
 parking_lot = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tokio = { version = "1.50", features = ["sync", "rt"] }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -21,6 +21,9 @@ use async_trait::async_trait;
 use resp::{ProtocolNegotiator, RespCommand, RespData, RespResult};
 use tokio::sync::Mutex;
 
+pub mod storage_stats;
+pub use storage_stats::*;
+
 #[async_trait]
 pub trait StreamTrait: Send + Sync {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error>;

--- a/src/client/src/storage_stats.rs
+++ b/src/client/src/storage_stats.rs
@@ -11,7 +11,7 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF KIND, either express or implied.
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
@@ -25,9 +25,9 @@
 //!
 //! The real collector ([`RealStorageStatsCollector`]) is installed once per
 //! storage request via the [`STORAGE_STATS_COLLECTOR`] task-local and read by
-//! the storage engine at the point where reads, writes and deletes actually
-//! happen, so the byte/key counters reflect true I/O rather than values
-//! inferred from Redis command arguments.
+//! the storage facade after backend outcomes are known. Key and byte counters
+//! describe successful logical storage operations and their payload sizes;
+//! RocksDB-specific observations are reported separately when available.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
@@ -36,6 +36,7 @@ use serde::{Deserialize, Serialize};
 
 /// Statistics about storage operations for monitoring.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(default)]
 pub struct StorageStats {
     /// Number of keys read during the operation
     pub keys_read: u64,
@@ -43,33 +44,53 @@ pub struct StorageStats {
     pub keys_written: u64,
     /// Number of keys deleted during the operation
     pub keys_deleted: u64,
-    /// Size of data read in bytes (key bytes + value bytes)
+    /// Logical payload read in bytes (key bytes + returned value bytes)
     pub bytes_read: u64,
-    /// Size of data written in bytes (key bytes + value bytes)
+    /// Logical payload written in bytes (key bytes + accepted value bytes)
     pub bytes_written: u64,
-    /// Size of data removed by delete operations in bytes
+    /// Logical key bytes affected by successful delete operations
     pub bytes_deleted: u64,
     /// Whether the operation hit a cache (e.g. block/moka cache)
     pub cache_hit: bool,
-    /// RocksDB compaction level accessed
+    /// RocksDB compaction level accessed, when the engine can attribute one
     pub compaction_level: Option<u32>,
+}
+
+impl StorageStats {
+    /// Merge another completed request into this aggregate without wrapping.
+    pub fn merge(&mut self, request: &Self) {
+        self.keys_read = self.keys_read.saturating_add(request.keys_read);
+        self.keys_written = self.keys_written.saturating_add(request.keys_written);
+        self.keys_deleted = self.keys_deleted.saturating_add(request.keys_deleted);
+        self.bytes_read = self.bytes_read.saturating_add(request.bytes_read);
+        self.bytes_written = self.bytes_written.saturating_add(request.bytes_written);
+        self.bytes_deleted = self.bytes_deleted.saturating_add(request.bytes_deleted);
+        self.cache_hit |= request.cache_hit;
+        if request.compaction_level.is_some() {
+            self.compaction_level = request.compaction_level;
+        }
+    }
 }
 
 /// Request-local collector for storage-layer instrumentation.
 ///
-/// Implementations must record the *actual* byte sizes measured by the storage
-/// layer, not sizes inferred from Redis command arguments.
+/// Implementations record sizes observed by the storage facade after the
+/// backend outcome is known, rather than inferring success in command parsing.
 pub trait StorageStatsCollector: Send + Sync {
-    /// Record a storage read. `key_bytes` and `value_bytes` are measured by the
-    /// storage layer.
+    /// Record a successful logical storage read.
     fn record_read(&self, key_bytes: u64, value_bytes: u64);
 
-    /// Record a storage write. `key_bytes` and `value_bytes` are measured after
-    /// the storage layer accepts the mutation.
+    /// Record a logical storage write after the backend accepts the mutation.
     fn record_write(&self, key_bytes: u64, value_bytes: u64);
 
-    /// Record a storage delete. `key_bytes` is measured by the storage layer.
+    /// Record a logical delete after the backend confirms a mutation.
     fn record_delete(&self, key_bytes: u64);
+
+    /// Record that this request was served from a storage cache.
+    fn record_cache_hit(&self) {}
+
+    /// Record the RocksDB compaction level that served this request.
+    fn record_compaction_level(&self, _level: u32) {}
 
     /// Return the accumulated statistics for the request.
     fn finish(&self) -> StorageStats;
@@ -126,16 +147,6 @@ impl RealStorageStatsCollector {
             compaction_level: StdMutex::new(None),
         }
     }
-
-    /// Mark that this request hit a cache (e.g. block/moka cache).
-    pub fn mark_cache_hit(&self) {
-        self.cache_hit.store(true, Ordering::Relaxed);
-    }
-
-    /// Record the RocksDB compaction level that served this request.
-    pub fn set_compaction_level(&self, level: u32) {
-        *self.compaction_level.lock().expect("compaction_level poisoned") = Some(level);
-    }
 }
 
 impl StorageStatsCollector for RealStorageStatsCollector {
@@ -156,6 +167,17 @@ impl StorageStatsCollector for RealStorageStatsCollector {
         self.bytes_deleted.fetch_add(key_bytes, Ordering::Relaxed);
     }
 
+    fn record_cache_hit(&self) {
+        self.cache_hit.store(true, Ordering::Relaxed);
+    }
+
+    fn record_compaction_level(&self, level: u32) {
+        *self
+            .compaction_level
+            .lock()
+            .expect("compaction_level poisoned") = Some(level);
+    }
+
     fn finish(&self) -> StorageStats {
         StorageStats {
             keys_read: self.keys_read.load(Ordering::Relaxed),
@@ -165,7 +187,10 @@ impl StorageStatsCollector for RealStorageStatsCollector {
             bytes_written: self.bytes_written.load(Ordering::Relaxed),
             bytes_deleted: self.bytes_deleted.load(Ordering::Relaxed),
             cache_hit: self.cache_hit.load(Ordering::Relaxed),
-            compaction_level: *self.compaction_level.lock().expect("compaction_level poisoned"),
+            compaction_level: *self
+                .compaction_level
+                .lock()
+                .expect("compaction_level poisoned"),
         }
     }
 }
@@ -189,7 +214,23 @@ pub fn try_collector() -> Option<Arc<dyn StorageStatsCollector + Send + Sync>> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
+
     use super::*;
+
+    struct LegacyCollector;
+
+    impl StorageStatsCollector for LegacyCollector {
+        fn record_read(&self, _key_bytes: u64, _value_bytes: u64) {}
+
+        fn record_write(&self, _key_bytes: u64, _value_bytes: u64) {}
+
+        fn record_delete(&self, _key_bytes: u64) {}
+
+        fn finish(&self) -> StorageStats {
+            StorageStats::default()
+        }
+    }
 
     #[test]
     fn real_collector_accumulates_reads_writes_deletes() {
@@ -212,6 +253,46 @@ mod tests {
     #[test]
     fn noop_yields_empty_stats() {
         assert_eq!(NoopStorageStatsCollector.finish(), StorageStats::default());
+    }
+
+    #[test]
+    fn legacy_collectors_use_default_optional_recorders() {
+        LegacyCollector.record_cache_hit();
+        LegacyCollector.record_compaction_level(3);
+        assert_eq!(LegacyCollector.finish(), StorageStats::default());
+    }
+
+    #[test]
+    fn legacy_serialized_stats_default_new_fields() {
+        let stats: StorageStats = serde_json::from_str(
+            r#"{
+                "keys_read": 1,
+                "keys_written": 2,
+                "keys_deleted": 3,
+                "bytes_read": 4,
+                "bytes_written": 5,
+                "cache_hit": true,
+                "compaction_level": null
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(stats.bytes_deleted, 0);
+        assert_eq!(stats.keys_read, 1);
+        assert!(stats.cache_hit);
+    }
+
+    #[test]
+    fn trait_object_records_cache_and_compaction_details() {
+        let collector: Arc<dyn StorageStatsCollector + Send + Sync> =
+            Arc::new(RealStorageStatsCollector::new());
+
+        collector.record_cache_hit();
+        collector.record_compaction_level(3);
+
+        let stats = collector.finish();
+        assert!(stats.cache_hit);
+        assert_eq!(stats.compaction_level, Some(3));
     }
 
     #[test]

--- a/src/client/src/storage_stats.rs
+++ b/src/client/src/storage_stats.rs
@@ -1,0 +1,246 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Request-local storage-layer instrumentation.
+//!
+//! These types were originally declared in `runtime::message` (see
+//! <https://github.com/arana-db/kiwi/issues/312>). They live in the `client`
+//! crate so that `storage`, `runtime` and `cmd` can share them without
+//! creating a dependency cycle (`client` is a leaf crate that everything else
+//! already depends on).
+//!
+//! The real collector ([`RealStorageStatsCollector`]) is installed once per
+//! storage request via the [`STORAGE_STATS_COLLECTOR`] task-local and read by
+//! the storage engine at the point where reads, writes and deletes actually
+//! happen, so the byte/key counters reflect true I/O rather than values
+//! inferred from Redis command arguments.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+
+use serde::{Deserialize, Serialize};
+
+/// Statistics about storage operations for monitoring.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct StorageStats {
+    /// Number of keys read during the operation
+    pub keys_read: u64,
+    /// Number of keys written during the operation
+    pub keys_written: u64,
+    /// Number of keys deleted during the operation
+    pub keys_deleted: u64,
+    /// Size of data read in bytes (key bytes + value bytes)
+    pub bytes_read: u64,
+    /// Size of data written in bytes (key bytes + value bytes)
+    pub bytes_written: u64,
+    /// Size of data removed by delete operations in bytes
+    pub bytes_deleted: u64,
+    /// Whether the operation hit a cache (e.g. block/moka cache)
+    pub cache_hit: bool,
+    /// RocksDB compaction level accessed
+    pub compaction_level: Option<u32>,
+}
+
+/// Request-local collector for storage-layer instrumentation.
+///
+/// Implementations must record the *actual* byte sizes measured by the storage
+/// layer, not sizes inferred from Redis command arguments.
+pub trait StorageStatsCollector: Send + Sync {
+    /// Record a storage read. `key_bytes` and `value_bytes` are measured by the
+    /// storage layer.
+    fn record_read(&self, key_bytes: u64, value_bytes: u64);
+
+    /// Record a storage write. `key_bytes` and `value_bytes` are measured after
+    /// the storage layer accepts the mutation.
+    fn record_write(&self, key_bytes: u64, value_bytes: u64);
+
+    /// Record a storage delete. `key_bytes` is measured by the storage layer.
+    fn record_delete(&self, key_bytes: u64);
+
+    /// Return the accumulated statistics for the request.
+    fn finish(&self) -> StorageStats;
+}
+
+/// Placeholder collector used until storage-layer instrumentation is wired in.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopStorageStatsCollector;
+
+impl StorageStatsCollector for NoopStorageStatsCollector {
+    fn record_read(&self, _key_bytes: u64, _value_bytes: u64) {}
+
+    fn record_write(&self, _key_bytes: u64, _value_bytes: u64) {}
+
+    fn record_delete(&self, _key_bytes: u64) {}
+
+    fn finish(&self) -> StorageStats {
+        StorageStats::default()
+    }
+}
+
+/// A real per-request collector backed by lock-free atomic counters.
+///
+/// Safe to share across the (single) task that executes one storage request:
+/// every field is an atomic and `finish` snapshots the accumulated values.
+pub struct RealStorageStatsCollector {
+    keys_read: AtomicU64,
+    keys_written: AtomicU64,
+    keys_deleted: AtomicU64,
+    bytes_read: AtomicU64,
+    bytes_written: AtomicU64,
+    bytes_deleted: AtomicU64,
+    cache_hit: AtomicBool,
+    compaction_level: StdMutex<Option<u32>>,
+}
+
+impl Default for RealStorageStatsCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RealStorageStatsCollector {
+    /// Create an empty collector ready to accumulate one request's stats.
+    pub fn new() -> Self {
+        Self {
+            keys_read: AtomicU64::new(0),
+            keys_written: AtomicU64::new(0),
+            keys_deleted: AtomicU64::new(0),
+            bytes_read: AtomicU64::new(0),
+            bytes_written: AtomicU64::new(0),
+            bytes_deleted: AtomicU64::new(0),
+            cache_hit: AtomicBool::new(false),
+            compaction_level: StdMutex::new(None),
+        }
+    }
+
+    /// Mark that this request hit a cache (e.g. block/moka cache).
+    pub fn mark_cache_hit(&self) {
+        self.cache_hit.store(true, Ordering::Relaxed);
+    }
+
+    /// Record the RocksDB compaction level that served this request.
+    pub fn set_compaction_level(&self, level: u32) {
+        *self.compaction_level.lock().expect("compaction_level poisoned") = Some(level);
+    }
+}
+
+impl StorageStatsCollector for RealStorageStatsCollector {
+    fn record_read(&self, key_bytes: u64, value_bytes: u64) {
+        self.keys_read.fetch_add(1, Ordering::Relaxed);
+        self.bytes_read
+            .fetch_add(key_bytes.saturating_add(value_bytes), Ordering::Relaxed);
+    }
+
+    fn record_write(&self, key_bytes: u64, value_bytes: u64) {
+        self.keys_written.fetch_add(1, Ordering::Relaxed);
+        self.bytes_written
+            .fetch_add(key_bytes.saturating_add(value_bytes), Ordering::Relaxed);
+    }
+
+    fn record_delete(&self, key_bytes: u64) {
+        self.keys_deleted.fetch_add(1, Ordering::Relaxed);
+        self.bytes_deleted.fetch_add(key_bytes, Ordering::Relaxed);
+    }
+
+    fn finish(&self) -> StorageStats {
+        StorageStats {
+            keys_read: self.keys_read.load(Ordering::Relaxed),
+            keys_written: self.keys_written.load(Ordering::Relaxed),
+            keys_deleted: self.keys_deleted.load(Ordering::Relaxed),
+            bytes_read: self.bytes_read.load(Ordering::Relaxed),
+            bytes_written: self.bytes_written.load(Ordering::Relaxed),
+            bytes_deleted: self.bytes_deleted.load(Ordering::Relaxed),
+            cache_hit: self.cache_hit.load(Ordering::Relaxed),
+            compaction_level: *self.compaction_level.lock().expect("compaction_level poisoned"),
+        }
+    }
+}
+
+tokio::task_local! {
+    /// Per-request storage stats collector, scoped for the duration of a single
+    /// storage command execution. The storage layer reads it via
+    /// [`try_collector`].
+    pub static STORAGE_STATS_COLLECTOR: Arc<dyn StorageStatsCollector + Send + Sync>;
+}
+
+/// Returns the active request-local collector, if one was installed for the
+/// current async task.
+///
+/// Returns `None` when no collector is scoped (e.g. unit tests that call the
+/// storage engine directly, or background storage tasks), so callers can record
+/// unconditionally without special-casing those paths.
+pub fn try_collector() -> Option<Arc<dyn StorageStatsCollector + Send + Sync>> {
+    STORAGE_STATS_COLLECTOR.try_with(|c| c.clone()).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn real_collector_accumulates_reads_writes_deletes() {
+        let c = RealStorageStatsCollector::new();
+        c.record_read(3, 5);
+        c.record_write(3, 7);
+        c.record_read(2, 4);
+        c.record_delete(3);
+
+        let stats = c.finish();
+        assert_eq!(stats.keys_read, 2);
+        assert_eq!(stats.keys_written, 1);
+        assert_eq!(stats.keys_deleted, 1);
+        assert_eq!(stats.bytes_read, (3 + 5) + (2 + 4));
+        assert_eq!(stats.bytes_written, 3 + 7);
+        assert_eq!(stats.bytes_deleted, 3);
+        assert!(!stats.cache_hit);
+    }
+
+    #[test]
+    fn noop_yields_empty_stats() {
+        assert_eq!(NoopStorageStatsCollector.finish(), StorageStats::default());
+    }
+
+    #[test]
+    fn scoped_collector_is_visible_to_try_collector() {
+        // Mirrors how `storage_server` installs the collector and how the
+        // storage facade reads it via `try_collector` — without needing a real
+        // RocksDB instance.
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let collector: Arc<dyn StorageStatsCollector + Send + Sync> =
+                Arc::new(RealStorageStatsCollector::new());
+            STORAGE_STATS_COLLECTOR
+                .scope(Arc::clone(&collector), async {
+                    if let Some(c) = try_collector() {
+                        c.record_write(3, 5);
+                        c.record_read(2, 4);
+                    } else {
+                        panic!("try_collector() must return the scoped collector");
+                    }
+                })
+                .await;
+            let stats = collector.finish();
+            assert_eq!(stats.keys_written, 1);
+            assert_eq!(stats.bytes_written, 8);
+            assert_eq!(stats.keys_read, 1);
+            assert_eq!(stats.bytes_read, 6);
+        });
+    }
+}

--- a/src/common/runtime/message.rs
+++ b/src/common/runtime/message.rs
@@ -81,8 +81,8 @@ pub enum StorageCommand {
 /// creating a dependency cycle. Re-exported here for backward compatibility with
 /// existing `runtime::message::*` importers.
 pub use client::storage_stats::{
-    RealStorageStatsCollector, STORAGE_STATS_COLLECTOR, StorageStats, StorageStatsCollector,
-    NoopStorageStatsCollector, try_collector,
+    NoopStorageStatsCollector, RealStorageStatsCollector, STORAGE_STATS_COLLECTOR, StorageStats,
+    StorageStatsCollector, try_collector,
 };
 
 /// Request sent from network runtime to storage runtime
@@ -792,6 +792,8 @@ pub struct StorageClient {
     message_channel: Arc<MessageChannel>,
     /// Map of pending requests waiting for responses
     pending_requests: Arc<Mutex<HashMap<RequestId, oneshot::Receiver<StorageResponse>>>>,
+    /// Aggregate logical storage I/O from all received responses
+    storage_io_stats: Arc<Mutex<StorageStats>>,
     /// Default timeout for storage requests
     default_timeout: Duration,
     /// Retry configuration
@@ -821,6 +823,7 @@ impl StorageClient {
         Self {
             message_channel,
             pending_requests: Arc::new(Mutex::new(HashMap::new())),
+            storage_io_stats: Arc::new(Mutex::new(StorageStats::default())),
             default_timeout,
             retry_config,
             circuit_breaker: Arc::new(Mutex::new(CircuitBreaker::new(5, Duration::from_secs(30)))),
@@ -842,6 +845,7 @@ impl StorageClient {
         Self {
             message_channel,
             pending_requests: Arc::new(Mutex::new(HashMap::new())),
+            storage_io_stats: Arc::new(Mutex::new(StorageStats::default())),
             default_timeout,
             retry_config,
             circuit_breaker: Arc::new(Mutex::new(CircuitBreaker::new(5, Duration::from_secs(30)))),
@@ -860,6 +864,7 @@ impl StorageClient {
         Self {
             message_channel,
             pending_requests: Arc::new(Mutex::new(HashMap::new())),
+            storage_io_stats: Arc::new(Mutex::new(StorageStats::default())),
             default_timeout,
             retry_config: RetryConfig::default(),
             circuit_breaker: Arc::new(Mutex::new(CircuitBreaker::new(5, Duration::from_secs(30)))),
@@ -876,6 +881,11 @@ impl StorageClient {
     ) -> Result<RespData, crate::error::DualRuntimeError> {
         self.send_request_with_timeout(command, self.default_timeout)
             .await
+    }
+
+    /// Return aggregate logical storage I/O from responses received by this client.
+    pub async fn storage_io_stats(&self) -> StorageStats {
+        self.storage_io_stats.lock().await.clone()
     }
 
     /// Send a storage request with a custom timeout
@@ -1087,12 +1097,18 @@ impl StorageClient {
                 };
 
                 match tokio::time::timeout(timeout, response_receiver).await {
-                    Ok(Ok(response)) => match response.result {
-                        Ok(data) => Ok(data),
-                        Err(storage_err) => Err(
-                            crate::error::DualRuntimeError::from_storage_error(storage_err),
-                        ),
-                    },
+                    Ok(Ok(response)) => {
+                        self.storage_io_stats
+                            .lock()
+                            .await
+                            .merge(&response.storage_stats);
+                        match response.result {
+                            Ok(data) => Ok(data),
+                            Err(storage_err) => Err(
+                                crate::error::DualRuntimeError::from_storage_error(storage_err),
+                            ),
+                        }
+                    }
                     Ok(Err(_)) => {
                         // Response channel was closed
                         Err(crate::error::DualRuntimeError::Channel(
@@ -1620,6 +1636,52 @@ mod tests {
 
         assert!(client.is_healthy());
         assert_eq!(client.pending_request_count().await, 0);
+        assert_eq!(client.storage_io_stats().await, StorageStats::default());
+    }
+
+    #[tokio::test]
+    async fn storage_client_aggregates_stats_from_responses() {
+        let mut channel = MessageChannel::new(4);
+        let mut requests = channel.take_request_receiver().unwrap();
+        let client = StorageClient::new(Arc::new(channel), Duration::from_secs(1));
+
+        let responder = tokio::spawn(async move {
+            let request = requests.recv().await.unwrap();
+            request
+                .response_channel
+                .send(StorageResponse {
+                    id: request.id,
+                    result: Ok(RespData::Integer(1)),
+                    execution_time: Duration::from_millis(1),
+                    storage_stats: StorageStats {
+                        keys_read: 1,
+                        bytes_read: 9,
+                        cache_hit: true,
+                        ..StorageStats::default()
+                    },
+                })
+                .expect("storage client should still be waiting for the response");
+        });
+
+        let result = client
+            .send_request(StorageCommand::Execute {
+                cmd_name: b"get".to_vec(),
+                argv: vec![b"get".to_vec(), b"key".to_vec()],
+            })
+            .await
+            .unwrap();
+
+        responder.await.unwrap();
+        assert_eq!(result, RespData::Integer(1));
+        assert_eq!(
+            client.storage_io_stats().await,
+            StorageStats {
+                keys_read: 1,
+                bytes_read: 9,
+                cache_hit: true,
+                ..StorageStats::default()
+            }
+        );
     }
 
     #[tokio::test]

--- a/src/common/runtime/message.rs
+++ b/src/common/runtime/message.rs
@@ -73,62 +73,17 @@ pub enum StorageCommand {
     Batch { commands: Vec<StorageCommand> },
 }
 
-/// Statistics about storage operations for monitoring
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct StorageStats {
-    /// Number of keys read during the operation
-    pub keys_read: u64,
-    /// Number of keys written during the operation
-    pub keys_written: u64,
-    /// Number of keys deleted during the operation
-    pub keys_deleted: u64,
-    /// Size of data read in bytes
-    pub bytes_read: u64,
-    /// Size of data written in bytes
-    pub bytes_written: u64,
-    /// Whether the operation hit the cache
-    pub cache_hit: bool,
-    /// RocksDB compaction level accessed
-    pub compaction_level: Option<u32>,
-}
-
-/// Request-local collector for storage-layer instrumentation.
+/// Storage-layer instrumentation types.
 ///
-/// TODO(storage-stats): Thread a real collector through `Cmd::execute` and the
-/// `storage` crate APIs so these counters are recorded at the point where
-/// reads, writes, deletes, cache hits, and RocksDB details actually happen.
-/// Tracked in <https://github.com/arana-db/kiwi/issues/312>.
-pub trait StorageStatsCollector: Send + Sync {
-    /// Record a storage read. `key_bytes` and `value_bytes` should be measured
-    /// by the storage layer, not inferred from Redis command arguments.
-    fn record_read(&self, key_bytes: u64, value_bytes: u64);
-
-    /// Record a storage write. `key_bytes` and `value_bytes` should be measured
-    /// after the storage layer accepts the mutation.
-    fn record_write(&self, key_bytes: u64, value_bytes: u64);
-
-    /// Record a storage delete. `key_bytes` should be measured by the storage layer.
-    fn record_delete(&self, key_bytes: u64);
-
-    /// Return the accumulated statistics for the request.
-    fn finish(&self) -> StorageStats;
-}
-
-/// Placeholder collector used until storage-layer instrumentation is wired in.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct NoopStorageStatsCollector;
-
-impl StorageStatsCollector for NoopStorageStatsCollector {
-    fn record_read(&self, _key_bytes: u64, _value_bytes: u64) {}
-
-    fn record_write(&self, _key_bytes: u64, _value_bytes: u64) {}
-
-    fn record_delete(&self, _key_bytes: u64) {}
-
-    fn finish(&self) -> StorageStats {
-        StorageStats::default()
-    }
-}
+/// These were originally defined here (see
+/// <https://github.com/arana-db/kiwi/issues/312>) but now live in the `client`
+/// crate so that `storage`, `runtime` and `cmd` can all depend on them without
+/// creating a dependency cycle. Re-exported here for backward compatibility with
+/// existing `runtime::message::*` importers.
+pub use client::storage_stats::{
+    RealStorageStatsCollector, STORAGE_STATS_COLLECTOR, StorageStats, StorageStatsCollector,
+    NoopStorageStatsCollector, try_collector,
+};
 
 /// Request sent from network runtime to storage runtime
 #[derive(Debug)]

--- a/src/common/runtime/metrics.rs
+++ b/src/common/runtime/metrics.rs
@@ -29,6 +29,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::sync::Mutex;
 
+use client::storage_stats::StorageStats;
+
 use crate::error::DualRuntimeError;
 
 /// Comprehensive runtime metrics for monitoring and observability
@@ -99,6 +101,9 @@ pub struct StorageRuntimeMetrics {
     pub p99_execution_time_ms: f64,
     /// Number of failed operations
     pub failed_operations: u64,
+    /// Logical storage I/O accumulated from completed requests
+    #[serde(default)]
+    pub storage_io_stats: StorageStats,
     /// RocksDB specific metrics
     pub rocksdb_metrics: RocksDBMetrics,
     /// Batch processing metrics
@@ -474,6 +479,8 @@ pub struct StorageMetricsTracker {
     pending_requests: AtomicUsize,
     /// Operation statistics
     operation_stats: Arc<Mutex<OperationStats>>,
+    /// Logical storage I/O reported by request-local collectors
+    storage_io_stats: Arc<Mutex<StorageStats>>,
     /// RocksDB metrics
     rocksdb_metrics: Arc<Mutex<RocksDBMetricsData>>,
     /// Batch processing metrics
@@ -800,6 +807,7 @@ impl StorageMetricsTracker {
                 start_time: Some(Instant::now()),
                 ..Default::default()
             })),
+            storage_io_stats: Arc::new(Mutex::new(StorageStats::default())),
             rocksdb_metrics: Arc::new(Mutex::new(RocksDBMetricsData::default())),
             batch_metrics: Arc::new(Mutex::new(BatchMetricsData::default())),
             latency_samples: Arc::new(Mutex::new(LatencySamples::default())),
@@ -833,6 +841,11 @@ impl StorageMetricsTracker {
 
         let mut samples = self.latency_samples.lock().await;
         samples.add_sample(execution_time.as_millis() as u64, self.sample_window_size);
+    }
+
+    /// Merge one completed request's logical storage I/O into runtime metrics.
+    pub async fn record_storage_stats(&self, request: &StorageStats) {
+        self.storage_io_stats.lock().await.merge(request);
     }
 
     /// Update RocksDB metrics
@@ -907,6 +920,7 @@ impl StorageMetricsTracker {
     pub async fn get_metrics(&self) -> StorageRuntimeMetrics {
         let pending_requests = self.pending_requests.load(Ordering::Relaxed);
         let operation_stats = self.operation_stats.lock().await;
+        let storage_io_stats = self.storage_io_stats.lock().await;
         let rocksdb_metrics = self.rocksdb_metrics.lock().await;
         let batch_metrics = self.batch_metrics.lock().await;
         let samples = self.latency_samples.lock().await;
@@ -967,6 +981,7 @@ impl StorageMetricsTracker {
             p95_execution_time_ms: p95_execution_time,
             p99_execution_time_ms: p99_execution_time,
             failed_operations: operation_stats.failed_operations,
+            storage_io_stats: storage_io_stats.clone(),
             rocksdb_metrics: RocksDBMetrics {
                 total_keys: rocksdb_metrics.total_keys,
                 total_size_bytes: rocksdb_metrics.total_size_bytes,
@@ -1007,6 +1022,9 @@ impl StorageMetricsTracker {
             start_time: Some(Instant::now()),
             ..Default::default()
         };
+
+        let mut storage_io_stats = self.storage_io_stats.lock().await;
+        *storage_io_stats = StorageStats::default();
 
         let mut rocksdb_metrics = self.rocksdb_metrics.lock().await;
         *rocksdb_metrics = RocksDBMetricsData::default();
@@ -1419,8 +1437,25 @@ mod tests {
         tracker
             .record_operation_success(Duration::from_millis(5))
             .await;
+        tracker.record_operation_started();
         tracker
             .record_operation_failure(Duration::from_millis(15))
+            .await;
+        tracker
+            .record_storage_stats(&StorageStats {
+                keys_read: 2,
+                bytes_read: 20,
+                cache_hit: true,
+                ..StorageStats::default()
+            })
+            .await;
+        tracker
+            .record_storage_stats(&StorageStats {
+                keys_written: 1,
+                bytes_written: 8,
+                compaction_level: Some(3),
+                ..StorageStats::default()
+            })
             .await;
         tracker
             .record_batch_processed(10, Duration::from_millis(50))
@@ -1430,8 +1465,22 @@ mod tests {
         let metrics = tracker.get_metrics().await;
         assert_eq!(metrics.total_operations, 2);
         assert_eq!(metrics.failed_operations, 1);
+        assert_eq!(metrics.storage_io_stats.keys_read, 2);
+        assert_eq!(metrics.storage_io_stats.bytes_read, 20);
+        assert_eq!(metrics.storage_io_stats.keys_written, 1);
+        assert_eq!(metrics.storage_io_stats.bytes_written, 8);
+        assert!(metrics.storage_io_stats.cache_hit);
+        assert_eq!(metrics.storage_io_stats.compaction_level, Some(3));
         assert_eq!(metrics.batch_metrics.total_batches, 1);
         assert_eq!(metrics.batch_metrics.backpressure_events, 1);
+
+        tracker.reset().await;
+        let reset_metrics = tracker.get_metrics().await;
+        assert_eq!(reset_metrics.total_operations, 0);
+        assert_eq!(reset_metrics.failed_operations, 0);
+        assert_eq!(reset_metrics.storage_io_stats, StorageStats::default());
+        assert_eq!(reset_metrics.batch_metrics.total_batches, 0);
+        assert_eq!(reset_metrics.batch_metrics.backpressure_events, 0);
     }
 
     #[tokio::test]

--- a/src/common/runtime/storage_server.rs
+++ b/src/common/runtime/storage_server.rs
@@ -35,8 +35,8 @@ use storage::storage::Storage;
 use crate::error::DualRuntimeError;
 use crate::global_storage::GlobalStorage;
 use crate::message::{
-    NoopStorageStatsCollector, RequestPriority, StorageCommand, StorageRequest, StorageResponse,
-    StorageStatsCollector,
+    RealStorageStatsCollector, RequestPriority, STORAGE_STATS_COLLECTOR, StorageCommand,
+    StorageRequest, StorageResponse, StorageStatsCollector,
 };
 use crate::metrics::StorageMetricsTracker;
 
@@ -563,13 +563,21 @@ impl StorageServer {
             // tracker.record_operation_started();
         }
 
-        // TODO(storage-stats): Pass this request-local collector through
-        // `Cmd::execute` and into the storage crate so stats are recorded by
-        // actual storage operations instead of inferred from command arguments.
-        let stats_collector = NoopStorageStatsCollector;
+        // Per-request storage stats collector, scoped for the duration of the
+        // command execution so the storage engine records real I/O counters
+        // instead of values inferred from command arguments.
+        // See <https://github.com/arana-db/kiwi/issues/312>.
+        let stats_collector: Arc<dyn StorageStatsCollector + Send + Sync> =
+            Arc::new(RealStorageStatsCollector::new());
 
-        // Route the request based on command type
-        let result = Self::execute_storage_command(&storage, &request.command).await;
+        // Route the request based on command type. The collector is installed as a
+        // task-local so the storage facade methods can read it without changing
+        // every `Cmd::execute` signature.
+        let result = STORAGE_STATS_COLLECTOR
+            .scope(Arc::clone(&stats_collector), async move {
+                Self::execute_storage_command(&storage, &request.command).await
+            })
+            .await;
 
         let execution_time = start_time.elapsed();
         debug!(

--- a/src/common/runtime/storage_server.rs
+++ b/src/common/runtime/storage_server.rs
@@ -558,14 +558,13 @@ impl StorageServer {
         );
 
         // Record operation started
-        if let Some(ref _tracker) = metrics_tracker {
-            // TODO: Fix type annotation issue
-            // tracker.record_operation_started();
+        if let Some(ref tracker) = metrics_tracker {
+            tracker.record_operation_started();
         }
 
         // Per-request storage stats collector, scoped for the duration of the
-        // command execution so the storage engine records real I/O counters
-        // instead of values inferred from command arguments.
+        // command execution so the storage facade records successful logical
+        // operations after backend outcomes are known.
         // See <https://github.com/arana-db/kiwi/issues/312>.
         let stats_collector: Arc<dyn StorageStatsCollector + Send + Sync> =
             Arc::new(RealStorageStatsCollector::new());
@@ -585,25 +584,23 @@ impl StorageServer {
             request_id, execution_time
         );
 
-        // Record operation completed
-        if let Some(ref _tracker) = metrics_tracker {
-            match result {
-                Ok(_) => {
-                    // TODO: Fix type annotation issue
-                    // tracker.record_operation_success(execution_time).await
-                }
-                Err(_) => {
-                    // TODO: Fix type annotation issue
-                    // tracker.record_operation_failure(execution_time).await
-                }
+        let storage_stats = stats_collector.finish();
+
+        // Record operation outcome and request-local I/O in runtime metrics.
+        if let Some(ref tracker) = metrics_tracker {
+            if result.is_ok() {
+                tracker.record_operation_success(execution_time).await;
+            } else {
+                tracker.record_operation_failure(execution_time).await;
             }
+            tracker.record_storage_stats(&storage_stats).await;
         }
 
         let response = StorageResponse {
             id: request_id,
             result,
             execution_time,
-            storage_stats: stats_collector.finish(),
+            storage_stats,
         };
 
         // Send response back to network runtime
@@ -1384,10 +1381,10 @@ impl StorageServer {
 
         if command.requires_exclusive_storage_access() {
             let _guard = storage.acquire_exclusive_command_access().await;
-            command.execute(&client, Arc::clone(storage));
+            storage.with_storage_perf_context(|| command.execute(&client, Arc::clone(storage)));
         } else {
             let _guard = storage.acquire_shared_command_access().await;
-            command.execute(&client, Arc::clone(storage));
+            storage.with_storage_perf_context(|| command.execute(&client, Arc::clone(storage)));
         }
         Ok(client.take_reply())
     }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -51,6 +51,7 @@ moka = { version = "0.12", features = ["sync"] }
 foyer.workspace = true
 rand.workspace = true
 conf.workspace = true
+client = { path = "../client" }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys.workspace = true

--- a/src/storage/src/redis_hashes.rs
+++ b/src/storage/src/redis_hashes.rs
@@ -272,6 +272,16 @@ impl Redis {
     }
 
     pub fn hset(&self, key: &[u8], field: &[u8], value: &[u8]) -> Result<i32> {
+        self.hset_with_outcome(key, field, value)
+            .map(|(added, _changed)| added)
+    }
+
+    pub(crate) fn hset_with_outcome(
+        &self,
+        key: &[u8],
+        field: &[u8],
+        value: &[u8],
+    ) -> Result<(i32, bool)> {
         let (db, cfs) = get_db_and_cfs!(
             self,
             ColumnFamilyIndex::MetaCF,
@@ -316,7 +326,7 @@ impl Redis {
                 match self.check_type_state(meta_val_bytes.as_ref(), DataType::Hash)? {
                     TypeCheckState::Missing | TypeCheckState::Stale => {
                         create_new_hash(self, key, field, value)?;
-                        return Ok(1);
+                        return Ok((1, true));
                     }
                     TypeCheckState::Match => {}
                 }
@@ -340,7 +350,7 @@ impl Redis {
                         &data_value.encode(),
                     )?;
                     batch.commit()?;
-                    Ok(1)
+                    Ok((1, true))
                 } else {
                     let version = parsed_meta.version();
                     let data_key = MemberDataKey::new(key, version, field);
@@ -356,7 +366,7 @@ impl Redis {
                             existing_data.strip_suffix();
 
                             if existing_data.user_value() == value {
-                                Ok(0)
+                                Ok((0, false))
                             } else {
                                 let data_value = BaseDataValue::new(value.to_vec());
                                 let mut batch = self.create_batch()?;
@@ -366,7 +376,7 @@ impl Redis {
                                     &data_value.encode(),
                                 )?;
                                 batch.commit()?;
-                                Ok(0)
+                                Ok((0, true))
                             }
                         }
                         None => {
@@ -391,14 +401,14 @@ impl Redis {
                                 &data_value.encode(),
                             )?;
                             batch.commit()?;
-                            Ok(1)
+                            Ok((1, true))
                         }
                     }
                 }
             }
             None => {
                 create_new_hash(self, key, field, value)?;
-                Ok(1)
+                Ok((1, true))
             }
         }
     }

--- a/src/storage/src/redis_strings.rs
+++ b/src/storage/src/redis_strings.rs
@@ -304,6 +304,16 @@ impl Redis {
     /// O(1) for small strings when offset is within current length,
     /// O(M) where M is the length of the value argument for other cases.
     pub fn setrange(&self, key: &[u8], offset: i64, value: &[u8]) -> Result<i32> {
+        self.setrange_with_outcome(key, offset, value)
+            .map(|(length, _changed)| length)
+    }
+
+    pub(crate) fn setrange_with_outcome(
+        &self,
+        key: &[u8],
+        offset: i64,
+        value: &[u8],
+    ) -> Result<(i32, bool)> {
         // Validate offset early to avoid unnecessary database operations
         if offset < 0 {
             return Err(RedisErr {
@@ -357,7 +367,7 @@ impl Redis {
             let current_len = existing_value.len() as i32;
             // If offset is within current string, no modification needed
             if offset <= current_len as i64 {
-                return Ok(current_len);
+                return Ok((current_len, false));
             }
             // If offset is beyond current string, we need to pad
         }
@@ -406,7 +416,7 @@ impl Redis {
         )?;
         batch.commit()?;
 
-        Ok(new_len as i32)
+        Ok((new_len as i32, true))
     }
 
     /// Append a value to a key

--- a/src/storage/src/storage_impl.rs
+++ b/src/storage/src/storage_impl.rs
@@ -22,6 +22,32 @@ use crate::storage::Storage;
 
 use client::storage_stats::try_collector;
 
+fn record_read(key: &[u8], value_len: usize) {
+    if let Some(collector) = try_collector() {
+        collector.record_read(key.len() as u64, value_len as u64);
+    }
+}
+
+fn record_write(key: &[u8], value_len: usize) {
+    if let Some(collector) = try_collector() {
+        collector.record_write(key.len() as u64, value_len as u64);
+    }
+}
+
+fn record_delete(key: &[u8]) {
+    if let Some(collector) = try_collector() {
+        collector.record_delete(key.len() as u64);
+    }
+}
+
+struct PerfStatsGuard;
+
+impl Drop for PerfStatsGuard {
+    fn drop(&mut self) {
+        rocksdb::perf::set_perf_stats(rocksdb::PerfStatsLevel::Disable);
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BeforeOrAfter {
     Before,
@@ -30,6 +56,26 @@ pub enum BeforeOrAfter {
 
 // Implementation of Storage struct methods
 impl Storage {
+    /// Execute one synchronous command while sampling RocksDB's thread-local
+    /// block-cache counter. The closure must not cross an `.await`, because a
+    /// Tokio task may resume on a different worker thread.
+    pub fn with_storage_perf_context<T>(&self, operation: impl FnOnce() -> T) -> T {
+        let Some(collector) = try_collector() else {
+            return operation();
+        };
+
+        rocksdb::perf::set_perf_stats(rocksdb::PerfStatsLevel::EnableCount);
+        let _perf_stats_guard = PerfStatsGuard;
+        let mut context = rocksdb::PerfContext::default();
+        context.reset();
+
+        let result = operation();
+        if context.metric(rocksdb::PerfMetric::BlockCacheHitCount) > 0 {
+            collector.record_cache_hit();
+        }
+        result
+    }
+
     fn key_etime_for_instance(&self, instance_id: usize, key: &[u8]) -> Result<Option<u64>> {
         self.insts[instance_id].key_etime(key)
     }
@@ -48,32 +94,43 @@ impl Storage {
     // Set key to hold the string value. if key
     // already holds a value, it is overwritten
     pub fn set(&self, key: &[u8], value: &[u8]) -> Result<()> {
-        if let Some(c) = try_collector() {
-            c.record_write(key.len() as u64, value.len() as u64);
-        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        self.insts[instance_id].set(key, value)
+        self.insts[instance_id].set(key, value)?;
+        record_write(key, value.len());
+        Ok(())
     }
 
     pub fn get(&self, key: &[u8]) -> Result<String> {
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        let value = self.insts[instance_id].get(key)?;
-        if let Some(c) = try_collector() {
-            c.record_read(key.len() as u64, value.len() as u64);
+        match self.insts[instance_id].get(key) {
+            Ok(value) => {
+                record_read(key, value.len());
+                Ok(value)
+            }
+            Err(err @ Error::KeyNotFound { .. }) => {
+                record_read(key, 0);
+                Err(err)
+            }
+            Err(err) => Err(err),
         }
-        Ok(value)
     }
 
     pub fn get_binary(&self, key: &[u8]) -> Result<Vec<u8>> {
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        let value = self.insts[instance_id].get_binary(key)?;
-        if let Some(c) = try_collector() {
-            c.record_read(key.len() as u64, value.len() as u64);
+        match self.insts[instance_id].get_binary(key) {
+            Ok(value) => {
+                record_read(key, value.len());
+                Ok(value)
+            }
+            Err(err @ Error::KeyNotFound { .. }) => {
+                record_read(key, 0);
+                Err(err)
+            }
+            Err(err) => Err(err),
         }
-        Ok(value)
     }
 
     pub fn mget(&self, keys: &[Vec<u8>]) -> Result<Vec<Option<String>>> {
@@ -89,13 +146,11 @@ impl Storage {
             return Ok(Vec::new());
         }
 
-        // Record per-key read stats with the actual returned value sizes.
+        // Record each completed shard immediately. A later shard can fail after
+        // RocksDB has already served earlier reads.
         let record = |keys: &[Vec<u8>], results: &[Option<Vec<u8>>]| {
-            if let Some(c) = try_collector() {
-                for (key, value) in keys.iter().zip(results.iter()) {
-                    let value_len = value.as_ref().map(|v| v.len()).unwrap_or(0);
-                    c.record_read(key.len() as u64, value_len as u64);
-                }
+            for (key, value) in keys.iter().zip(results.iter()) {
+                record_read(key, value.as_ref().map_or(0, Vec::len));
             }
         };
 
@@ -107,8 +162,8 @@ impl Storage {
         }
 
         // Multi-instance: group keys by instance and process
-        let mut instance_keys: std::collections::HashMap<usize, Vec<(usize, &Vec<u8>)>> =
-            std::collections::HashMap::new();
+        let mut instance_keys: std::collections::BTreeMap<usize, Vec<(usize, &Vec<u8>)>> =
+            std::collections::BTreeMap::new();
 
         for (idx, key) in keys.iter().enumerate() {
             let slot_id = key_to_slot_id(key);
@@ -125,13 +180,12 @@ impl Storage {
             let instance_keys: Vec<Vec<u8>> =
                 key_indices.iter().map(|(_, key)| (*key).clone()).collect();
             let instance_results = self.insts[instance_id].mget_binary(&instance_keys)?;
+            record(&instance_keys, &instance_results);
 
             for ((original_idx, _), result) in key_indices.iter().zip(instance_results) {
                 results[*original_idx] = result;
             }
         }
-
-        record(keys, &results);
         Ok(results)
     }
 
@@ -140,22 +194,20 @@ impl Storage {
             return Ok(());
         }
 
-        if let Some(c) = try_collector() {
-            for (k, v) in kvs {
-                c.record_write(k.len() as u64, v.len() as u64);
-            }
-        }
-
         // If single instance, process directly for better performance
         if self.insts.len() == 1 {
-            return self.insts[0].mset(kvs);
+            self.insts[0].mset(kvs)?;
+            for (key, value) in kvs {
+                record_write(key, value.len());
+            }
+            return Ok(());
         }
 
-        // Define type alias for complex HashMap type to satisfy clippy::type_complexity
-        type InstanceKvs = std::collections::HashMap<usize, Vec<(Vec<u8>, Vec<u8>)>>;
+        // Define a type alias for the grouped key/value pairs.
+        type InstanceKvs = std::collections::BTreeMap<usize, Vec<(Vec<u8>, Vec<u8>)>>;
 
         // Multi-instance: group key-value pairs by instance and process
-        let mut instance_kvs: InstanceKvs = std::collections::HashMap::new();
+        let mut instance_kvs = InstanceKvs::new();
 
         for (key, value) in kvs {
             let slot_id = key_to_slot_id(key);
@@ -169,6 +221,9 @@ impl Storage {
         // Execute mset on each instance
         for (instance_id, instance_kvs) in instance_kvs {
             self.insts[instance_id].mset(&instance_kvs)?;
+            for (key, value) in &instance_kvs {
+                record_write(key, value.len());
+            }
         }
 
         Ok(())
@@ -181,18 +236,16 @@ impl Storage {
 
         if self.insts.len() == 1 {
             let ok = self.insts[0].msetnx(kvs)?;
-            if ok {
-                if let Some(c) = try_collector() {
-                    for (k, v) in kvs {
-                        c.record_write(k.len() as u64, v.len() as u64);
-                    }
+            if ok && let Some(c) = try_collector() {
+                for (key, value) in kvs {
+                    c.record_write(key.len() as u64, value.len() as u64);
                 }
             }
             return Ok(ok);
         }
 
-        type InstanceKvs = std::collections::HashMap<usize, Vec<(Vec<u8>, Vec<u8>)>>;
-        let mut instance_kvs: InstanceKvs = std::collections::HashMap::new();
+        type InstanceKvs = std::collections::BTreeMap<usize, Vec<(Vec<u8>, Vec<u8>)>>;
+        let mut instance_kvs = InstanceKvs::new();
 
         // Group key-value pairs by instance
         for (key, value) in kvs {
@@ -228,11 +281,8 @@ impl Storage {
         // Set all key-value pairs since none exist
         for (instance_id, kv_pairs) in instance_kvs {
             self.insts[instance_id].mset(&kv_pairs)?;
-        }
-
-        if let Some(c) = try_collector() {
-            for (k, v) in kvs {
-                c.record_write(k.len() as u64, v.len() as u64);
+            for (key, value) in &kv_pairs {
+                record_write(key, value.len());
             }
         }
 
@@ -246,12 +296,11 @@ impl Storage {
     }
 
     pub fn append(&self, key: &[u8], value: &[u8]) -> Result<i32> {
-        if let Some(c) = try_collector() {
-            c.record_write(key.len() as u64, value.len() as u64);
-        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        self.insts[instance_id].append(key, value)
+        let length = self.insts[instance_id].append(key, value)?;
+        record_write(key, value.len());
+        Ok(length)
     }
 
     pub fn strlen(&self, key: &[u8]) -> Result<i32> {
@@ -271,21 +320,22 @@ impl Storage {
     }
 
     pub fn setrange(&self, key: &[u8], offset: i64, value: &[u8]) -> Result<i32> {
-        if let Some(c) = try_collector() {
-            c.record_write(key.len() as u64, value.len() as u64);
-        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        self.insts[instance_id].setrange(key, offset, value)
+        let (length, changed) =
+            self.insts[instance_id].setrange_with_outcome(key, offset, value)?;
+        if changed {
+            record_write(key, value.len());
+        }
+        Ok(length)
     }
 
     pub fn setex(&self, key: &[u8], seconds: i64, value: &[u8]) -> Result<()> {
-        if let Some(c) = try_collector() {
-            c.record_write(key.len() as u64, value.len() as u64);
-        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        self.insts[instance_id].setex(key, seconds, value)
+        self.insts[instance_id].setex(key, seconds, value)?;
+        record_write(key, value.len());
+        Ok(())
     }
 
     pub fn psetex(&self, key: &[u8], milliseconds: i64, value: &[u8]) -> Result<()> {
@@ -295,30 +345,29 @@ impl Storage {
     }
 
     pub fn setnx(&self, key: &[u8], value: &[u8]) -> Result<i32> {
-        if let Some(c) = try_collector() {
-            c.record_write(key.len() as u64, value.len() as u64);
-        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        self.insts[instance_id].setnx(key, value)
+        let inserted = self.insts[instance_id].setnx(key, value)?;
+        if inserted != 0 {
+            record_write(key, value.len());
+        }
+        Ok(inserted)
     }
 
     pub fn setbit(&self, key: &[u8], offset: i64, value: i64) -> Result<i64> {
-        if let Some(c) = try_collector() {
-            c.record_write(key.len() as u64, 0);
-        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        self.insts[instance_id].setbit(key, offset, value)
+        let old_value = self.insts[instance_id].setbit(key, offset, value)?;
+        record_write(key, 0);
+        Ok(old_value)
     }
 
     pub fn getbit(&self, key: &[u8], offset: i64) -> Result<i64> {
-        if let Some(c) = try_collector() {
-            c.record_read(key.len() as u64, 0);
-        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        self.insts[instance_id].getbit(key, offset)
+        let value = self.insts[instance_id].getbit(key, offset)?;
+        record_read(key, 0);
+        Ok(value)
     }
 
     pub fn bitcount(&self, key: &[u8], start: Option<i64>, end: Option<i64>) -> Result<i64> {
@@ -359,12 +408,11 @@ impl Storage {
     }
 
     pub fn getset(&self, key: &[u8], value: &[u8]) -> Result<Option<String>> {
-        if let Some(c) = try_collector() {
-            c.record_write(key.len() as u64, value.len() as u64);
-        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        self.insts[instance_id].getset(key, value)
+        let old_value = self.insts[instance_id].getset(key, value)?;
+        record_write(key, value.len());
+        Ok(old_value)
     }
 
     pub fn incr_decr_float(&self, key: &[u8], incr: f64) -> Result<f64> {
@@ -376,12 +424,13 @@ impl Storage {
     // Hash Commands Implementation
 
     pub fn hset(&self, key: &[u8], field: &[u8], value: &[u8]) -> Result<i32> {
-        if let Some(c) = try_collector() {
-            c.record_write(key.len() as u64, value.len() as u64);
-        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        self.insts[instance_id].hset(key, field, value)
+        let (added, changed) = self.insts[instance_id].hset_with_outcome(key, field, value)?;
+        if changed {
+            record_write(key, value.len());
+        }
+        Ok(added)
     }
 
     pub fn hget(&self, key: &[u8], field: &[u8]) -> Result<Option<String>> {
@@ -396,12 +445,13 @@ impl Storage {
     }
 
     pub fn hdel(&self, key: &[u8], fields: &[Vec<u8>]) -> Result<i32> {
-        if let Some(c) = try_collector() {
-            c.record_delete(key.len() as u64);
-        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        self.insts[instance_id].hdel(key, fields)
+        let deleted = self.insts[instance_id].hdel(key, fields)?;
+        if deleted > 0 {
+            record_delete(key);
+        }
+        Ok(deleted)
     }
 
     pub fn hexists(&self, key: &[u8], field: &[u8]) -> Result<bool> {

--- a/src/storage/src/storage_impl.rs
+++ b/src/storage/src/storage_impl.rs
@@ -20,6 +20,8 @@ use crate::format_zset_score_key::ZsetScoreMember;
 use crate::slot_indexer::key_to_slot_id;
 use crate::storage::Storage;
 
+use client::storage_stats::try_collector;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BeforeOrAfter {
     Before,
@@ -46,6 +48,9 @@ impl Storage {
     // Set key to hold the string value. if key
     // already holds a value, it is overwritten
     pub fn set(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        if let Some(c) = try_collector() {
+            c.record_write(key.len() as u64, value.len() as u64);
+        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
         self.insts[instance_id].set(key, value)
@@ -54,13 +59,21 @@ impl Storage {
     pub fn get(&self, key: &[u8]) -> Result<String> {
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        self.insts[instance_id].get(key)
+        let value = self.insts[instance_id].get(key)?;
+        if let Some(c) = try_collector() {
+            c.record_read(key.len() as u64, value.len() as u64);
+        }
+        Ok(value)
     }
 
     pub fn get_binary(&self, key: &[u8]) -> Result<Vec<u8>> {
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        self.insts[instance_id].get_binary(key)
+        let value = self.insts[instance_id].get_binary(key)?;
+        if let Some(c) = try_collector() {
+            c.record_read(key.len() as u64, value.len() as u64);
+        }
+        Ok(value)
     }
 
     pub fn mget(&self, keys: &[Vec<u8>]) -> Result<Vec<Option<String>>> {
@@ -76,9 +89,21 @@ impl Storage {
             return Ok(Vec::new());
         }
 
+        // Record per-key read stats with the actual returned value sizes.
+        let record = |keys: &[Vec<u8>], results: &[Option<Vec<u8>>]| {
+            if let Some(c) = try_collector() {
+                for (key, value) in keys.iter().zip(results.iter()) {
+                    let value_len = value.as_ref().map(|v| v.len()).unwrap_or(0);
+                    c.record_read(key.len() as u64, value_len as u64);
+                }
+            }
+        };
+
         // If single instance, process directly for better performance
         if self.insts.len() == 1 {
-            return self.insts[0].mget_binary(keys);
+            let results = self.insts[0].mget_binary(keys)?;
+            record(keys, &results);
+            return Ok(results);
         }
 
         // Multi-instance: group keys by instance and process
@@ -106,12 +131,19 @@ impl Storage {
             }
         }
 
+        record(keys, &results);
         Ok(results)
     }
 
     pub fn mset(&self, kvs: &[(Vec<u8>, Vec<u8>)]) -> Result<()> {
         if kvs.is_empty() {
             return Ok(());
+        }
+
+        if let Some(c) = try_collector() {
+            for (k, v) in kvs {
+                c.record_write(k.len() as u64, v.len() as u64);
+            }
         }
 
         // If single instance, process directly for better performance
@@ -148,7 +180,15 @@ impl Storage {
         }
 
         if self.insts.len() == 1 {
-            return self.insts[0].msetnx(kvs);
+            let ok = self.insts[0].msetnx(kvs)?;
+            if ok {
+                if let Some(c) = try_collector() {
+                    for (k, v) in kvs {
+                        c.record_write(k.len() as u64, v.len() as u64);
+                    }
+                }
+            }
+            return Ok(ok);
         }
 
         type InstanceKvs = std::collections::HashMap<usize, Vec<(Vec<u8>, Vec<u8>)>>;
@@ -190,6 +230,12 @@ impl Storage {
             self.insts[instance_id].mset(&kv_pairs)?;
         }
 
+        if let Some(c) = try_collector() {
+            for (k, v) in kvs {
+                c.record_write(k.len() as u64, v.len() as u64);
+            }
+        }
+
         Ok(true)
     }
 
@@ -200,6 +246,9 @@ impl Storage {
     }
 
     pub fn append(&self, key: &[u8], value: &[u8]) -> Result<i32> {
+        if let Some(c) = try_collector() {
+            c.record_write(key.len() as u64, value.len() as u64);
+        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
         self.insts[instance_id].append(key, value)
@@ -214,16 +263,26 @@ impl Storage {
     pub fn getrange(&self, key: &[u8], start: i64, end: i64) -> Result<Vec<u8>> {
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        self.insts[instance_id].getrange(key, start, end)
+        let value = self.insts[instance_id].getrange(key, start, end)?;
+        if let Some(c) = try_collector() {
+            c.record_read(key.len() as u64, value.len() as u64);
+        }
+        Ok(value)
     }
 
     pub fn setrange(&self, key: &[u8], offset: i64, value: &[u8]) -> Result<i32> {
+        if let Some(c) = try_collector() {
+            c.record_write(key.len() as u64, value.len() as u64);
+        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
         self.insts[instance_id].setrange(key, offset, value)
     }
 
     pub fn setex(&self, key: &[u8], seconds: i64, value: &[u8]) -> Result<()> {
+        if let Some(c) = try_collector() {
+            c.record_write(key.len() as u64, value.len() as u64);
+        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
         self.insts[instance_id].setex(key, seconds, value)
@@ -236,18 +295,27 @@ impl Storage {
     }
 
     pub fn setnx(&self, key: &[u8], value: &[u8]) -> Result<i32> {
+        if let Some(c) = try_collector() {
+            c.record_write(key.len() as u64, value.len() as u64);
+        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
         self.insts[instance_id].setnx(key, value)
     }
 
     pub fn setbit(&self, key: &[u8], offset: i64, value: i64) -> Result<i64> {
+        if let Some(c) = try_collector() {
+            c.record_write(key.len() as u64, 0);
+        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
         self.insts[instance_id].setbit(key, offset, value)
     }
 
     pub fn getbit(&self, key: &[u8], offset: i64) -> Result<i64> {
+        if let Some(c) = try_collector() {
+            c.record_read(key.len() as u64, 0);
+        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
         self.insts[instance_id].getbit(key, offset)
@@ -291,6 +359,9 @@ impl Storage {
     }
 
     pub fn getset(&self, key: &[u8], value: &[u8]) -> Result<Option<String>> {
+        if let Some(c) = try_collector() {
+            c.record_write(key.len() as u64, value.len() as u64);
+        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
         self.insts[instance_id].getset(key, value)
@@ -305,6 +376,9 @@ impl Storage {
     // Hash Commands Implementation
 
     pub fn hset(&self, key: &[u8], field: &[u8], value: &[u8]) -> Result<i32> {
+        if let Some(c) = try_collector() {
+            c.record_write(key.len() as u64, value.len() as u64);
+        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
         self.insts[instance_id].hset(key, field, value)
@@ -313,10 +387,18 @@ impl Storage {
     pub fn hget(&self, key: &[u8], field: &[u8]) -> Result<Option<String>> {
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
-        self.insts[instance_id].hget(key, field)
+        let value = self.insts[instance_id].hget(key, field)?;
+        if let Some(c) = try_collector() {
+            let value_len = value.as_ref().map(|v| v.len()).unwrap_or(0);
+            c.record_read(key.len() as u64, value_len as u64);
+        }
+        Ok(value)
     }
 
     pub fn hdel(&self, key: &[u8], fields: &[Vec<u8>]) -> Result<i32> {
+        if let Some(c) = try_collector() {
+            c.record_delete(key.len() as u64);
+        }
         let slot_id = key_to_slot_id(key);
         let instance_id = self.slot_indexer.get_instance_id(slot_id);
         self.insts[instance_id].hdel(key, fields)
@@ -701,7 +783,12 @@ impl Storage {
 
             // Try to delete the key - this will handle all data types
             match self.insts[instance_id].del_key(key) {
-                Ok(true) => deleted_count += 1,
+                Ok(true) => {
+                    deleted_count += 1;
+                    if let Some(c) = try_collector() {
+                        c.record_delete(key.len() as u64);
+                    }
+                }
                 Ok(false) => {} // Key doesn't exist
                 Err(e) => {
                     // Log error but continue deleting other keys

--- a/src/storage/tests/storage_stats_test.rs
+++ b/src/storage/tests/storage_stats_test.rs
@@ -1,0 +1,200 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use client::storage_stats::{
+    RealStorageStatsCollector, STORAGE_STATS_COLLECTOR, StorageStats, StorageStatsCollector,
+};
+use storage::slot_indexer::key_to_slot_id;
+use storage::storage::Storage;
+use storage::{StorageOptions, fail_next_rocks_batch_commit};
+
+async fn collect_stats<T>(operation: impl FnOnce() -> T) -> (T, StorageStats) {
+    let collector = Arc::new(RealStorageStatsCollector::new());
+    let scoped: Arc<dyn StorageStatsCollector + Send + Sync> = collector.clone();
+    let result = STORAGE_STATS_COLLECTOR
+        .scope(scoped, async { operation() })
+        .await;
+    (result, collector.finish())
+}
+
+fn open_storage(instance_count: usize, path: &std::path::Path) -> Storage {
+    let mut storage = Storage::new(instance_count, 0);
+    let _background_tasks = storage
+        .open(Arc::new(StorageOptions::default()), path)
+        .unwrap();
+    storage
+}
+
+#[tokio::test]
+async fn setnx_and_hdel_record_only_actual_mutations() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = open_storage(1, temp_dir.path());
+    let key = b"stats:key";
+    let value = b"value";
+
+    let (set_result, stats) = collect_stats(|| storage.setnx(key, value)).await;
+    assert_eq!(set_result.unwrap(), 1);
+    assert_eq!(stats.keys_written, 1);
+    assert_eq!(stats.bytes_written, (key.len() + value.len()) as u64);
+
+    let (set_result, stats) = collect_stats(|| storage.setnx(key, value)).await;
+    assert_eq!(set_result.unwrap(), 0);
+    assert_eq!(stats, StorageStats::default());
+
+    let hash_key = b"stats:hash";
+    let field = b"field";
+    storage.hset(hash_key, field, b"hash-value").unwrap();
+
+    let (delete_result, stats) = collect_stats(|| storage.hdel(hash_key, &[field.to_vec()])).await;
+    assert_eq!(delete_result.unwrap(), 1);
+    assert_eq!(stats.keys_deleted, 1);
+    assert_eq!(stats.bytes_deleted, hash_key.len() as u64);
+
+    let (delete_result, stats) = collect_stats(|| storage.hdel(hash_key, &[field.to_vec()])).await;
+    assert_eq!(delete_result.unwrap(), 0);
+    assert_eq!(stats, StorageStats::default());
+}
+
+#[tokio::test]
+async fn failed_mutations_do_not_record_writes() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = open_storage(1, temp_dir.path());
+
+    let (setex_result, stats) = collect_stats(|| storage.setex(b"key", 0, b"value")).await;
+    assert!(setex_result.is_err());
+    assert_eq!(stats, StorageStats::default());
+
+    storage.set(b"wrong-type", b"string").unwrap();
+    let (hset_result, stats) =
+        collect_stats(|| storage.hset(b"wrong-type", b"field", b"value")).await;
+    assert!(hset_result.is_err());
+    assert_eq!(stats, StorageStats::default());
+
+    let _fail_commit = fail_next_rocks_batch_commit(&temp_dir.path().join("0"));
+    let (set_result, stats) = collect_stats(|| storage.set(b"commit", b"fails")).await;
+    assert!(set_result.is_err());
+    assert_eq!(stats, StorageStats::default());
+}
+
+#[tokio::test]
+async fn successful_noops_do_not_record_writes() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = open_storage(1, temp_dir.path());
+
+    storage.set(b"range", b"value").unwrap();
+    let (setrange_result, stats) = collect_stats(|| storage.setrange(b"range", 2, b"")).await;
+    assert_eq!(setrange_result.unwrap(), 5);
+    assert_eq!(stats, StorageStats::default());
+
+    storage.hset(b"hash", b"field", b"value").unwrap();
+    let (hset_result, stats) = collect_stats(|| storage.hset(b"hash", b"field", b"value")).await;
+    assert_eq!(hset_result.unwrap(), 0);
+    assert_eq!(stats, StorageStats::default());
+
+    let (hset_result, stats) =
+        collect_stats(|| storage.hset(b"hash", b"field", b"new-value")).await;
+    assert_eq!(hset_result.unwrap(), 0);
+    assert_eq!(stats.keys_written, 1);
+    assert_eq!(
+        stats.bytes_written,
+        (b"hash".len() + b"new-value".len()) as u64
+    );
+}
+
+#[tokio::test]
+async fn missing_get_records_a_logical_read() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = open_storage(1, temp_dir.path());
+    let key = b"missing";
+
+    let (result, stats) = collect_stats(|| storage.get_binary(key)).await;
+    assert!(result.is_err());
+    assert_eq!(stats.keys_read, 1);
+    assert_eq!(stats.bytes_read, key.len() as u64);
+}
+
+#[tokio::test]
+async fn multi_instance_mset_records_every_completed_pair() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = open_storage(3, temp_dir.path());
+
+    let mut keys_by_instance = HashMap::new();
+    for index in 0..10_000 {
+        let key = format!("stats:mset:{index}").into_bytes();
+        let instance_id = storage.slot_indexer.get_instance_id(key_to_slot_id(&key));
+        keys_by_instance.entry(instance_id).or_insert(key);
+        if keys_by_instance.len() == 3 {
+            break;
+        }
+    }
+    assert_eq!(keys_by_instance.len(), 3);
+
+    let kvs: Vec<(Vec<u8>, Vec<u8>)> = keys_by_instance
+        .into_values()
+        .enumerate()
+        .map(|(index, key)| (key, format!("value-{index}").into_bytes()))
+        .collect();
+    let expected_bytes = kvs
+        .iter()
+        .map(|(key, value)| key.len() + value.len())
+        .sum::<usize>() as u64;
+
+    let (result, stats) = collect_stats(|| storage.mset(&kvs)).await;
+    result.unwrap();
+    assert_eq!(stats.keys_written, kvs.len() as u64);
+    assert_eq!(stats.bytes_written, expected_bytes);
+}
+
+#[tokio::test]
+async fn multi_instance_mset_preserves_stats_for_shards_committed_before_failure() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = open_storage(3, temp_dir.path());
+
+    let mut keys_by_instance = HashMap::new();
+    for index in 0..10_000 {
+        let key = format!("stats:partial:{index}").into_bytes();
+        let instance_id = storage.slot_indexer.get_instance_id(key_to_slot_id(&key));
+        keys_by_instance.entry(instance_id).or_insert(key);
+        if keys_by_instance.contains_key(&0) && keys_by_instance.contains_key(&1) {
+            break;
+        }
+    }
+
+    let first_key = keys_by_instance.remove(&0).unwrap();
+    let failing_key = keys_by_instance.remove(&1).unwrap();
+    let first_value = b"committed".to_vec();
+    let kvs = vec![
+        (failing_key, b"rejected".to_vec()),
+        (first_key.clone(), first_value.clone()),
+    ];
+
+    let _fail_commit = fail_next_rocks_batch_commit(&temp_dir.path().join("1"));
+    let (result, stats) = collect_stats(|| storage.mset(&kvs)).await;
+
+    assert!(result.is_err());
+    assert_eq!(stats.keys_written, 1);
+    assert_eq!(
+        stats.bytes_written,
+        (first_key.len() + first_value.len()) as u64
+    );
+    assert_eq!(storage.get_binary(&first_key).unwrap(), first_value);
+}


### PR DESCRIPTION
## Summary

This PR introduces request-local storage statistics infrastructure and wires an initial set of string, multi-key, and hash operations into it.

- Installs `RealStorageStatsCollector` per storage request using a Tokio task-local.
- Records logical key and payload counters only after backend outcomes are known.
- Preserves statistics for shards completed before a later multi-instance failure.
- Adds backward-compatible cache and compaction recording APIs to the collector trait; block-cache hits are sampled only across the synchronous command execution boundary.
- Returns per-request statistics in `StorageResponse`, aggregates received responses in `StorageClient`, and feeds the optional runtime metrics tracker.
- Keeps existing `runtime::message` imports working through compatibility re-exports.

## Correctness details

- Failed mutations and successful no-ops do not count as writes or deletes.
- `SETNX`, `HDEL`, `SETRANGE`, and `HSET` distinguish actual mutations from no-ops.
- GET misses count as successful logical reads because the command layer returns a normal nil response.
- Multi-instance MGET/MSET/MSETNX process shards in deterministic order and account for each completed shard immediately.
- RocksDB `PerfContext` is sampled only inside synchronous `Cmd::execute`; it is not kept across `.await` points where Tokio may move the task to another worker thread.
- New optional trait methods have no-op defaults, so existing custom collectors remain source-compatible.
- `StorageStats` defaults newly added fields during deserialization, and resetting runtime metrics now clears aggregated storage I/O as well.

## Scope

This is an incremental implementation related to #312. It does not close that issue: the remaining `Storage` facade methods still need logical operation instrumentation, and the current RocksDB Rust API does not expose a reliable request-attributable served compaction level.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p client` (6 passed)
- `cargo test -p runtime` (135 passed)
- `cargo test -p storage --features test-fault-injection --test storage_stats_test -- --test-threads=1 --nocapture` (6 passed)
- `cargo clippy --manifest-path ./Cargo.toml --all-features --workspace -- -D warnings -D clippy::unwrap_used`
- `git diff --check`
- Exact license-header comparison for every changed or added Rust source file

Related to #312
