### PR TITLE
fix: resolve code-quality issues across workspace (#396-#401)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,9 @@ jobs:
 
       - run: make lint
 
+      - name: Lint runtime baseline tool targets
+        run: cargo clippy -p runtime-baseline --all-targets -- -D warnings -D clippy::unwrap_used
+
   build-and-test:
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,9 +136,6 @@ jobs:
 
       - run: make lint
 
-      - name: Lint runtime baseline tool targets
-        run: cargo clippy -p runtime-baseline --all-targets -- -D warnings -D clippy::unwrap_used
-
   build-and-test:
     strategy:
       fail-fast: false
@@ -222,6 +219,10 @@ jobs:
           timeout_minutes: 30
           max_attempts: 2
           command: bash -o pipefail -c "make test 2>&1 | tee cargo-test.log"
+
+      - name: Test storage stats with fault injection
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo test -p storage --features test-fault-injection --test storage_stats_test
 
       - name: Test runtime baseline tool
         run: cargo test -p runtime-baseline --all-targets

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ fmt-check:
 	@cargo fmt --manifest-path ./Cargo.toml --all -- --check
 
 lint:
-	@cargo clippy --manifest-path ./Cargo.toml --all-features --workspace -- -D warnings -D clippy::unwrap_used
+	@cargo clippy --manifest-path ./Cargo.toml --all-features --workspace --all-targets -- -D warnings -D clippy::unwrap_used
 
 standalone:
 	@$(DEV) build

--- a/docs/quality/quality-gates.md
+++ b/docs/quality/quality-gates.md
@@ -16,7 +16,7 @@
 ```text
 license header / third-party license check
 cargo fmt --check
-cargo clippy --all-features --workspace -- -D warnings -D clippy::unwrap_used
+cargo clippy --all-features --workspace --all-targets -- -D warnings -D clippy::unwrap_used
 targeted unit tests
 affected compatibility manifest tests
 Cache OFF compatibility and recovery evidence

--- a/src/cmd/src/set.rs
+++ b/src/cmd/src/set.rs
@@ -48,7 +48,7 @@ impl Cmd for SetCmd {
 
     /// SET key value
     fn do_initial(&self, client: &Client) -> bool {
-        // TODO: support xx, nx, ex, px
+        // TODO(#400): support xx, nx, ex, px
         let argv = client.argv();
 
         let key = argv[1].clone();

--- a/src/common/runtime/additional_unit_tests.rs
+++ b/src/common/runtime/additional_unit_tests.rs
@@ -372,7 +372,7 @@ mod serialization_tests {
 
     #[test]
     fn test_noop_storage_stats_collector() {
-        let collector = NoopStorageStatsCollector::default();
+        let collector = NoopStorageStatsCollector;
 
         collector.record_read(3, 5);
         collector.record_write(7, 11);

--- a/src/common/runtime/baseline.rs
+++ b/src/common/runtime/baseline.rs
@@ -80,17 +80,17 @@ pub enum AttemptState {
 }
 
 impl AttemptState {
-    fn from_u8(value: u8) -> Self {
+    fn from_u8(value: u8) -> Option<Self> {
         match value {
-            0 => Self::Offered,
-            1 => Self::ChannelQueued,
-            2 => Self::BatchQueued,
-            3 => Self::WaitingGate,
-            4 => Self::Running,
-            5 => Self::ExecutionFinished,
-            6 => Self::ShutdownRejectedAfterAccept,
-            7 => Self::Abandoned,
-            _ => unreachable!("baseline attempt state is only written from AttemptState"),
+            0 => Some(Self::Offered),
+            1 => Some(Self::ChannelQueued),
+            2 => Some(Self::BatchQueued),
+            3 => Some(Self::WaitingGate),
+            4 => Some(Self::Running),
+            5 => Some(Self::ExecutionFinished),
+            6 => Some(Self::ShutdownRejectedAfterAccept),
+            7 => Some(Self::Abandoned),
+            _ => None,
         }
     }
 
@@ -322,6 +322,7 @@ impl BaselineAttempt {
 
     pub fn state(&self) -> AttemptState {
         AttemptState::from_u8(self.inner.state.load(Ordering::Acquire))
+            .unwrap_or(AttemptState::Abandoned)
     }
 
     /// Irrevocably reject a physical attempt before the request channel accepts it.
@@ -1912,7 +1913,7 @@ mod tests {
         source.transition(AttemptState::ChannelQueued).unwrap();
 
         assert_eq!(
-            AttemptState::from_u8(target_inner.state.load(Ordering::Acquire)),
+            AttemptState::from_u8(target_inner.state.load(Ordering::Acquire)).unwrap(),
             AttemptState::Abandoned
         );
         assert!(target_handle.failed());

--- a/src/common/runtime/baseline.rs
+++ b/src/common/runtime/baseline.rs
@@ -1016,6 +1016,45 @@ mod tests {
     }
 
     #[test]
+    fn attempt_state_decodes_every_valid_discriminant() {
+        let states = [
+            AttemptState::Offered,
+            AttemptState::ChannelQueued,
+            AttemptState::BatchQueued,
+            AttemptState::WaitingGate,
+            AttemptState::Running,
+            AttemptState::ExecutionFinished,
+            AttemptState::ShutdownRejectedAfterAccept,
+            AttemptState::Abandoned,
+        ];
+
+        for state in states {
+            assert_eq!(AttemptState::from_u8(state as u8), Some(state));
+        }
+    }
+
+    #[test]
+    fn attempt_state_rejects_unknown_discriminant() {
+        assert_eq!(AttemptState::from_u8(8), None);
+        assert_eq!(AttemptState::from_u8(u8::MAX), None);
+    }
+
+    #[test]
+    fn attempt_state_accessor_falls_back_to_abandoned_for_unknown_raw_state() {
+        let observer = Arc::new(RecordingObserver::default());
+        let attempt = attempt(observer);
+
+        attempt.inner.state.store(u8::MAX, Ordering::Release);
+        assert_eq!(attempt.state(), AttemptState::Abandoned);
+
+        // Restore a valid pre-accept state so Drop follows the ordinary path.
+        attempt
+            .inner
+            .state
+            .store(AttemptState::Offered as u8, Ordering::Release);
+    }
+
+    #[test]
     fn legal_transitions_record_previous_and_next_state() {
         let observer = Arc::new(RecordingObserver::default());
         let attempt = attempt(observer.clone());

--- a/src/common/runtime/storage_server.rs
+++ b/src/common/runtime/storage_server.rs
@@ -1096,7 +1096,7 @@ impl BackgroundTaskManager {
 
                         // Record compaction started
                         if let Some(ref _tracker) = metrics_tracker {
-                            // TODO: Fix type annotation issue
+                            // TODO(#400): re-enable after type annotation fixed
                             // tracker.record_compaction_started().await;
                         }
 
@@ -1112,7 +1112,7 @@ impl BackgroundTaskManager {
 
                             // Record compaction completed
                             if let Some(ref _tracker) = metrics_tracker {
-                                // TODO: Fix type annotation issue
+                                // TODO(#400): re-enable after type annotation fixed
                                 // tracker.record_compaction_completed(0, compaction_duration).await; // TODO: Get actual bytes compacted
                             }
                         }
@@ -1170,7 +1170,7 @@ impl BackgroundTaskManager {
 
                             // Record flush started
                             if let Some(ref _tracker) = metrics_tracker {
-                                // TODO: Fix type annotation issue
+                                // TODO(#400): re-enable after type annotation fixed
                                 // tracker.record_flush_started().await;
                             }
 
@@ -1180,7 +1180,7 @@ impl BackgroundTaskManager {
 
                             // Record flush completed (simulated)
                             if let Some(ref _tracker) = metrics_tracker {
-                                // TODO: Fix type annotation issue
+                                // TODO(#400): re-enable after type annotation fixed
                                 // tracker.record_flush_completed(0, Duration::from_millis(10)).await; // TODO: Get actual flush metrics
                             }
                         }
@@ -1236,7 +1236,7 @@ impl BackgroundTaskManager {
 
                     // Update metrics tracker if available
                     if let Some(ref _tracker) = metrics_tracker {
-                        // TODO: Fix type annotation issue
+                        // TODO(#400): re-enable after type annotation fixed
                         // tracker.update_rocksdb_metrics(
                         //     rocksdb_stats.total_keys,
                         //     rocksdb_stats.total_size_bytes,

--- a/src/executor/src/executor.rs
+++ b/src/executor/src/executor.rs
@@ -83,6 +83,7 @@ impl CmdExecutor {
     }
 
     pub async fn execute(&self, exec: CmdExecution) {
+        let client = Arc::clone(&exec.client);
         let (done_tx, done_rx) = oneshot::channel();
         let work = CmdExecutionWork {
             exec,
@@ -108,11 +109,15 @@ impl CmdExecutor {
                 work.exec
                     .client
                     .set_reply(RespData::Error("ERR executor unavailable".into()));
+                return;
             }
         }
 
         // TODO(#400): add a timeout for waiting
-        let _ = done_rx.await;
+        if let Err(err) = done_rx.await {
+            error!("executor worker exited before completing work: {err}");
+            client.set_reply(RespData::Error("ERR executor unavailable".into()));
+        }
     }
 
     pub async fn close(&mut self) {
@@ -363,6 +368,66 @@ mod tests {
         assert!(executed.load(Ordering::SeqCst));
 
         // Test graceful shutdown
+        executor.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn accepted_work_reports_unavailable_when_worker_exits() {
+        let storage = Arc::new(Storage::new(1, 0));
+        let exclusive = storage.acquire_exclusive_command_access().await;
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempt_notify = Arc::new(tokio::sync::Notify::new());
+        let executed = Arc::new(AtomicUsize::new(0));
+        let command = Arc::new(WaitingSharedCmd::new(
+            Arc::clone(&attempts),
+            Arc::clone(&attempt_notify),
+            Arc::clone(&executed),
+        ));
+        let client = Arc::new(Client::new(Box::new(TestStream::new())));
+        client.set_cmd_name(b"waiting-shared");
+        client.set_argv(&[b"waiting-shared".to_vec()]);
+        let executor = Arc::new(CmdExecutor::new(1, 1));
+
+        let executor_for_task = Arc::clone(&executor);
+        let client_for_task = Arc::clone(&client);
+        let storage_for_task = Arc::clone(&storage);
+        let execute_task = tokio::spawn(async move {
+            executor_for_task
+                .execute(CmdExecution {
+                    cmd: command,
+                    client: client_for_task,
+                    storage: storage_for_task,
+                })
+                .await;
+        });
+
+        tokio::time::timeout(Duration::from_secs(1), attempt_notify.notified())
+            .await
+            .expect("worker must dequeue accepted work");
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+        executor.workers[0].abort();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !executor.workers[0].is_finished() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("aborted worker must finish");
+        tokio::time::timeout(Duration::from_secs(1), execute_task)
+            .await
+            .expect("execute must observe the cancelled completion channel")
+            .expect("execute task must not panic");
+
+        assert_eq!(executed.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            client.take_reply(),
+            RespData::Error("ERR executor unavailable".into())
+        );
+
+        drop(exclusive);
+        let mut executor = Arc::try_unwrap(executor)
+            .unwrap_or_else(|_| panic!("test must release all executor references"));
         executor.close().await;
     }
 

--- a/src/executor/src/executor.rs
+++ b/src/executor/src/executor.rs
@@ -100,15 +100,18 @@ impl CmdExecutor {
         // send the work to the worker pool
         match self.work_tx.send(work).await {
             Ok(_) => {}
-            Err(async_channel::SendError(_)) => {
+            Err(async_channel::SendError(work)) => {
                 // this should not happen, because the only case when all the workers
                 // has been closed is when the executor is closed. and we've already
-                // checked the cancellation_token.
-                panic!("Failed to send work to worker; executor likely closed");
+                // checked the cancellation_token. Degrade gracefully instead of panicking.
+                error!("failed to send work to worker; executor likely closed");
+                work.exec
+                    .client
+                    .set_reply(RespData::Error("ERR executor unavailable".into()));
             }
         }
 
-        // TODO: add a timeout for waiting
+        // TODO(#400): add a timeout for waiting
         let _ = done_rx.await;
     }
 

--- a/src/kstd/src/env.rs
+++ b/src/kstd/src/env.rs
@@ -29,7 +29,7 @@ pub fn is_dir<P: AsRef<Path>>(path: P) -> io::Result<bool> {
 
 /// Creates a directory and all its parent directories with the specified mode.
 /// This corresponds to the 'mkpath' functionality.
-/// TODO: remove allow dead code
+/// TODO(#400): remove allow dead code
 #[allow(dead_code)]
 pub fn mkdir_with_path<P: AsRef<Path>>(path: P, _mode: u32) -> io::Result<()> {
     // Use the fs::create_dir_all method to create the directory path.
@@ -46,7 +46,7 @@ pub fn mkdir_with_path<P: AsRef<Path>>(path: P, _mode: u32) -> io::Result<()> {
     Ok(())
 }
 
-/// TODO: remove allow dead code
+/// TODO(#400): remove allow dead code
 #[allow(dead_code)]
 pub fn delete_dir<P: AsRef<Path>>(dirname: P) -> io::Result<()> {
     let path = dirname.as_ref();

--- a/src/kstd/src/status.rs
+++ b/src/kstd/src/status.rs
@@ -23,7 +23,7 @@ pub struct Status {
     message: String,
 }
 
-/// TODO: remove allow dead code.
+/// TODO(#400): remove allow dead code.
 #[allow(dead_code)]
 #[derive(Debug, PartialEq)]
 pub enum Code {
@@ -32,7 +32,7 @@ pub enum Code {
     Busy,
 }
 
-/// TODO: remove allow dead code.
+/// TODO(#400): remove allow dead code.
 #[allow(dead_code)]
 impl Status {
     // Create a success status.

--- a/src/net/Cargo.toml
+++ b/src/net/Cargo.toml
@@ -28,6 +28,7 @@ raft = { path = "../raft" }
 
 [dev-dependencies]
 env_logger = "0.11"
+tokio = { workspace = true, features = ["test-util"] }
 
 [[bench]]
 name = "network_benchmark"

--- a/src/net/src/lib.rs
+++ b/src/net/src/lib.rs
@@ -28,7 +28,7 @@ pub mod pool;
 pub mod storage_client;
 pub mod tcp;
 
-// TODO: delete this module
+// TODO(#400): delete this module
 pub mod error;
 pub mod unix;
 

--- a/src/net/src/optimized_handler.rs
+++ b/src/net/src/optimized_handler.rs
@@ -201,7 +201,13 @@ impl OptimizedConnectionHandler {
                                             let error_response = RespData::Error(format!("ERR {}", e).into());
                                             let mut encoder = RespEncoder::new(RespVersion::RESP2);
                                             encoder.encode_resp_data(&error_response);
-                                            let _ = client.write(encoder.get_response().as_ref()).await;
+                                            if let Err(write_err) = client.write(encoder.get_response().as_ref()).await {
+                                                warn!("failed to write error response to client: {write_err}; closing connection");
+                                                if self.config.enable_buffer_pooling {
+                                                    self.buffer_manager.return_buffer(read_buffer).await;
+                                                }
+                                                return Ok(());
+                                            }
                                         }
                                     }
                                 }

--- a/src/net/src/pipeline.rs
+++ b/src/net/src/pipeline.rs
@@ -27,6 +27,8 @@ use storage::storage::Storage;
 use tokio::sync::{Semaphore, mpsc, oneshot};
 use tokio::time::timeout;
 
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Configuration for pipeline processing
 #[derive(Debug, Clone)]
 pub struct PipelineConfig {
@@ -113,7 +115,7 @@ pub struct CommandPipeline {
 
 impl CommandPipeline {
     pub fn new(
-        config: PipelineConfig,
+        mut config: PipelineConfig,
         storage: Arc<Storage>,
         cmd_table: Arc<CmdTable>,
         executor: Arc<CmdExecutor>,
@@ -121,7 +123,8 @@ impl CommandPipeline {
         // Bounded channel enforces backpressure: when the queue is full,
         // senders await instead of growing the queue unboundedly.
         // Guard against 0 (rendezvous) to avoid unintentional stalls.
-        let (command_tx, command_rx) = mpsc::channel(config.command_queue_size.max(1));
+        config.command_queue_size = config.command_queue_size.max(1);
+        let (command_tx, command_rx) = mpsc::channel(config.command_queue_size);
         let semaphore = Arc::new(Semaphore::new(config.max_concurrent_pipelines));
 
         let pipeline = Self {
@@ -155,18 +158,7 @@ impl CommandPipeline {
             response_tx,
         };
 
-        // Send command to pipeline. On a full bounded channel this awaits
-        // (backpressure) rather than growing the queue indefinitely.
-        self.command_tx
-            .send(command)
-            .await
-            .map_err(|_| PipelineError::ChannelClosed)?;
-
-        // Wait for response with timeout
-        timeout(Duration::from_secs(30), response_rx)
-            .await
-            .map_err(|_| PipelineError::Timeout)?
-            .map_err(|_| PipelineError::ResponseChannelClosed)
+        send_and_receive(&self.command_tx, command, response_rx, COMMAND_TIMEOUT).await
     }
 
     /// Start the background batch processor
@@ -396,12 +388,122 @@ pub enum PipelineError {
     Timeout,
 }
 
+async fn send_and_receive(
+    command_tx: &mpsc::Sender<PipelineCommand>,
+    command: PipelineCommand,
+    response_rx: oneshot::Receiver<RespData>,
+    request_timeout: Duration,
+) -> Result<RespData, PipelineError> {
+    timeout(request_timeout, async {
+        command_tx
+            .send(command)
+            .await
+            .map_err(|_| PipelineError::ChannelClosed)?;
+        response_rx
+            .await
+            .map_err(|_| PipelineError::ResponseChannelClosed)
+    })
+    .await
+    .map_err(|_| PipelineError::Timeout)?
+}
+
 #[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::time::Duration;
-    use tokio::time::sleep;
+    use tokio::time::{advance, sleep};
+
+    struct TestStream;
+
+    #[async_trait::async_trait]
+    impl client::StreamTrait for TestStream {
+        async fn read(&mut self, _buf: &mut [u8]) -> Result<usize, std::io::Error> {
+            Ok(0)
+        }
+
+        async fn write(&mut self, _data: &[u8]) -> Result<usize, std::io::Error> {
+            Ok(0)
+        }
+    }
+
+    fn pipeline_command(response_tx: oneshot::Sender<RespData>) -> PipelineCommand {
+        PipelineCommand {
+            data: RespData::Array(Some(Vec::new())),
+            client: Arc::new(Client::new(Box::new(TestStream))),
+            received_at: Instant::now(),
+            response_tx,
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn queue_wait_and_response_share_single_deadline() {
+        let (command_tx, mut command_rx) = mpsc::channel(1);
+        let (filler_response_tx, _filler_response_rx) = oneshot::channel();
+        command_tx
+            .send(pipeline_command(filler_response_tx))
+            .await
+            .expect("filler command must fit in the queue");
+
+        let (target_response_tx, target_response_rx) = oneshot::channel();
+        let target_command = pipeline_command(target_response_tx);
+        let submit_task = tokio::spawn(async move {
+            send_and_receive(
+                &command_tx,
+                target_command,
+                target_response_rx,
+                Duration::from_secs(30),
+            )
+            .await
+        });
+        tokio::task::yield_now().await;
+
+        advance(Duration::from_secs(20)).await;
+        let filler_command = command_rx
+            .recv()
+            .await
+            .expect("filler command must remain queued");
+        drop(filler_command);
+        tokio::task::yield_now().await;
+
+        advance(Duration::from_secs(11)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            submit_task.is_finished(),
+            "queue wait and response wait must share one deadline"
+        );
+        let result = submit_task.await.expect("submission task must not panic");
+        assert!(matches!(result, Err(PipelineError::Timeout)));
+
+        let target_command = command_rx
+            .recv()
+            .await
+            .expect("target command must have entered the queue");
+        assert!(
+            target_command
+                .response_tx
+                .send(RespData::SimpleString("late".into()))
+                .is_err(),
+            "timing out must close the target response receiver"
+        );
+    }
+
+    #[tokio::test]
+    async fn zero_command_queue_size_reports_effective_capacity() {
+        let config = PipelineConfig {
+            command_queue_size: 0,
+            ..Default::default()
+        };
+        let pipeline = CommandPipeline::new(
+            config,
+            Arc::new(Storage::new(1, 0)),
+            Arc::new(CmdTable::new()),
+            Arc::new(CmdExecutor::new(1, 1)),
+        );
+
+        assert_eq!(pipeline.command_tx.max_capacity(), 1);
+        assert_eq!(pipeline.stats().queue_capacity, 1);
+    }
 
     #[tokio::test]
     async fn test_pipeline_basic() {

--- a/src/net/src/pipeline.rs
+++ b/src/net/src/pipeline.rs
@@ -106,7 +106,7 @@ pub struct CommandPipeline {
     storage: Arc<Storage>,
     cmd_table: Arc<CmdTable>,
     executor: Arc<CmdExecutor>,
-    command_tx: mpsc::UnboundedSender<PipelineCommand>,
+    command_tx: mpsc::Sender<PipelineCommand>,
     semaphore: Arc<Semaphore>,
     batch_counter: Arc<std::sync::atomic::AtomicU64>,
 }
@@ -118,9 +118,10 @@ impl CommandPipeline {
         cmd_table: Arc<CmdTable>,
         executor: Arc<CmdExecutor>,
     ) -> Self {
-        // TODO: Consider using bounded channel instead of unbounded to properly enforce queue_capacity
-        // Currently using unbounded_channel means the command_queue_size config is not actually enforced
-        let (command_tx, command_rx) = mpsc::unbounded_channel();
+        // Bounded channel enforces backpressure: when the queue is full,
+        // senders await instead of growing the queue unboundedly.
+        // Guard against 0 (rendezvous) to avoid unintentional stalls.
+        let (command_tx, command_rx) = mpsc::channel(config.command_queue_size.max(1));
         let semaphore = Arc::new(Semaphore::new(config.max_concurrent_pipelines));
 
         let pipeline = Self {
@@ -154,9 +155,11 @@ impl CommandPipeline {
             response_tx,
         };
 
-        // Send command to pipeline
+        // Send command to pipeline. On a full bounded channel this awaits
+        // (backpressure) rather than growing the queue indefinitely.
         self.command_tx
             .send(command)
+            .await
             .map_err(|_| PipelineError::ChannelClosed)?;
 
         // Wait for response with timeout
@@ -167,7 +170,7 @@ impl CommandPipeline {
     }
 
     /// Start the background batch processor
-    fn start_batch_processor(&self, mut command_rx: mpsc::UnboundedReceiver<PipelineCommand>) {
+    fn start_batch_processor(&self, mut command_rx: mpsc::Receiver<PipelineCommand>) {
         let config = self.config.clone();
         let storage = self.storage.clone();
         let cmd_table = self.cmd_table.clone();
@@ -368,11 +371,7 @@ impl CommandPipeline {
         PipelineStats {
             available_permits: self.semaphore.available_permits(),
             max_concurrent_pipelines: self.config.max_concurrent_pipelines,
-            // Note: queue_capacity stat is currently misleading because the channel at line 121
-            // is unbounded (mpsc::unbounded_channel). This returns command_queue_size from config,
-            // but the actual channel has no capacity limit.
-            // TODO: Consider using bounded channel (mpsc::channel) and passing config.command_queue_size
-            // as the capacity to make this stat accurate.
+            // The channel is bounded by config.command_queue_size.
             queue_capacity: self.config.command_queue_size,
         }
     }

--- a/src/raft/src/conversion.rs
+++ b/src/raft/src/conversion.rs
@@ -398,6 +398,7 @@ impl TryInto<AppendEntriesResponse<u64>> for &proto::AppendEntriesResponse {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
 
     #[test]

--- a/src/raft/src/grpc/client.rs
+++ b/src/raft/src/grpc/client.rs
@@ -322,6 +322,7 @@ fn proto_binlog_to_binlog(
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
     use crate::raft_proto::{Binlog as ProtoBinlog, BinlogEntry as ProtoBinlogEntry};
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/raft/src/grpc/core.rs
+++ b/src/raft/src/grpc/core.rs
@@ -188,7 +188,7 @@ impl RaftCoreService for RaftCoreServiceImpl {
         &self,
         request: Request<tonic::Streaming<InstallSnapshotRequest>>,
     ) -> Result<Response<InstallSnapshotResponse>, Status> {
-        // FIXME: 实现快照安装
+        // FIXME(#400): implement snapshot installation
         // 当前故意丢弃所有快照分片，将来实现时必须删除此 workaround
         let mut stream = request.into_inner();
         while let Some(_chunk) = stream.message().await? {

--- a/src/raft/src/lib.rs
+++ b/src/raft/src/lib.rs
@@ -68,6 +68,7 @@ const _: () = assert!(
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
 
     #[test]

--- a/src/raft/src/log_store_rocksdb.rs
+++ b/src/raft/src/log_store_rocksdb.rs
@@ -513,6 +513,7 @@ fn decode_log_key(key: &[u8]) -> Result<u64, StorageError<u64>> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
     use conf::raft_type::{Binlog, BinlogEntry, OperateType};
     use openraft::storage::RaftLogStorageExt;

--- a/src/raft/src/network.rs
+++ b/src/raft/src/network.rs
@@ -165,13 +165,20 @@ impl RaftNetworkFactory<KiwiTypeConfig> for KiwiNetworkFactory {
         let addr = node.raft_addr.clone();
 
         // 使用配置创建 endpoint
-        let endpoint = tonic::transport::Endpoint::from_shared(format!("http://{}", addr))
-            .unwrap_or_else(|e| {
-                panic!(
-                    "invalid raft address '{}': failed to parse as gRPC endpoint: {}",
-                    addr, e
-                )
-            });
+        let endpoint = match tonic::transport::Endpoint::from_shared(format!("http://{}", addr)) {
+            Ok(ep) => ep,
+            Err(e) => {
+                log::error!(
+                    "invalid raft address '{}': failed to parse as gRPC endpoint: {}; \
+                     using fallback endpoint that will fail on connect",
+                    addr,
+                    e
+                );
+                // Fallback: a syntactically valid URL that will fail on connect,
+                // surfacing the error as an RPC failure rather than panicking.
+                tonic::transport::Endpoint::from_static("http://0.0.0.0:0")
+            }
+        };
 
         let endpoint = endpoint
             .connect_timeout(self.config.connect_timeout)

--- a/src/raft/src/network.rs
+++ b/src/raft/src/network.rs
@@ -331,3 +331,39 @@ impl RaftNetwork<KiwiTypeConfig> for KiwiNetwork {
         Err(rpc_failed_network_error(&self.target, last_error))
     }
 }
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod tests {
+    use openraft::Vote;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn invalid_raft_endpoint_returns_network_error_without_panicking() {
+        let invalid_target = "not a valid raft address";
+        let mut factory = KiwiNetworkFactory::with_config(ConnectionConfig {
+            max_retries: 0,
+            ..Default::default()
+        });
+        let node = KiwiNode {
+            raft_addr: invalid_target.to_string(),
+            resp_addr: String::new(),
+        };
+
+        let mut network = factory.new_client(2, &node).await;
+        let error = network
+            .vote(
+                VoteRequest::new(Vote::new(1, 1), None),
+                RPCOption::new(Duration::from_millis(50)),
+            )
+            .await
+            .expect_err("invalid endpoint must fail as a network error");
+
+        assert!(matches!(error, RPCErr::Network(_)));
+        assert!(
+            error.to_string().contains(invalid_target),
+            "network error must identify the configured target: {error}"
+        );
+    }
+}

--- a/src/raft/src/snapshot_archive.rs
+++ b/src/raft/src/snapshot_archive.rs
@@ -17,7 +17,7 @@
 
 //! Tar packing/unpacking for Raft snapshot checkpoints.
 //!
-//! TODO: stream snapshot bytes (read/write without holding the full tar in memory) for
+//! TODO(#400): stream snapshot bytes (read/write without holding the full tar in memory) for
 //! build and install paths; align with OpenRaft snapshot APIs when switching off in-memory buffers.
 
 use std::io::{self, Cursor};
@@ -110,6 +110,7 @@ pub fn unpacked_checkpoint_root(unpack_root: &Path) -> std::path::PathBuf {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
     use storage::RaftSnapshotMeta;
 

--- a/src/raft/tests/log_store_rocksdb_test.rs
+++ b/src/raft/tests/log_store_rocksdb_test.rs
@@ -20,6 +20,8 @@
 //! These tests verify the integration of RocksdbLogStore with the Raft system,
 //! including node restart scenarios and data recovery.
 
+#![allow(clippy::unwrap_used)]
+
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/src/raft/tests/logindex_integration.rs
+++ b/src/raft/tests/logindex_integration.rs
@@ -31,6 +31,8 @@
 // KIND, either express or implied.  See the License for the specific
 // language governing permissions and limitations under the License.
 
+#![allow(clippy::unwrap_used)]
+
 use std::sync::Arc;
 
 use raft::{

--- a/src/raft/tests/snapshot_logindex_test.rs
+++ b/src/raft/tests/snapshot_logindex_test.rs
@@ -105,10 +105,10 @@ async fn test_snapshot_with_logindex_state() -> anyhow::Result<()> {
         storage.set(b"test_key", b"test_value")?;
 
         // Force flush to ensure data is persisted to SST
-        if let Some(inst) = storage.insts.first() {
-            if let Some(db) = inst.db() {
-                db.flush().unwrap();
-            }
+        if let Some(inst) = storage.insts.first()
+            && let Some(db) = inst.db()
+        {
+            db.flush().unwrap();
         }
 
         // Simulate binlog write to update collector with (log_index, seqno) mapping

--- a/src/resp/src/encode.rs
+++ b/src/resp/src/encode.rs
@@ -228,16 +228,21 @@ impl RespEncode for RespEncoder {
                 self.append_crlf()
             }
             RespData::VerbatimString { format, data } => {
-                if format.len() != 3 {
-                    panic!(
-                        "RESP3 VerbatimString format must be exactly 3 bytes, got {}",
-                        format.len()
-                    );
-                }
-                let total_len = format.len() + 1 + data.len(); // format + ':' + data
+                // RESP3 VerbatimString format must be exactly 3 bytes.
+                // Fall back to "txt" if the caller supplied an invalid length
+                // rather than panicking, so a single bad value cannot take down
+                // the whole connection.
+                let fmt: [u8; 3] = if format.len() == 3 {
+                    let mut f = [0u8; 3];
+                    f.copy_from_slice(&format[..3]);
+                    f
+                } else {
+                    *b"txt"
+                };
+                let total_len = fmt.len() + 1 + data.len(); // format + ':' + data
                 let _ = write!(self.buffer, "={total_len}");
                 self.append_crlf();
-                self.buffer.extend_from_slice(format);
+                self.buffer.extend_from_slice(&fmt);
                 self.buffer.extend_from_slice(b":");
                 self.buffer.extend_from_slice(data);
                 self.append_crlf()
@@ -315,16 +320,19 @@ impl RespEncode for RespEncoder {
     }
 
     fn append_verbatim_string(&mut self, format: &str, data: &[u8]) -> &mut Self {
-        if format.len() != 3 {
-            panic!(
-                "RESP3 VerbatimString format must be exactly 3 bytes, got {}",
-                format.len()
-            );
-        }
-        let total_len = format.len() + 1 + data.len(); // format + ':' + data
+        // RESP3 VerbatimString format must be exactly 3 bytes. Fall back to
+        // "txt" for invalid lengths instead of panicking.
+        let fmt: [u8; 3] = if format.len() == 3 {
+            let mut f = [0u8; 3];
+            f.copy_from_slice(format.as_bytes());
+            f
+        } else {
+            *b"txt"
+        };
+        let total_len = fmt.len() + 1 + data.len(); // format + ':' + data
         let _ = write!(self.buffer, "={total_len}");
         self.append_crlf();
-        self.buffer.extend_from_slice(format.as_bytes());
+        self.buffer.extend_from_slice(&fmt);
         self.buffer.extend_from_slice(b":");
         self.buffer.extend_from_slice(data);
         self.append_crlf()

--- a/src/resp/src/encode.rs
+++ b/src/resp/src/encode.rs
@@ -459,6 +459,31 @@ mod tests {
     }
 
     #[test]
+    fn invalid_resp_data_verbatim_format_falls_back_to_txt() {
+        let mut encoder = RespEncoder::new(RespVersion::RESP3);
+        encoder.encode_resp_data(&RespData::VerbatimString {
+            format: Bytes::from("html"),
+            data: Bytes::from("payload"),
+        });
+
+        assert_eq!(
+            encoder.get_response(),
+            Bytes::from("=11\r\ntxt:payload\r\n")
+        );
+    }
+
+    #[test]
+    fn invalid_convenience_verbatim_format_falls_back_to_txt() {
+        let mut encoder = RespEncoder::new(RespVersion::RESP3);
+        encoder.append_verbatim_string("html", b"payload");
+
+        assert_eq!(
+            encoder.get_response(),
+            Bytes::from("=11\r\ntxt:payload\r\n")
+        );
+    }
+
+    #[test]
     fn test_encode_resp3_map() {
         let mut encoder = RespEncoder::new(RespVersion::RESP3);
         encoder.encode_resp_data(&RespData::Map(vec![

--- a/src/server/src/main.rs
+++ b/src/server/src/main.rs
@@ -227,44 +227,6 @@ fn preflight_server_startup(config: &Config) -> std::io::Result<()> {
     raft::state_machine::preflight_snapshot_install(std::path::Path::new(&config.data_dir))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::atomic::{AtomicU64, Ordering};
-
-    static TEST_SEQUENCE: AtomicU64 = AtomicU64::new(0);
-
-    #[test]
-    fn startup_preflight_rejects_marker_even_when_raft_is_disabled() {
-        let root = std::env::temp_dir().join(format!(
-            "kiwi-server-preflight-{}-{}",
-            std::process::id(),
-            TEST_SEQUENCE.fetch_add(1, Ordering::Relaxed)
-        ));
-        let db_path = root.join("data");
-        std::fs::create_dir_all(&root).expect("test should create its temporary root");
-        let marker_path = raft::state_machine::snapshot_install_marker_path(&db_path)
-            .expect("test DB path should support a marker");
-        std::fs::write(&marker_path, b"{not-json")
-            .expect("test should write a malformed install marker");
-        let mut config = Config::default();
-        config.data_dir = db_path.display().to_string();
-        config.raft = None;
-
-        let error = preflight_server_startup(&config)
-            .expect_err("server startup must reject an install marker without Raft configured");
-        assert!(
-            error
-                .to_string()
-                .contains(&marker_path.display().to_string()),
-            "server refusal must identify the marker path: {error}"
-        );
-
-        std::fs::remove_file(marker_path).expect("test should remove its marker");
-        std::fs::remove_dir_all(root).expect("test should remove its temporary root");
-    }
-}
-
 async fn initialize_storage(config: &Config) -> Result<GlobalStorage, DualRuntimeError> {
     info!("Initializing storage...");
 
@@ -462,5 +424,45 @@ async fn start_server(
             "Failed to create server for protocol '{}' on address '{}'",
             protocol, addr
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn startup_preflight_rejects_marker_even_when_raft_is_disabled() {
+        let root = std::env::temp_dir().join(format!(
+            "kiwi-server-preflight-{}-{}",
+            std::process::id(),
+            TEST_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let db_path = root.join("data");
+        std::fs::create_dir_all(&root).expect("test should create its temporary root");
+        let marker_path = raft::state_machine::snapshot_install_marker_path(&db_path)
+            .expect("test DB path should support a marker");
+        std::fs::write(&marker_path, b"{not-json")
+            .expect("test should write a malformed install marker");
+        let config = Config {
+            data_dir: db_path.display().to_string(),
+            raft: None,
+            ..Default::default()
+        };
+
+        let error = preflight_server_startup(&config)
+            .expect_err("server startup must reject an install marker without Raft configured");
+        assert!(
+            error
+                .to_string()
+                .contains(&marker_path.display().to_string()),
+            "server refusal must identify the marker path: {error}"
+        );
+
+        std::fs::remove_file(marker_path).expect("test should remove its marker");
+        std::fs::remove_dir_all(root).expect("test should remove its temporary root");
     }
 }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -27,6 +27,11 @@ path = "tests/redis_list_test.rs"
 name = "ttl_test"
 path = "tests/ttl_test.rs"
 
+[[test]]
+name = "storage_stats_test"
+path = "tests/storage_stats_test.rs"
+required-features = ["test-fault-injection"]
+
 [dependencies]
 rocksdb.workspace = true 
 log.workspace = true

--- a/src/storage/src/batch.rs
+++ b/src/storage/src/batch.rs
@@ -470,7 +470,7 @@ impl Batch for BinlogBatch {
 
         let slot_idx = Self::infer_slot_idx(&self.entries)?;
         let binlog = Binlog {
-            db_id: 0, // TODO: thread real db_id from Redis/Storage in a later task
+            db_id: 0, // TODO(#400): thread real db_id from Redis/Storage in a later task
             slot_idx,
             entries: self.entries,
         };

--- a/src/storage/src/checkpoint.rs
+++ b/src/storage/src/checkpoint.rs
@@ -462,7 +462,12 @@ fn remove_target_with_retry(target_db_path: &Path) -> io::Result<()> {
         }
     }
 
-    unreachable!("target removal loop always returns")
+    // Every match arm in the loop body returns, so this line is unreachable
+    // in practice. Return an error as a safe fallback rather than panicking.
+    Err(io::Error::other(format!(
+        "target removal loop exhausted for {}",
+        target_db_path.display()
+    )))
 }
 
 /// Copy checkpoint layout from `checkpoint_root` into `target_db_path` (`0/`, `1/`, …).

--- a/src/storage/src/custom_comparator.rs
+++ b/src/storage/src/custom_comparator.rs
@@ -466,7 +466,7 @@ mod tests {
     #[test]
     fn test_zsets_score_key_compare_sorting_order() {
         // 模拟多个 score 的排序
-        let mut keys = vec![
+        let mut keys = [
             ZSetsScoreKey::new(b"zset", 1, 3.0, b"c").encode().unwrap(),
             ZSetsScoreKey::new(b"zset", 1, 1.0, b"a").encode().unwrap(),
             ZSetsScoreKey::new(b"zset", 1, 2.0, b"b").encode().unwrap(),

--- a/src/storage/src/format_zset_score_key.rs
+++ b/src/storage/src/format_zset_score_key.rs
@@ -216,6 +216,7 @@ impl ParsedZSetsScoreKey {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
 
     #[test]

--- a/src/storage/src/logindex/table_properties.rs
+++ b/src/storage/src/logindex/table_properties.rs
@@ -170,6 +170,7 @@ pub fn get_largest_log_index_from_collection(
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
     use rocksdb::{DB, Options};
     use tempfile::TempDir;

--- a/src/storage/src/redis.rs
+++ b/src/storage/src/redis.rs
@@ -202,10 +202,12 @@ impl RocksDbOwnerDropTestGate {
 }
 
 #[cfg(test)]
-fn rocks_db_owner_drop_test_gate_registry()
--> &'static Mutex<Option<(std::path::PathBuf, Weak<RocksDbOwnerDropTestGate>)>> {
-    static GATE: OnceLock<Mutex<Option<(std::path::PathBuf, Weak<RocksDbOwnerDropTestGate>)>>> =
-        OnceLock::new();
+type RocksDbOwnerDropGateRegistry =
+    Mutex<Option<(std::path::PathBuf, Weak<RocksDbOwnerDropTestGate>)>>;
+
+#[cfg(test)]
+fn rocks_db_owner_drop_test_gate_registry() -> &'static RocksDbOwnerDropGateRegistry {
+    static GATE: OnceLock<RocksDbOwnerDropGateRegistry> = OnceLock::new();
     GATE.get_or_init(|| Mutex::new(None))
 }
 
@@ -1187,13 +1189,13 @@ mod type_check_state_tests {
     }
 
     /// Forge a raw on-disk value that matches `format_base_value::is_stale`:
-    ///   * `type_byte`  at offset 0      (a valid `DataType` tag, 0..=6)
-    ///   * `count`      at offset 1..9    (meta count; only consulted for
-    ///                        Set/Hash/ZSet/List — kept non-zero so those types
-    ///                        are not short-circuited as stale by `count == 0`)
-    ///   * `etime`      in the final 8 bytes (microseconds since epoch).
-    ///                        `etime == 0` means "permanent" (never stale); any
-    ///                        `etime < now` is stale.
+    ///   * `type_byte` at offset 0 (a valid `DataType` tag, 0..=6)
+    ///   * `count` at offset 1..9 (meta count; only consulted for
+    ///     Set/Hash/ZSet/List — kept non-zero so those types
+    ///     are not short-circuited as stale by `count == 0`)
+    ///   * `etime` in the final 8 bytes (microseconds since epoch).
+    ///     `etime == 0` means "permanent" (never stale); any
+    ///     `etime < now` is stale.
     fn make_value(type_byte: u8, count: u64, etime: u64, total_len: usize) -> Vec<u8> {
         assert!(
             total_len >= 9,

--- a/src/storage/src/redis_lists.rs
+++ b/src/storage/src/redis_lists.rs
@@ -1116,7 +1116,7 @@ impl Redis {
                     return OptionNoneSnafu {
                         message: "Destination list creation should always succeed".to_string(),
                     }
-                    .fail()
+                    .fail();
                 }
             }
 
@@ -1158,7 +1158,7 @@ impl Redis {
                 return OptionNoneSnafu {
                     message: "Destination list creation should always succeed".to_string(),
                 }
-                .fail()
+                .fail();
             }
         }
 

--- a/src/storage/src/redis_lists.rs
+++ b/src/storage/src/redis_lists.rs
@@ -270,7 +270,10 @@ impl Redis {
     pub fn lpush(&self, key: &[u8], values: &[Vec<u8>]) -> Result<i64> {
         match self.push_core(key, values, true, true, true)? {
             Some(count) => Ok(count),
-            None => unreachable!("lpush always creates list when key doesn't exist"),
+            None => OptionNoneSnafu {
+                message: "lpush always creates list when key doesn't exist".to_string(),
+            }
+            .fail(),
         }
     }
 
@@ -278,7 +281,10 @@ impl Redis {
     pub fn rpush(&self, key: &[u8], values: &[Vec<u8>]) -> Result<i64> {
         match self.push_core(key, values, false, true, true)? {
             Some(count) => Ok(count),
-            None => unreachable!("rpush always creates list when key doesn't exist"),
+            None => OptionNoneSnafu {
+                message: "rpush always creates list when key doesn't exist".to_string(),
+            }
+            .fail(),
         }
     }
 
@@ -1106,7 +1112,12 @@ impl Redis {
                 false,
             )? {
                 Some(_) => {}
-                None => unreachable!("Destination list creation should always succeed"),
+                None => {
+                    return OptionNoneSnafu {
+                        message: "Destination list creation should always succeed".to_string(),
+                    }
+                    .fail()
+                }
             }
 
             return Ok(Some(popped_value));
@@ -1143,7 +1154,12 @@ impl Redis {
             false,
         )? {
             Some(_) => {}
-            None => unreachable!("Destination list creation should always succeed"),
+            None => {
+                return OptionNoneSnafu {
+                    message: "Destination list creation should always succeed".to_string(),
+                }
+                .fail()
+            }
         }
 
         Ok(Some(popped_value))

--- a/src/storage/src/slot_indexer.rs
+++ b/src/storage/src/slot_indexer.rs
@@ -95,4 +95,18 @@ mod tests {
         assert_eq!(indexer.get_instance_id(8), 8);
         assert_eq!(indexer.get_instance_id(15), 5);
     }
+
+    #[test]
+    fn reshard_slots_returns_explicit_not_implemented_error() {
+        let error = SlotIndexer::new(3)
+            .reshard_slots(vec![1, 2, 3])
+            .expect_err("resharding must remain an explicit unsupported operation");
+
+        match error {
+            crate::error::Error::System { message, .. } => {
+                assert_eq!(message, "reshard_slots not implemented yet");
+            }
+            other => panic!("expected a system error, got {other}"),
+        }
+    }
 }

--- a/src/storage/src/slot_indexer.rs
+++ b/src/storage/src/slot_indexer.rs
@@ -51,11 +51,16 @@ impl SlotIndexer {
     }
 
     /// Placeholder for re-sharding slots functionality.
-    pub fn reshard_slots(&self, _slots: Vec<usize>) {
-        // TODO: Implement the logic for re-sharding slots.
+    ///
+    /// Returns `Err` until the re-sharding logic is implemented (see #397).
+    pub fn reshard_slots(&self, _slots: Vec<usize>) -> Result<(), crate::error::Error> {
+        // TODO(#397): Implement the logic for re-sharding slots.
         // When we implement this method, remove the underscore.
         // Don't forget add unit test.
-        unimplemented!("Resharding logic not implemented yet.");
+        Err(crate::error::Error::System {
+            message: "reshard_slots not implemented yet".into(),
+            location: snafu::location!(),
+        })
     }
 }
 

--- a/src/storage/src/storage_murmur3.rs
+++ b/src/storage/src/storage_murmur3.rs
@@ -41,20 +41,8 @@ pub fn murmur3_32<T: AsRef<[u8]>>(data: T, seed: u32) -> u32 {
 
     if !remainder.is_empty() {
         let mut k1 = 0;
-        match remainder.len() & 3 {
-            3 => {
-                k1 ^= (remainder[2] as u32) << 16;
-                k1 ^= (remainder[1] as u32) << 8;
-                k1 ^= remainder[0] as u32;
-            }
-            2 => {
-                k1 ^= (remainder[1] as u32) << 8;
-                k1 ^= remainder[0] as u32;
-            }
-            1 => {
-                k1 ^= remainder[0] as u32;
-            }
-            _ => unreachable!("remainder length is 0..=3, guaranteed by murmur3 finalization"),
+        for (index, byte) in remainder.iter().enumerate() {
+            k1 ^= u32::from(*byte) << (index * 8);
         }
 
         k1 = k1.wrapping_mul(c1);
@@ -76,6 +64,8 @@ pub fn murmur3_32<T: AsRef<[u8]>>(data: T, seed: u32) -> u32 {
 #[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
     use super::*;
 
     #[test]
@@ -106,6 +96,16 @@ mod tests {
             murmur3_32("The quick brown fox jumps over the lazy dog.", 0x2a),
             0xc02d1434
         );
+    }
+
+    #[test]
+    fn test_all_remainder_lengths_match_reference() {
+        for len in 0..=7 {
+            let data: Vec<u8> = (0..len as u8).collect();
+            let expected = murmur3::murmur3_32(&mut Cursor::new(&data), 0x2a)
+                .expect("reference Murmur3 implementation must read from memory");
+            assert_eq!(murmur3_32(&data, 0x2a), expected, "len={len}");
+        }
     }
 
     #[test]

--- a/src/storage/src/storage_murmur3.rs
+++ b/src/storage/src/storage_murmur3.rs
@@ -54,7 +54,7 @@ pub fn murmur3_32<T: AsRef<[u8]>>(data: T, seed: u32) -> u32 {
             1 => {
                 k1 ^= remainder[0] as u32;
             }
-            _ => unreachable!(),
+            _ => unreachable!("remainder length is 0..=3, guaranteed by murmur3 finalization"),
         }
 
         k1 = k1.wrapping_mul(c1);


### PR DESCRIPTION
## Summary

Resolves six code-quality issues (#396–#401) identified by a static scan + clippy pass, in a single PR. The overarching goal: **eliminate `panic!`/`unreachable!`/`unimplemented!` from production paths and harden runtime behavior**, without changing Redis compatibility or the storage/Raft data model.

## Changes by issue

### #396 — Production-path panic/unreachable cleanup (7 sites)
Each site handled per its signature constraints:
- `executor.rs:107` — `execute()` returns `()`, so the send-failure `panic!` degrades to an `error!` log + `ERR executor unavailable` reply.
- `baseline.rs:93` — `from_u8` now returns `Option<Self>`; `state()` falls back to `Abandoned` for unknown discriminants (no panic on corrupt/upgraded data).
- `redis_lists.rs` (4 sites) — `None => unreachable!` replaced with `OptionNoneSnafu.fail()` so `lpush`/`rpush`/moves return `Err`.
- `checkpoint.rs:465` — `unreachable!` replaced with `Err(io::Error::other(...))`.
- `encode.rs:232,319` — VerbatimString format-length `panic!` falls back to `"txt"` (signature returns `&mut Self`, changing to `Result` would cascade across net/resp callers).
- `network.rs:170` — gRPC endpoint parse failure logs + uses a fallback endpoint that fails on connect (openraft `RaftNetworkFactory` returns `Self::Network`, cannot return `Result`).
- `storage_murmur3.rs:57` — bare `unreachable!()` gained a descriptive message.

### #397 — `SlotIndexer::reshard_slots`
`unimplemented!()` → `Result<(), Error>` returning `Err` (`Error::System`). No callers exist today, so the signature change is safe.

### #398 — Bounded channel in `net/pipeline`
`mpsc::unbounded_channel()` → `mpsc::channel(config.command_queue_size.max(1))`, with `send(...).await` for backpressure. `command_queue_size` config is now actually enforced. No locks held across `send`, no deadlock risk.

### #399 — `optimized_handler` write-error handling
`let _ = client.write(...)` → `if let Err(...) { warn!(); return buffer; return Ok(()); }`, so a dead client triggers cleanup instead of being silently ignored.

### #400 — Ownerless TODO/FIXME cleanup
Key TODOs tagged with `TODO(#400)` (SET options, snapshot install, streaming snapshot, exec timeout, hardcoded db_id, type-annotation blocks). No functionality implemented — only tracking + dead-comment removal.

### #401 — `clippy::unwrap_used` in test modules
Added `#![allow(clippy::unwrap_used)]` to raft/storage test modules, eliminating **135 clippy errors** so `cargo clippy --workspace --all-targets` passes. This also closed a CI blind spot (the PR gate ran clippy without `--all-targets`).

## Pre-existing clippy cleanup (required for `--all-targets` to reach 0 errors)
To make `cargo clippy --workspace --all-targets -- -D warnings` pass, a few pre-existing warnings were also fixed (no behavior change): complex-type alias in `redis.rs`, doc indentation, `useless_vec`, `items_after_test_module` / `field_reassign_with_default` in `main.rs`, and a missing `required-features` gate on `storage_stats_test`.

## Verification

| Check | Result |
|-------|--------|
| `cargo check --workspace` | ✅ 0 errors |
| `cargo clippy --workspace --all-targets -- -D warnings -D clippy::unwrap_used` | ✅ 0 errors |
| `cargo test -p resp --lib` | ✅ 60 passed |
| `cargo test -p client --lib` | ✅ 6 passed |
| `cargo test -p kstd --lib` | ✅ 26 passed |
| `cargo test -p storage/executor/runtime/raft/conf --lib` | ⚠️ Cannot run locally — Windows DLL entrypoint error loading the rust-rocksdb fork (pre-existing, unrelated to this change). **CI (Linux) will run these.** |

## Notes for reviewers
- Three sites (#396-1 executor, #396-6 encode, #396-7 network) use **graceful degradation / fallback** rather than `Result` because their signatures are constrained by traits/cascading callers. Each is documented inline. If reviewers prefer `Result` propagation there, it should be a follow-up with its own impact analysis.
- #398 changes runtime behavior (bounded backpressure). Default `command_queue_size` is preserved; the only observable effect is that a saturated pipeline now awaits instead of growing unboundedly.

Closes #396, #397, #398, #399, #400, #401.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when executor workers, network endpoints, or client connections encounter failures.
  * Invalid response formats now fall back safely instead of causing errors.
  * Storage and list operations report structured errors rather than panicking.
  * Invalid persisted attempt states are handled safely.
  * Command queues now apply bounded capacity and backpressure to prevent unbounded growth.

* **Tests**
  * Expanded validation for startup configuration, storage statistics, snapshots, and error handling.
  * Improved test compatibility with updated lint checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->