### PR TITLE
fix(storage): align DEL with generation lifecycle

### DIFF
--- a/src/storage/src/data_compaction_filter.rs
+++ b/src/storage/src/data_compaction_filter.rs
@@ -102,10 +102,9 @@ impl CompactionFilterTestGate {
     }
 
     fn record_removed_key(&self, key: &[u8]) {
-        let mut state = self
-            .state
-            .lock()
-            .expect("compaction filter test gate mutex should not be poisoned");
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
         state.removed_keys.push(key.to_vec());
         self.changed.notify_all();
     }
@@ -115,10 +114,9 @@ impl CompactionFilterTestGate {
             return;
         }
 
-        let mut state = self
-            .state
-            .lock()
-            .expect("compaction filter test gate mutex should not be poisoned");
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
         if state.entered {
             return;
         }
@@ -126,10 +124,10 @@ impl CompactionFilterTestGate {
         state.entered = true;
         self.changed.notify_all();
         while !state.released {
-            state = self
-                .changed
-                .wait(state)
-                .expect("compaction filter test gate wait should succeed");
+            let Ok(next_state) = self.changed.wait(state) else {
+                return;
+            };
+            state = next_state;
         }
     }
 }
@@ -141,6 +139,12 @@ fn compaction_filter_test_gate() -> &'static Mutex<Option<Weak<CompactionFilterT
 }
 
 #[cfg(test)]
+pub(crate) fn compaction_filter_test_serial_mutex() -> &'static Mutex<()> {
+    static MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+    MUTEX.get_or_init(|| Mutex::new(()))
+}
+
+#[cfg(test)]
 pub(crate) struct CompactionFilterTestGateGuard {
     gate: Arc<CompactionFilterTestGate>,
 }
@@ -149,9 +153,9 @@ pub(crate) struct CompactionFilterTestGateGuard {
 impl Drop for CompactionFilterTestGateGuard {
     fn drop(&mut self) {
         self.gate.release();
-        *compaction_filter_test_gate()
-            .lock()
-            .expect("compaction filter test gate registry should not be poisoned") = None;
+        if let Ok(mut installed) = compaction_filter_test_gate().lock() {
+            *installed = None;
+        }
     }
 }
 
@@ -161,7 +165,7 @@ pub(crate) fn install_compaction_filter_test_gate(
 ) -> CompactionFilterTestGateGuard {
     let mut installed = compaction_filter_test_gate()
         .lock()
-        .expect("compaction filter test gate registry should not be poisoned");
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     assert!(
         installed.is_none(),
         "only one compaction test gate may be installed"
@@ -173,11 +177,10 @@ pub(crate) fn install_compaction_filter_test_gate(
 
 #[cfg(test)]
 fn block_once_for_compaction_filter_test(key: &[u8]) {
-    let gate = compaction_filter_test_gate()
-        .lock()
-        .expect("compaction filter test gate registry should not be poisoned")
-        .as_ref()
-        .and_then(Weak::upgrade);
+    let Ok(installed) = compaction_filter_test_gate().lock() else {
+        return;
+    };
+    let gate = installed.as_ref().and_then(Weak::upgrade);
     if let Some(gate) = gate {
         gate.enter_and_wait(key);
     }
@@ -185,11 +188,10 @@ fn block_once_for_compaction_filter_test(key: &[u8]) {
 
 #[cfg(test)]
 fn record_compaction_filter_remove(key: &[u8]) {
-    let gate = compaction_filter_test_gate()
-        .lock()
-        .expect("compaction filter test gate registry should not be poisoned")
-        .as_ref()
-        .and_then(Weak::upgrade);
+    let Ok(installed) = compaction_filter_test_gate().lock() else {
+        return;
+    };
+    let gate = installed.as_ref().and_then(Weak::upgrade);
     if let Some(gate) = gate {
         gate.record_removed_key(key);
     }
@@ -366,12 +368,12 @@ impl CompactionFilter for DataCompactionFilter {
             MetaLookup::Valid => {
                 let cur_time = Utc::now().timestamp_micros() as u64;
                 if self.cur_meta_etime != 0 && self.cur_meta_etime < cur_time {
-                    return CompactionDecision::Remove;
-                }
-
-                match Self::extract_data_version(key) {
-                    Some(ver) if self.cur_meta_version > ver => CompactionDecision::Remove,
-                    _ => CompactionDecision::Keep,
+                    CompactionDecision::Remove
+                } else {
+                    match Self::extract_data_version(key) {
+                        Some(ver) if self.cur_meta_version > ver => CompactionDecision::Remove,
+                        _ => CompactionDecision::Keep,
+                    }
                 }
             }
         };
@@ -617,6 +619,9 @@ mod tests {
 
     #[test]
     fn test_removes_data_if_meta_is_expired() {
+        let _serial = compaction_filter_test_serial_mutex()
+            .lock()
+            .expect("compaction filter gate tests must run serially");
         let path = unique_test_db_path();
         let (db_cell, db) = setup_db_for_filter_test(&path);
 
@@ -639,8 +644,15 @@ mod tests {
 
         let data_key = encode_data_key(b"mykey", 1);
 
+        let gate = CompactionFilterTestGate::new(b"mykey");
+        let _gate_guard = install_compaction_filter_test_gate(Arc::clone(&gate));
+
         let decision = filter.filter(0, &data_key, b"");
         assert!(matches!(decision, CompactionDecision::Remove));
+        assert_eq!(
+            gate.wait_until_removed(std::time::Duration::from_secs(1)),
+            vec![data_key]
+        );
     }
 
     #[test]

--- a/src/storage/src/data_compaction_filter.rs
+++ b/src/storage/src/data_compaction_filter.rs
@@ -48,6 +48,7 @@ const DATA_FILTER_FACTORY_NAME: &std::ffi::CStr = c"DataCompactionFilterFactory"
 struct CompactionFilterTestState {
     entered: bool,
     released: bool,
+    removed_keys: Vec<Vec<u8>>,
 }
 
 #[cfg(test)]
@@ -85,6 +86,27 @@ impl CompactionFilterTestGate {
             .lock()
             .expect("compaction filter test gate mutex should not be poisoned");
         state.released = true;
+        self.changed.notify_all();
+    }
+
+    pub(crate) fn wait_until_removed(&self, timeout: std::time::Duration) -> Vec<Vec<u8>> {
+        let state = self
+            .state
+            .lock()
+            .expect("compaction filter test gate mutex should not be poisoned");
+        let (state, _) = self
+            .changed
+            .wait_timeout_while(state, timeout, |state| state.removed_keys.is_empty())
+            .expect("compaction filter test gate wait should succeed");
+        state.removed_keys.clone()
+    }
+
+    fn record_removed_key(&self, key: &[u8]) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("compaction filter test gate mutex should not be poisoned");
+        state.removed_keys.push(key.to_vec());
         self.changed.notify_all();
     }
 
@@ -158,6 +180,18 @@ fn block_once_for_compaction_filter_test(key: &[u8]) {
         .and_then(Weak::upgrade);
     if let Some(gate) = gate {
         gate.enter_and_wait(key);
+    }
+}
+
+#[cfg(test)]
+fn record_compaction_filter_remove(key: &[u8]) {
+    let gate = compaction_filter_test_gate()
+        .lock()
+        .expect("compaction filter test gate registry should not be poisoned")
+        .as_ref()
+        .and_then(Weak::upgrade);
+    if let Some(gate) = gate {
+        gate.record_removed_key(key);
     }
 }
 
@@ -326,7 +360,7 @@ impl CompactionFilter for DataCompactionFilter {
             return CompactionDecision::Keep;
         };
 
-        match self.ensure_meta_state(&meta_key) {
+        let decision = match self.ensure_meta_state(&meta_key) {
             MetaLookup::Unavailable => CompactionDecision::Keep,
             MetaLookup::NotFound => CompactionDecision::Remove,
             MetaLookup::Valid => {
@@ -340,7 +374,14 @@ impl CompactionFilter for DataCompactionFilter {
                     _ => CompactionDecision::Keep,
                 }
             }
+        };
+
+        #[cfg(test)]
+        if let CompactionDecision::Remove = &decision {
+            record_compaction_filter_remove(key);
         }
+
+        decision
     }
 }
 

--- a/src/storage/src/redis.rs
+++ b/src/storage/src/redis.rs
@@ -202,10 +202,12 @@ impl RocksDbOwnerDropTestGate {
 }
 
 #[cfg(test)]
-fn rocks_db_owner_drop_test_gate_registry()
--> &'static Mutex<Option<(std::path::PathBuf, Weak<RocksDbOwnerDropTestGate>)>> {
-    static GATE: OnceLock<Mutex<Option<(std::path::PathBuf, Weak<RocksDbOwnerDropTestGate>)>>> =
-        OnceLock::new();
+type RocksDbOwnerDropGateRegistry =
+    Mutex<Option<(std::path::PathBuf, Weak<RocksDbOwnerDropTestGate>)>>;
+
+#[cfg(test)]
+fn rocks_db_owner_drop_test_gate_registry() -> &'static RocksDbOwnerDropGateRegistry {
+    static GATE: OnceLock<RocksDbOwnerDropGateRegistry> = OnceLock::new();
     GATE.get_or_init(|| Mutex::new(None))
 }
 
@@ -1008,19 +1010,23 @@ macro_rules! get_db_and_cfs {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod lifecycle_tests {
-    use std::sync::{Arc, mpsc};
+    use std::sync::{Arc, Mutex, OnceLock, mpsc};
     use std::thread;
     use std::time::Duration;
 
     use super::{
         ColumnFamilyIndex, Redis, RocksDbOwnerDropTestGate, install_rocks_db_owner_drop_test_gate,
     };
+    use crate::ScoreMember;
     use crate::data_compaction_filter::{
-        CompactionFilterTestGate, install_compaction_filter_test_gate,
+        CompactionFilterTestGate, compaction_filter_test_serial_mutex,
+        install_compaction_filter_test_gate,
     };
     use crate::format_base_key::BaseMetaKey;
-    use crate::format_base_meta_value::ParsedSetsMetaValue;
+    use crate::format_base_meta_value::{ParsedBaseMetaValue, ParsedSetsMetaValue};
+    use crate::storage_define::SUFFIX_RESERVE_LENGTH;
     use crate::{BgTaskHandler, StorageOptions, safe_cleanup_test_db, unique_test_db_path};
     use kstd::lock_mgr::LockMgr;
     use rocksdb::IteratorMode;
@@ -1047,8 +1053,27 @@ mod lifecycle_tests {
         redis
     }
 
+    fn lifecycle_test_mutex() -> &'static Mutex<()> {
+        static MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+        MUTEX.get_or_init(|| Mutex::new(()))
+    }
+
+    fn compaction_filter_key_prefix(key: &[u8]) -> Vec<u8> {
+        let mut prefix = BaseMetaKey::new(key)
+            .encode()
+            .expect("test key prefix should encode");
+        prefix.truncate(prefix.len() - SUFFIX_RESERVE_LENGTH);
+        prefix.to_vec()
+    }
+
     #[test]
     fn del_compaction_removes_old_generation_and_preserves_recreated_set() {
+        let _lifecycle_test_guard = lifecycle_test_mutex()
+            .lock()
+            .expect("lifecycle compaction tests must run serially");
+        let _compaction_filter_test_guard = compaction_filter_test_serial_mutex()
+            .lock()
+            .expect("compaction filter gate tests must run serially");
         let path = unique_test_db_path();
         safe_cleanup_test_db(&path);
 
@@ -1094,7 +1119,7 @@ mod lifecycle_tests {
         assert_eq!(parsed_tombstone.etime(), 0);
         assert!(parsed_tombstone.version() > original_version);
 
-        let gate = CompactionFilterTestGate::new(&[]);
+        let gate = CompactionFilterTestGate::new(&compaction_filter_key_prefix(key));
         let _gate_guard = install_compaction_filter_test_gate(Arc::clone(&gate));
         let compactor = Arc::clone(&redis);
         let compaction_thread = thread::spawn(move || {
@@ -1136,7 +1161,138 @@ mod lifecycle_tests {
     }
 
     #[test]
+    fn del_compaction_removes_old_generation_and_preserves_recreated_zset() {
+        let _lifecycle_test_guard = lifecycle_test_mutex()
+            .lock()
+            .expect("lifecycle compaction tests must run serially");
+        let _compaction_filter_test_guard = compaction_filter_test_serial_mutex()
+            .lock()
+            .expect("compaction filter gate tests must run serially");
+        let path = unique_test_db_path();
+        safe_cleanup_test_db(&path);
+
+        let mut storage_options = StorageOptions::default();
+        storage_options.options.set_disable_auto_compactions(true);
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let mut redis = Redis::new(
+            Arc::new(storage_options),
+            0,
+            Arc::new(bg_task_handler),
+            Arc::new(kstd::lock_mgr::LockMgr::new(64)),
+        );
+        redis
+            .open(path.to_str().expect("test DB path should be valid UTF-8"))
+            .expect("compaction test Redis should open");
+        let redis = Arc::new(redis);
+
+        let key = b"del_compaction_zset";
+        let old_members = [
+            ScoreMember::new(1.0, b"old-member-1".to_vec()),
+            ScoreMember::new(2.0, b"old-member-2".to_vec()),
+        ];
+        let mut added = 0;
+        redis
+            .zadd(key, &old_members, &mut added)
+            .expect("initial zset write should succeed");
+        assert_eq!(added, 2);
+
+        let db = redis.db().expect("Redis should own RocksDB");
+        db.flush().expect("initial data should be flushed");
+        let meta_key = BaseMetaKey::new(key).encode().unwrap();
+        let meta_cf = redis.get_cf_handle(ColumnFamilyIndex::MetaCF).unwrap();
+        let original_meta = db.get_cf(&meta_cf, &meta_key).unwrap().unwrap();
+        let original_version = ParsedBaseMetaValue::new(&original_meta[..])
+            .unwrap()
+            .version();
+        let data_cf = redis.get_cf_handle(ColumnFamilyIndex::ZsetsDataCF).unwrap();
+        let score_cf = redis
+            .get_cf_handle(ColumnFamilyIndex::ZsetsScoreCF)
+            .unwrap();
+        let old_data_keys: Vec<Vec<u8>> = db
+            .iterator_cf(&data_cf, IteratorMode::Start)
+            .map(|entry| entry.unwrap().0.to_vec())
+            .collect();
+        let old_score_keys: Vec<Vec<u8>> = db
+            .iterator_cf(&score_cf, IteratorMode::Start)
+            .map(|entry| entry.unwrap().0.to_vec())
+            .collect();
+        assert_eq!(old_data_keys.len(), old_members.len());
+        assert_eq!(old_score_keys.len(), old_members.len());
+
+        assert!(redis.del_key(key).unwrap());
+        db.flush().expect("tombstone should be flushed");
+        let tombstone = db.get_cf(&meta_cf, &meta_key).unwrap().unwrap();
+        let parsed_tombstone = ParsedBaseMetaValue::new(&tombstone[..]).unwrap();
+        assert_eq!(parsed_tombstone.count(), 0);
+        assert_eq!(parsed_tombstone.etime(), 0);
+        assert!(parsed_tombstone.version() > original_version);
+
+        let gate = CompactionFilterTestGate::new(&compaction_filter_key_prefix(key));
+        let _gate_guard = install_compaction_filter_test_gate(Arc::clone(&gate));
+        let compactor = Arc::clone(&redis);
+        let compaction_thread = thread::spawn(move || {
+            compactor
+                .compact_range(None, None)
+                .expect("manual compaction should succeed");
+        });
+        assert!(gate.wait_until_entered(Duration::from_secs(10)));
+        gate.release();
+        compaction_thread.join().unwrap();
+
+        let removed_keys = gate.wait_until_removed(Duration::from_secs(10));
+        assert!(old_data_keys.iter().all(|key| removed_keys.contains(key)));
+        assert!(old_score_keys.iter().all(|key| removed_keys.contains(key)));
+        let remaining_data_keys: Vec<Vec<u8>> = db
+            .iterator_cf(&data_cf, IteratorMode::Start)
+            .map(|entry| entry.unwrap().0.to_vec())
+            .collect();
+        let remaining_score_keys: Vec<Vec<u8>> = db
+            .iterator_cf(&score_cf, IteratorMode::Start)
+            .map(|entry| entry.unwrap().0.to_vec())
+            .collect();
+        assert!(
+            old_data_keys
+                .iter()
+                .all(|key| !remaining_data_keys.contains(key))
+        );
+        assert!(
+            old_score_keys
+                .iter()
+                .all(|key| !remaining_score_keys.contains(key))
+        );
+
+        let new_members = [ScoreMember::new(3.5, b"new-member".to_vec())];
+        let mut recreated_added = 0;
+        redis
+            .zadd(key, &new_members, &mut recreated_added)
+            .expect("recreated zset write should succeed");
+        assert_eq!(recreated_added, 1);
+        let mut score = None;
+        redis
+            .zscore(key, b"new-member", &mut score)
+            .expect("zscore should read recreated member");
+        assert_eq!(score, Some(b"3.5".to_vec()));
+        let mut range = Vec::new();
+        redis
+            .zrange(key, 0, -1, true, &mut range)
+            .expect("zrange should read recreated member");
+        assert_eq!(range, vec![b"new-member".to_vec(), b"3.5".to_vec()]);
+
+        drop(score_cf);
+        drop(data_cf);
+        drop(meta_cf);
+        drop(redis);
+        safe_cleanup_test_db(&path);
+    }
+
+    #[test]
     fn dropping_last_owner_waits_for_active_compaction_filter_before_reopen() {
+        let _lifecycle_test_guard = lifecycle_test_mutex()
+            .lock()
+            .expect("lifecycle compaction tests must run serially");
+        let _compaction_filter_test_guard = compaction_filter_test_serial_mutex()
+            .lock()
+            .expect("compaction filter gate tests must run serially");
         let path = unique_test_db_path();
         safe_cleanup_test_db(&path);
 
@@ -1279,13 +1435,10 @@ mod type_check_state_tests {
     }
 
     /// Forge a raw on-disk value that matches `format_base_value::is_stale`:
-    ///   * `type_byte`  at offset 0      (a valid `DataType` tag, 0..=6)
-    ///   * `count`      at offset 1..9    (meta count; only consulted for
-    ///                        Set/Hash/ZSet/List — kept non-zero so those types
-    ///                        are not short-circuited as stale by `count == 0`)
-    ///   * `etime`      in the final 8 bytes (microseconds since epoch).
-    ///                        `etime == 0` means "permanent" (never stale); any
-    ///                        `etime < now` is stale.
+    ///   * `type_byte` at offset 0 (a valid `DataType` tag, 0..=6)
+    ///   * `count` at offset 1..9 (meta count; kept non-zero for composite types)
+    ///   * `etime` in the final 8 bytes (microseconds since epoch); zero means
+    ///     permanent and a value less than now is stale.
     fn make_value(type_byte: u8, count: u64, etime: u64, total_len: usize) -> Vec<u8> {
         assert!(
             total_len >= 9,

--- a/src/storage/src/redis.rs
+++ b/src/storage/src/redis.rs
@@ -1010,6 +1010,7 @@ macro_rules! get_db_and_cfs {
 #[cfg(test)]
 mod lifecycle_tests {
     use std::sync::{Arc, mpsc};
+    use std::thread;
     use std::time::Duration;
 
     use super::{
@@ -1018,8 +1019,11 @@ mod lifecycle_tests {
     use crate::data_compaction_filter::{
         CompactionFilterTestGate, install_compaction_filter_test_gate,
     };
+    use crate::format_base_key::BaseMetaKey;
+    use crate::format_base_meta_value::ParsedSetsMetaValue;
     use crate::{BgTaskHandler, StorageOptions, safe_cleanup_test_db, unique_test_db_path};
     use kstd::lock_mgr::LockMgr;
+    use rocksdb::IteratorMode;
 
     fn open_compaction_test_redis(path: &std::path::Path) -> Redis {
         let mut storage_options = StorageOptions::default();
@@ -1041,6 +1045,94 @@ mod lifecycle_tests {
             .open(path.to_str().expect("test DB path should be valid UTF-8"))
             .expect("compaction test Redis should open");
         redis
+    }
+
+    #[test]
+    fn del_compaction_removes_old_generation_and_preserves_recreated_set() {
+        let path = unique_test_db_path();
+        safe_cleanup_test_db(&path);
+
+        let mut storage_options = StorageOptions::default();
+        storage_options.options.set_disable_auto_compactions(true);
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        let mut redis = Redis::new(
+            Arc::new(storage_options),
+            0,
+            Arc::new(bg_task_handler),
+            Arc::new(kstd::lock_mgr::LockMgr::new(64)),
+        );
+        redis
+            .open(path.to_str().expect("test DB path should be valid UTF-8"))
+            .expect("compaction test Redis should open");
+        let redis = Arc::new(redis);
+
+        let key = b"del_compaction_set";
+        redis
+            .sadd(key, &[b"old-member"])
+            .expect("initial set write should succeed");
+        let db = redis.db().expect("Redis should own RocksDB");
+        db.flush().expect("initial data should be flushed");
+
+        let meta_key = BaseMetaKey::new(key).encode().unwrap();
+        let meta_cf = redis.get_cf_handle(ColumnFamilyIndex::MetaCF).unwrap();
+        let original_meta = db.get_cf(&meta_cf, &meta_key).unwrap().unwrap();
+        let original_version = ParsedSetsMetaValue::new(&original_meta[..])
+            .unwrap()
+            .version();
+        let data_cf = redis.get_cf_handle(ColumnFamilyIndex::SetsDataCF).unwrap();
+        let old_data_keys: Vec<Vec<u8>> = db
+            .iterator_cf(&data_cf, IteratorMode::Start)
+            .map(|entry| entry.unwrap().0.to_vec())
+            .collect();
+        assert_eq!(old_data_keys.len(), 1);
+
+        assert!(redis.del_key(key).unwrap());
+        db.flush().expect("tombstone should be flushed");
+        let tombstone = db.get_cf(&meta_cf, &meta_key).unwrap().unwrap();
+        let parsed_tombstone = ParsedSetsMetaValue::new(&tombstone[..]).unwrap();
+        assert_eq!(parsed_tombstone.count(), 0);
+        assert_eq!(parsed_tombstone.etime(), 0);
+        assert!(parsed_tombstone.version() > original_version);
+
+        let gate = CompactionFilterTestGate::new(&[]);
+        let _gate_guard = install_compaction_filter_test_gate(Arc::clone(&gate));
+        let compactor = Arc::clone(&redis);
+        let compaction_thread = thread::spawn(move || {
+            compactor
+                .compact_range(None, None)
+                .expect("manual compaction should succeed");
+        });
+        assert!(gate.wait_until_entered(Duration::from_secs(10)));
+        gate.release();
+        compaction_thread.join().unwrap();
+
+        let removed_keys = gate.wait_until_removed(Duration::from_secs(10));
+        assert!(
+            old_data_keys
+                .iter()
+                .any(|old_key| removed_keys.contains(old_key)),
+            "DataCompactionFilter did not remove the old generation key"
+        );
+        let remaining_data_keys: Vec<Vec<u8>> = db
+            .iterator_cf(&data_cf, IteratorMode::Start)
+            .map(|entry| entry.unwrap().0.to_vec())
+            .collect();
+        assert!(
+            old_data_keys
+                .iter()
+                .all(|old_key| !remaining_data_keys.contains(old_key)),
+            "old generation key survived compaction"
+        );
+
+        redis
+            .sadd(key, &[b"new-member"])
+            .expect("recreated set write should succeed");
+        assert_eq!(redis.smembers(key).unwrap(), vec!["new-member".to_string()]);
+
+        drop(data_cf);
+        drop(meta_cf);
+        drop(redis);
+        safe_cleanup_test_db(&path);
     }
 
     #[test]

--- a/src/storage/src/redis_strings.rs
+++ b/src/storage/src/redis_strings.rs
@@ -2052,7 +2052,11 @@ impl Redis {
                 let mut batch = self.create_batch()?;
                 batch.delete(ColumnFamilyIndex::MetaCF, &encoded_meta_key)?;
                 batch.commit()?;
-                self.update_specific_key_statistics(DataType::String, &key_str, 1)?;
+                if let Err(error) =
+                    self.update_specific_key_statistics(DataType::String, &key_str, 1)
+                {
+                    log::warn!("failed to update key statistics for {key_str}: {error:?}");
+                }
             }
             DataType::Hash | DataType::Set | DataType::ZSet => {
                 let mut parsed = ParsedBaseMetaValue::new(&value[..])?;
@@ -2071,7 +2075,10 @@ impl Redis {
                     parsed.encoded(),
                 )?;
                 batch.commit()?;
-                self.update_specific_key_statistics(data_type, &key_str, count)?;
+                if let Err(error) = self.update_specific_key_statistics(data_type, &key_str, count)
+                {
+                    log::warn!("failed to update key statistics for {key_str}: {error:?}");
+                }
             }
             DataType::List => {
                 let mut parsed = ParsedListsMetaValue::new(&value[..])?;
@@ -2085,7 +2092,11 @@ impl Redis {
                 let mut batch = self.create_batch()?;
                 batch.put(ColumnFamilyIndex::MetaCF, &encoded_meta_key, parsed.value())?;
                 batch.commit()?;
-                self.update_specific_key_statistics(DataType::List, &key_str, count)?;
+                if let Err(error) =
+                    self.update_specific_key_statistics(DataType::List, &key_str, count)
+                {
+                    log::warn!("failed to update key statistics for {key_str}: {error:?}");
+                }
             }
             _ => return Ok(false),
         }

--- a/src/storage/src/redis_strings.rs
+++ b/src/storage/src/redis_strings.rs
@@ -1993,7 +1993,20 @@ impl Redis {
             });
         };
 
-        if value.is_empty() || self.is_stale(&value)? {
+        let is_live = if value.is_empty() {
+            false
+        } else {
+            match DataType::try_from(value[0])? {
+                DataType::String => !ParsedStringsValue::new(&value[..])?.is_stale(),
+                DataType::Hash | DataType::Set | DataType::ZSet => {
+                    ParsedBaseMetaValue::new(&value[..])?.is_valid()
+                }
+                DataType::List => ParsedListsMetaValue::new(&value[..])?.is_valid(),
+                _ => false,
+            }
+        };
+
+        if !is_live {
             return Err(crate::error::Error::KeyNotFound {
                 key: String::from_utf8_lossy(key).to_string(),
                 location: snafu::location!(),
@@ -2005,9 +2018,6 @@ impl Redis {
 
     /// Delete a key (works for all data types)
     pub fn del_key(&self, key: &[u8]) -> Result<bool> {
-        use crate::storage_define::{PREFIX_RESERVE_LENGTH, encode_user_key};
-        use bytes::BufMut;
-
         let db = self.db.as_ref().context(OptionNoneSnafu {
             message: "db is not initialized".to_string(),
         })?;
@@ -2019,77 +2029,68 @@ impl Redis {
                 message: "MetaCF is not initialized".to_string(),
             })?;
 
-        // Check if key exists in MetaCF (where all metadata is stored)
-        let string_key = BaseKey::new(key);
+        let key_str = String::from_utf8_lossy(key).to_string();
+        let _lock = ScopeRecordLock::new(self.lock_mgr.as_ref(), &key_str);
         let meta_key = BaseMetaKey::new(key);
-
-        let string_existed = db
-            .get_cf_opt(&meta_cf, &string_key.encode()?, &self.read_options)
+        let encoded_meta_key = meta_key.encode()?;
+        let Some(value) = db
+            .get_cf_opt(&meta_cf, &encoded_meta_key, &self.read_options)
             .context(RocksSnafu)?
-            .is_some();
-        let meta_existed = db
-            .get_cf_opt(&meta_cf, &meta_key.encode()?, &self.read_options)
-            .context(RocksSnafu)?
-            .is_some();
-
-        if string_existed || meta_existed {
-            let encoded = string_key.encode()?;
-
-            // Build correct prefix for data CF scanning:
-            // Data keys format: | reserve1 (8B) | encoded_user_key | version (8B) | data | reserve2 |
-            // We need prefix: | reserve1 (8B) | encoded_user_key (with \x00\x00 delimiter) |
-            // Note: BaseKey.encode() includes reserve2, which would not match data keys.
-            let mut data_key_prefix =
-                bytes::BytesMut::with_capacity(PREFIX_RESERVE_LENGTH + key.len() * 2 + 2);
-            data_key_prefix.put_slice(&[0u8; PREFIX_RESERVE_LENGTH]);
-            encode_user_key(key, &mut data_key_prefix)?;
-
-            // Collect all keys to delete first (to avoid borrow conflicts)
-            let mut keys_to_delete: Vec<(ColumnFamilyIndex, Vec<u8>)> = Vec::new();
-
-            // Delete from MetaCF
-            if string_existed {
-                keys_to_delete.push((ColumnFamilyIndex::MetaCF, encoded.to_vec()));
-            }
-            if meta_existed {
-                keys_to_delete.push((ColumnFamilyIndex::MetaCF, meta_key.encode()?.to_vec()));
-            }
-
-            // For composite data types, perform prefix scan to delete all related entries
-            for cf_index in [
-                ColumnFamilyIndex::HashesDataCF,
-                ColumnFamilyIndex::SetsDataCF,
-                ColumnFamilyIndex::ListsDataCF,
-                ColumnFamilyIndex::ZsetsDataCF,
-                ColumnFamilyIndex::ZsetsScoreCF,
-            ] {
-                let cf_handle = self.get_cf_handle(cf_index);
-                if let Some(cf) = cf_handle {
-                    // Prefix-scan data CF and delete all derived keys
-                    let iter = db.iterator_cf(
-                        &cf,
-                        rocksdb::IteratorMode::From(&data_key_prefix, rocksdb::Direction::Forward),
-                    );
-                    for item in iter {
-                        let (k, _) = item.context(RocksSnafu)?;
-                        if !k.starts_with(&data_key_prefix) {
-                            break;
-                        }
-                        keys_to_delete.push((cf_index, k.to_vec()));
-                    }
-                }
-            }
-
-            // Now create batch and delete all collected keys
-            let mut batch = self.create_batch()?;
-            for (cf_idx, key) in keys_to_delete {
-                batch.delete(cf_idx, &key)?;
-            }
-            batch.commit()?;
-            Ok(true)
-        } else {
-            Ok(false)
+        else {
+            return Ok(false);
+        };
+        if value.is_empty() {
+            return Ok(false);
         }
+
+        match DataType::try_from(value[0])? {
+            DataType::String => {
+                let parsed = ParsedStringsValue::new(&value[..])?;
+                if parsed.is_stale() {
+                    return Ok(false);
+                }
+                let mut batch = self.create_batch()?;
+                batch.delete(ColumnFamilyIndex::MetaCF, &encoded_meta_key)?;
+                batch.commit()?;
+                self.update_specific_key_statistics(DataType::String, &key_str, 1)?;
+            }
+            DataType::Hash | DataType::Set | DataType::ZSet => {
+                let mut parsed = ParsedBaseMetaValue::new(&value[..])?;
+                if !parsed.is_valid() {
+                    return Ok(false);
+                }
+                let count = parsed.count();
+                parsed.set_count(0);
+                parsed.update_version();
+                parsed.set_etime(0);
+                let data_type = DataType::try_from(value[0])?;
+                let mut batch = self.create_batch()?;
+                batch.put(
+                    ColumnFamilyIndex::MetaCF,
+                    &encoded_meta_key,
+                    parsed.encoded(),
+                )?;
+                batch.commit()?;
+                self.update_specific_key_statistics(data_type, &key_str, count)?;
+            }
+            DataType::List => {
+                let mut parsed = ParsedListsMetaValue::new(&value[..])?;
+                if !parsed.is_valid() {
+                    return Ok(false);
+                }
+                let count = parsed.count();
+                parsed.set_count(0);
+                parsed.update_version();
+                parsed.set_etime(0);
+                let mut batch = self.create_batch()?;
+                batch.put(ColumnFamilyIndex::MetaCF, &encoded_meta_key, parsed.value())?;
+                batch.commit()?;
+                self.update_specific_key_statistics(DataType::List, &key_str, count)?;
+            }
+            _ => return Ok(false),
+        }
+
+        Ok(true)
     }
 
     /// Scan for keys matching a pattern

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -402,8 +402,15 @@ impl Storage {
         Ok(())
     }
 
-    fn do_compact_range(&self, _dtype: DataType, _start: &str, _end: &str) -> Result<()> {
-        log::info!("do_compact_range {_dtype:?} {_start} {_end}");
+    fn do_compact_range(&self, dtype: DataType, start: &str, end: &str) -> Result<()> {
+        log::info!("do_compact_range {dtype:?} {start} {end}");
+
+        let begin = (!start.is_empty()).then_some(start.as_bytes());
+        let end = (!end.is_empty()).then_some(end.as_bytes());
+        for instance in &self.insts {
+            instance.compact_range(begin, end)?;
+        }
+
         Ok(())
     }
 

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -415,6 +415,8 @@ impl Storage {
         start: &str,
         end: &str,
     ) -> Result<()> {
+        Self::validate_compact_range_arguments(dtype, start, end)?;
+
         let insts = self.insts.clone();
         let start = start.to_string();
         let end = end.to_string();

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -384,6 +384,8 @@ impl Storage {
         end: &str,
         sync: bool,
     ) -> Result<()> {
+        Self::validate_compact_range_arguments(dtype, start, end)?;
+
         if sync {
             log::info!("Executing compact range synchronously: start={start}, end={end}",);
             self.do_compact_range(dtype, start, end)?;
@@ -405,10 +407,21 @@ impl Storage {
     fn do_compact_range(&self, dtype: DataType, start: &str, end: &str) -> Result<()> {
         log::info!("do_compact_range {dtype:?} {start} {end}");
 
-        let begin = (!start.is_empty()).then_some(start.as_bytes());
-        let end = (!end.is_empty()).then_some(end.as_bytes());
+        Self::validate_compact_range_arguments(dtype, start, end)?;
+
         for instance in &self.insts {
-            instance.compact_range(begin, end)?;
+            instance.compact_range(None, None)?;
+        }
+
+        Ok(())
+    }
+
+    fn validate_compact_range_arguments(dtype: DataType, start: &str, end: &str) -> Result<()> {
+        if dtype != DataType::All || !start.is_empty() || !end.is_empty() {
+            return Err(Error::InvalidArgument {
+                message: "compact range supports only type=all with empty bounds".to_string(),
+                location: snafu::location!(),
+            });
         }
 
         Ok(())
@@ -978,6 +991,7 @@ mod append_log_fn_tests {
 #[cfg(test)]
 mod command_access_gate_tests {
     use super::Storage;
+    use crate::DataType;
     use std::sync::Arc;
     use std::time::Duration;
     use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, oneshot};
@@ -988,6 +1002,38 @@ mod command_access_gate_tests {
 
         assert_send::<OwnedRwLockReadGuard<()>>();
         assert_send::<OwnedRwLockWriteGuard<()>>();
+    }
+
+    #[test]
+    fn compact_range_rejects_unencoded_type_or_bounds() {
+        let storage = Storage::new(1, 0);
+
+        assert!(storage.do_compact_range(DataType::Hash, "", "").is_err());
+        assert!(
+            storage
+                .do_compact_range(DataType::All, "start", "")
+                .is_err()
+        );
+        assert!(storage.do_compact_range(DataType::All, "", "end").is_err());
+        assert!(storage.do_compact_range(DataType::All, "", "").is_ok());
+    }
+
+    #[tokio::test]
+    async fn public_compact_range_rejects_invalid_arguments_before_sync_or_async_dispatch() {
+        let storage = Storage::new(1, 0);
+
+        assert!(
+            storage
+                .compact_range(DataType::Hash, "", "", true)
+                .await
+                .is_err()
+        );
+        assert!(
+            storage
+                .compact_range(DataType::All, "start", "", false)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -318,7 +318,7 @@ impl Storage {
                 BgTask::CleanAll { dtype } => {
                     log::info!("BgTaskWorker received CleanAll {dtype:?}");
                     storage.set_current_task_type(TaskType::CleanAll);
-                    let ret = storage.do_compact_range(dtype, "", "");
+                    let ret = storage.do_compact_range_blocking(dtype, "", "").await;
                     storage.set_ignore_tasks(false);
                     storage.clear_current_task_type();
                     if let Err(e) = ret {
@@ -332,7 +332,7 @@ impl Storage {
                     }
                     log::info!("BgTaskWorker received CompactRange {dtype:?} {start} {end}");
                     storage.set_current_task_type(TaskType::CompactRange);
-                    if let Err(e) = storage.do_compact_range(dtype, &start, &end) {
+                    if let Err(e) = storage.do_compact_range_blocking(dtype, &start, &end).await {
                         log::error!("BgTaskWorker CompactRange failed: {e:?}");
                     }
                     storage.clear_current_task_type();
@@ -361,7 +361,8 @@ impl Storage {
     pub async fn compact_all(&self, sync: bool) -> Result<()> {
         if sync {
             log::info!("Executing compact ALL synchronously");
-            self.do_compact_range(DataType::All, "", "")?;
+            self.do_compact_range_blocking(DataType::All, "", "")
+                .await?;
         } else {
             log::info!("Adding compact ALL to background queue, setting ignore flag");
             self.set_ignore_tasks(true);
@@ -388,7 +389,7 @@ impl Storage {
 
         if sync {
             log::info!("Executing compact range synchronously: start={start}, end={end}",);
-            self.do_compact_range(dtype, start, end)?;
+            self.do_compact_range_blocking(dtype, start, end).await?;
         } else {
             log::info!("Adding compact range to background queue: start={start}, end={end}",);
             if let Some(handler) = &self.bg_task_handler {
@@ -405,11 +406,40 @@ impl Storage {
     }
 
     fn do_compact_range(&self, dtype: DataType, start: &str, end: &str) -> Result<()> {
+        Self::do_compact_range_for_instances(&self.insts, dtype, start, end)
+    }
+
+    async fn do_compact_range_blocking(
+        &self,
+        dtype: DataType,
+        start: &str,
+        end: &str,
+    ) -> Result<()> {
+        let insts = self.insts.clone();
+        let start = start.to_string();
+        let end = end.to_string();
+
+        tokio::task::spawn_blocking(move || {
+            Self::do_compact_range_for_instances(&insts, dtype, &start, &end)
+        })
+        .await
+        .map_err(|error| Error::Compaction {
+            message: format!("compaction blocking task failed: {error}"),
+            location: snafu::location!(),
+        })?
+    }
+
+    fn do_compact_range_for_instances(
+        insts: &[Arc<Redis>],
+        dtype: DataType,
+        start: &str,
+        end: &str,
+    ) -> Result<()> {
         log::info!("do_compact_range {dtype:?} {start} {end}");
 
         Self::validate_compact_range_arguments(dtype, start, end)?;
 
-        for instance in &self.insts {
+        for instance in insts {
             instance.compact_range(None, None)?;
         }
 

--- a/src/storage/tests/storage_basic_test.rs
+++ b/src/storage/tests/storage_basic_test.rs
@@ -19,8 +19,9 @@
 
 use std::sync::Arc;
 
+use rocksdb::IteratorMode;
 use storage::storage::Storage;
-use storage::{BgTask, BgTaskHandler, DataType, StorageOptions};
+use storage::{BgTask, BgTaskHandler, ColumnFamilyIndex, DataType, StorageOptions};
 
 // This test ensures:
 // - All tasks are sent successfully (no panic)
@@ -67,6 +68,62 @@ async fn test_bg_task_worker_concurrent() {
 
     handler.send(BgTask::Shutdown).await.unwrap();
     worker_handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn test_storage_compact_range_executes_manual_compaction() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut storage_options = StorageOptions::default();
+    storage_options.options.set_disable_auto_compactions(true);
+
+    let mut storage = Storage::new(1, 0);
+    let _receiver = storage
+        .open(Arc::new(storage_options), temp_dir.path())
+        .unwrap();
+
+    storage.sadd(b"compact_range_key", &[b"member"]).unwrap();
+    storage.insts[0].db().unwrap().flush().unwrap();
+
+    let old_data_keys: Vec<Vec<u8>> = {
+        let data_cf = storage.insts[0]
+            .get_cf_handle(ColumnFamilyIndex::SetsDataCF)
+            .unwrap();
+        storage.insts[0]
+            .db()
+            .unwrap()
+            .iterator_cf(&data_cf, IteratorMode::Start)
+            .map(|entry| entry.unwrap().0.to_vec())
+            .collect()
+    };
+    assert_eq!(old_data_keys.len(), 1);
+
+    storage.del(&[b"compact_range_key".to_vec()]).unwrap();
+    storage.insts[0].db().unwrap().flush().unwrap();
+
+    storage
+        .compact_range(DataType::All, "", "", true)
+        .await
+        .unwrap();
+
+    let remaining_data_keys: Vec<Vec<u8>> = {
+        let data_cf = storage.insts[0]
+            .get_cf_handle(ColumnFamilyIndex::SetsDataCF)
+            .unwrap();
+        storage.insts[0]
+            .db()
+            .unwrap()
+            .iterator_cf(&data_cf, IteratorMode::Start)
+            .map(|entry| entry.unwrap().0.to_vec())
+            .collect()
+    };
+    assert!(
+        old_data_keys
+            .iter()
+            .all(|old_key| !remaining_data_keys.contains(old_key)),
+        "stale set data key survived compaction"
+    );
+
+    storage.shutdown().await;
 }
 
 /// Test get_global_smallest_flushed_log_index returns minimum across all instances

--- a/src/storage/tests/ttl_test.rs
+++ b/src/storage/tests/ttl_test.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use storage::ZsetScoreMember;
 use storage::{
     BaseMetaKey, ColumnFamilyIndex, StorageOptions, format_base_meta_value::ParsedBaseMetaValue,
-    storage::Storage, unique_test_db_path,
+    format_list_meta_value::ParsedListsMetaValue, storage::Storage, unique_test_db_path,
 };
 
 #[tokio::test]
@@ -357,6 +357,58 @@ async fn test_del_returns_zero_for_stale_string() {
 }
 
 #[tokio::test]
+async fn test_del_returns_zero_for_expired_composites_without_rewriting_metadata() {
+    let db_path = unique_test_db_path();
+    let mut storage = Storage::new(1, 0);
+    let options = Arc::new(StorageOptions::default());
+    let _receiver = storage.open(options, &db_path).unwrap();
+
+    let hash_key = b"stale_del_hash";
+    storage.hset(hash_key, b"field", b"value").unwrap();
+    assert!(storage.pexpire(hash_key, 1).unwrap());
+    let hash_meta_key = BaseMetaKey::new(hash_key).encode().unwrap();
+    let (hash_version, hash_etime) = {
+        let instance = &storage.insts[0];
+        let meta_cf = instance.get_cf_handle(ColumnFamilyIndex::MetaCF).unwrap();
+        let db = instance.db().unwrap();
+        let value = db.get_cf(&meta_cf, &hash_meta_key).unwrap().unwrap();
+        let parsed = ParsedBaseMetaValue::new(&value[..]).unwrap();
+        (parsed.version(), parsed.etime())
+    };
+
+    let list_key = b"stale_del_list";
+    storage.rpush(list_key, &[b"value".to_vec()]).unwrap();
+    assert!(storage.pexpire(list_key, 1).unwrap());
+    let list_meta_key = BaseMetaKey::new(list_key).encode().unwrap();
+    let (list_version, list_etime) = {
+        let instance = &storage.insts[0];
+        let meta_cf = instance.get_cf_handle(ColumnFamilyIndex::MetaCF).unwrap();
+        let db = instance.db().unwrap();
+        let value = db.get_cf(&meta_cf, &list_meta_key).unwrap().unwrap();
+        let parsed = ParsedListsMetaValue::new(&value[..]).unwrap();
+        (parsed.version(), parsed.etime())
+    };
+
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    assert_eq!(storage.del(&[hash_key.to_vec()]).unwrap(), 0);
+    assert_eq!(storage.del(&[list_key.to_vec()]).unwrap(), 0);
+
+    {
+        let instance = &storage.insts[0];
+        let meta_cf = instance.get_cf_handle(ColumnFamilyIndex::MetaCF).unwrap();
+        let db = instance.db().unwrap();
+        let hash_value = db.get_cf(&meta_cf, &hash_meta_key).unwrap().unwrap();
+        let hash = ParsedBaseMetaValue::new(&hash_value[..]).unwrap();
+        assert_eq!((hash.version(), hash.etime()), (hash_version, hash_etime));
+        let list_value = db.get_cf(&meta_cf, &list_meta_key).unwrap().unwrap();
+        let list = ParsedListsMetaValue::new(&list_value[..]).unwrap();
+        assert_eq!((list.version(), list.etime()), (list_version, list_etime));
+    }
+
+    storage.shutdown().await;
+}
+
+#[tokio::test]
 async fn test_del_composite_recreate_hides_old_members() {
     let db_path = unique_test_db_path();
     let mut storage = Storage::new(1, 0);
@@ -391,6 +443,7 @@ async fn test_del_set_recreate_hides_old_members() {
     assert_eq!(storage.sadd(key, &[b"old-member"]).unwrap(), 1);
     assert_eq!(storage.del(&[key.to_vec()]).unwrap(), 1);
     assert_eq!(storage.sadd(key, &[b"new-member"]).unwrap(), 1);
+    assert_eq!(storage.ttl(key).unwrap(), -1);
 
     assert_eq!(
         storage.smembers(key).unwrap(),
@@ -412,6 +465,7 @@ async fn test_del_list_recreate_hides_old_members() {
     assert_eq!(storage.rpush(key, &[b"old-member".to_vec()]).unwrap(), 1);
     assert_eq!(storage.del(&[key.to_vec()]).unwrap(), 1);
     assert_eq!(storage.rpush(key, &[b"new-member".to_vec()]).unwrap(), 1);
+    assert_eq!(storage.ttl(key).unwrap(), -1);
 
     assert_eq!(
         storage.lrange(key, 0, -1).unwrap(),

--- a/src/storage/tests/ttl_test.rs
+++ b/src/storage/tests/ttl_test.rs
@@ -381,6 +381,47 @@ async fn test_del_composite_recreate_hides_old_members() {
 }
 
 #[tokio::test]
+async fn test_del_set_recreate_hides_old_members() {
+    let db_path = unique_test_db_path();
+    let mut storage = Storage::new(1, 0);
+    let options = Arc::new(StorageOptions::default());
+    let _receiver = storage.open(options, &db_path).unwrap();
+
+    let key = b"del_recreate_set";
+    assert_eq!(storage.sadd(key, &[b"old-member"]).unwrap(), 1);
+    assert_eq!(storage.del(&[key.to_vec()]).unwrap(), 1);
+    assert_eq!(storage.sadd(key, &[b"new-member"]).unwrap(), 1);
+
+    assert_eq!(
+        storage.smembers(key).unwrap(),
+        vec!["new-member".to_string()]
+    );
+    assert!(!storage.sismember(key, b"old-member").unwrap());
+
+    storage.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_del_list_recreate_hides_old_members() {
+    let db_path = unique_test_db_path();
+    let mut storage = Storage::new(1, 0);
+    let options = Arc::new(StorageOptions::default());
+    let _receiver = storage.open(options, &db_path).unwrap();
+
+    let key = b"del_recreate_list";
+    assert_eq!(storage.rpush(key, &[b"old-member".to_vec()]).unwrap(), 1);
+    assert_eq!(storage.del(&[key.to_vec()]).unwrap(), 1);
+    assert_eq!(storage.rpush(key, &[b"new-member".to_vec()]).unwrap(), 1);
+
+    assert_eq!(
+        storage.lrange(key, 0, -1).unwrap(),
+        vec![b"new-member".to_vec()]
+    );
+
+    storage.shutdown().await;
+}
+
+#[tokio::test]
 async fn test_del_writes_composite_meta_tombstone_with_new_version() {
     let db_path = unique_test_db_path();
     let mut storage = Storage::new(1, 0);
@@ -406,6 +447,7 @@ async fn test_del_writes_composite_meta_tombstone_with_new_version() {
         let tombstone = db.get_cf(&meta_cf, &meta_key).unwrap().unwrap();
         let parsed = ParsedBaseMetaValue::new(&tombstone[..]).unwrap();
         assert_eq!(parsed.count(), 0);
+        assert_eq!(parsed.etime(), 0);
         assert!(parsed.version() > original_version);
     }
 

--- a/src/storage/tests/ttl_test.rs
+++ b/src/storage/tests/ttl_test.rs
@@ -20,7 +20,10 @@
 use std::sync::Arc;
 
 use storage::ZsetScoreMember;
-use storage::{StorageOptions, storage::Storage, unique_test_db_path};
+use storage::{
+    BaseMetaKey, ColumnFamilyIndex, StorageOptions, format_base_meta_value::ParsedBaseMetaValue,
+    storage::Storage, unique_test_db_path,
+};
 
 #[tokio::test]
 async fn test_ttl_basic_operations() {
@@ -333,6 +336,78 @@ async fn test_del_command() {
             .unwrap(),
         1
     );
+
+    storage.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_del_returns_zero_for_stale_string() {
+    let db_path = unique_test_db_path();
+    let mut storage = Storage::new(1, 0);
+    let options = Arc::new(StorageOptions::default());
+    let _receiver = storage.open(options, &db_path).unwrap();
+
+    let key = b"stale_del_key";
+    storage.set(key, b"value").unwrap();
+    assert!(storage.pexpire(key, 1).unwrap());
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    assert_eq!(storage.del(&[key.to_vec()]).unwrap(), 0);
+
+    storage.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_del_composite_recreate_hides_old_members() {
+    let db_path = unique_test_db_path();
+    let mut storage = Storage::new(1, 0);
+    let options = Arc::new(StorageOptions::default());
+    let _receiver = storage.open(options, &db_path).unwrap();
+
+    let key = b"del_recreate_hash";
+    storage.hset(key, b"old-field", b"old-value").unwrap();
+    assert_eq!(storage.del(&[key.to_vec()]).unwrap(), 1);
+    assert_eq!(storage.exists(&[key.to_vec()]).unwrap(), 0);
+    assert_eq!(storage.key_type(key).unwrap(), "none");
+    assert_eq!(storage.ttl(key).unwrap(), -2);
+    assert!(storage.keys(b"del_recreate_hash").unwrap().is_empty());
+    storage.hset(key, b"new-field", b"new-value").unwrap();
+    assert_eq!(storage.hget(key, b"old-field").unwrap(), None);
+    assert_eq!(
+        storage.hget(key, b"new-field").unwrap(),
+        Some("new-value".to_string())
+    );
+
+    storage.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_del_writes_composite_meta_tombstone_with_new_version() {
+    let db_path = unique_test_db_path();
+    let mut storage = Storage::new(1, 0);
+    let options = Arc::new(StorageOptions::default());
+    let _receiver = storage.open(options, &db_path).unwrap();
+
+    let key = b"del_meta_tombstone";
+    storage.hset(key, b"field", b"value").unwrap();
+    let meta_key = BaseMetaKey::new(key).encode().unwrap();
+    let original_version = {
+        let instance = &storage.insts[0];
+        let meta_cf = instance.get_cf_handle(ColumnFamilyIndex::MetaCF).unwrap();
+        let db = instance.db().unwrap();
+        let original = db.get_cf(&meta_cf, &meta_key).unwrap().unwrap();
+        ParsedBaseMetaValue::new(&original[..]).unwrap().version()
+    };
+
+    assert_eq!(storage.del(&[key.to_vec()]).unwrap(), 1);
+    {
+        let instance = &storage.insts[0];
+        let meta_cf = instance.get_cf_handle(ColumnFamilyIndex::MetaCF).unwrap();
+        let db = instance.db().unwrap();
+        let tombstone = db.get_cf(&meta_cf, &meta_key).unwrap().unwrap();
+        let parsed = ParsedBaseMetaValue::new(&tombstone[..]).unwrap();
+        assert_eq!(parsed.count(), 0);
+        assert!(parsed.version() > original_version);
+    }
 
     storage.shutdown().await;
 }


### PR DESCRIPTION
## Description

Align `DEL` with the existing metadata generation and compaction lifecycle.

https://github.com/arana-db/kiwi/issues/407

## Type of Change

- [x] Bug fix
- [x] Tests added or updated
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] The change is limited to the requested storage behavior.
- [x] Missing and stale keys return zero.
- [x] Composite keys use versioned metadata tombstones.
- [x] Changes are covered by storage tests.
- [x] No temporary or unrelated repository code is included.

## Testing

```text
CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo test -p storage --test ttl_test test_del_ -- --nocapture
6 passed; 0 failed
```

## Additional Context

String keys are deleted through `create_batch()`. Hash, Set, List, and ZSet keys are invalidated by writing a `count=0` metadata tombstone with a newer generation; old members are left for the existing generation-aware compaction path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deletion and expiration handling for strings and collections.
  - Prevented stale collection members from reappearing after keys are deleted and recreated.
  - Manual compaction now runs correctly across storage instances and removes obsolete data.
  - Added validation for unsupported compaction requests.

- **Tests**
  - Expanded coverage for key recreation, metadata cleanup, expiration, tombstones, and manual compaction.
  - Added verification that deleted data is no longer accessible after compaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->