### PR TITLE
fix(storage): share block cache across instances when share-block-cache is enabled (#143)

### DIFF
--- a/src/conf/src/config.rs
+++ b/src/conf/src/config.rs
@@ -90,6 +90,10 @@ pub struct Config {
     #[validate(range(min = 1024, max = 65535))]
     pub port: u16,
     pub memory: u64,
+    /// When enabled, all RocksDB column families share a single block cache
+    /// built once in `StorageOptions::from_config`. When disabled, each
+    /// database instance builds its own independent block cache.
+    pub share_block_cache: bool,
     pub small_compaction_threshold: usize,
     pub small_compaction_duration_threshold: usize,
     pub rocksdb_max_subcompactions: u32,
@@ -134,6 +138,7 @@ impl std::fmt::Debug for Config {
         f.debug_struct("Config")
             .field("port", &self.port)
             .field("memory", &self.memory)
+            .field("share_block_cache", &self.share_block_cache)
             .field(
                 "small_compaction_threshold",
                 &self.small_compaction_threshold,
@@ -242,6 +247,7 @@ impl Default for Config {
             port: DEFAULT_PORT,
             timeout: 50,
             memory: 1024 * 1024 * 1024, // 1GB
+            share_block_cache: true,
             log_dir: "./kiwi_data/logs".to_string(),
             data_dir: "./kiwi_data/db".to_string(),
             redis_compatible_mode: false,
@@ -368,6 +374,15 @@ impl Config {
                 "memory" => {
                     config.memory =
                         parse_memory(&value).map_err(|e| Error::MemoryParse { source: e })?;
+                }
+                "share-block-cache" => {
+                    config.share_block_cache =
+                        parse_bool_from_string(&value).map_err(|e| Error::InvalidConfig {
+                            source: serde_ini::de::Error::Custom(format!(
+                                "Invalid share-block-cache: {}",
+                                e
+                            )),
+                        })?;
                 }
                 "small-compaction-threshold" => {
                     config.small_compaction_threshold =
@@ -815,5 +830,53 @@ impl Config {
 
     pub fn get_rocksdb_block_based_table_options(&self) -> rocksdb::BlockBasedOptions {
         rocksdb::BlockBasedOptions::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+    use std::io::Write;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn default_share_block_cache_is_enabled() {
+        let config = Config::default();
+        assert!(config.share_block_cache);
+    }
+
+    /// Write `content` to a uniquely-named temp file and load it as a [`Config`].
+    /// The unique name avoids collisions when tests run in parallel.
+    fn load_from_str(content: &str) -> Result<Config, Error> {
+        let n = TEMP_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let filename = format!("kiwi_test_sbc_{}_{}.conf", std::process::id(), n);
+        let path = std::env::temp_dir().join(filename);
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{}", content).unwrap();
+        drop(f);
+        let result = Config::load(path.to_str().unwrap());
+        let _ = std::fs::remove_file(&path);
+        result
+    }
+
+    #[test]
+    fn parse_share_block_cache_yes() {
+        let config = load_from_str("share-block-cache yes").unwrap();
+        assert!(config.share_block_cache);
+    }
+
+    #[test]
+    fn parse_share_block_cache_no() {
+        let config = load_from_str("share-block-cache no").unwrap();
+        assert!(!config.share_block_cache);
+    }
+
+    #[test]
+    fn parse_share_block_cache_invalid() {
+        assert!(load_from_str("share-block-cache maybe").is_err());
     }
 }

--- a/src/conf/src/lib.rs
+++ b/src/conf/src/lib.rs
@@ -92,6 +92,7 @@ mod tests {
             port: 999,
             timeout: 100,
             redis_compatible_mode: false,
+            share_block_cache: true,
             log_dir: "".to_string(),
             data_dir: "./kiwi_data/db".to_string(),
             memory: 1024,

--- a/src/raft/src/state_machine.rs
+++ b/src/raft/src/state_machine.rs
@@ -593,6 +593,12 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
         let current_storage = self.storage_swap.load_full();
         let db_instance_num = current_storage.db_instance_num;
         let db_id = current_storage.db_id;
+        let options = current_storage.storage_options().unwrap_or_else(|| {
+            log::warn!(
+                "snapshot install found unopened Storage without configured options; using defaults"
+            );
+            Arc::new(StorageOptions::default())
+        });
         let prepared = prepare_checkpoint_restore(&checkpoint_root, &self.db_path, db_instance_num)
             .map_err(io_err_to_raft)?;
 
@@ -650,7 +656,6 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
             .map_err(|error| post_marker_error("committing the staged checkpoint", &error))?;
 
         let mut new_storage = Storage::new(db_instance_num, db_id);
-        let options = Arc::new(StorageOptions::default());
         new_storage
             .open(options, &self.db_path)
             .map_err(|error| post_marker_error("opening the restored storage", &error))?;

--- a/src/raft/tests/snapshot_roundtrip_test.rs
+++ b/src/raft/tests/snapshot_roundtrip_test.rs
@@ -693,7 +693,13 @@ async fn install_snapshot_replaces_open_target_storage() -> anyhow::Result<()> {
     close_storage(source_storage, "source storage").await?;
 
     let mut target_storage = Storage::new(1, 0);
-    let options = Arc::new(StorageOptions::default());
+    let configured_cache = Arc::new(rocksdb::Cache::new_lru_cache(4 * 1024 * 1024));
+    let options = Arc::new(StorageOptions {
+        block_cache_size: 4 * 1024 * 1024,
+        share_block_cache: true,
+        block_cache: Some(Arc::clone(&configured_cache)),
+        ..StorageOptions::default()
+    });
     let _target_rx = target_storage.open(options, &restore_db_path)?;
     target_storage.set(b"stale_key", b"stale_value")?;
 
@@ -730,6 +736,20 @@ async fn install_snapshot_replaces_open_target_storage() -> anyhow::Result<()> {
     let restored = target_swap.load_full();
     assert_eq!(restored.get(b"snapshot_key")?, "snapshot_value");
     assert!(restored.get(b"stale_key").is_err());
+    let restored_options = &restored.insts[0].storage;
+    assert!(restored_options.share_block_cache);
+    assert_eq!(restored_options.block_cache_size, 4 * 1024 * 1024);
+    assert!(
+        restored_options.block_cache.is_some(),
+        "snapshot install should preserve the configured shared block cache"
+    );
+    assert!(Arc::ptr_eq(
+        restored_options
+            .block_cache
+            .as_ref()
+            .expect("restored cache should exist"),
+        &configured_cache
+    ));
 
     drop(target_sm);
     drop(target_swap);

--- a/src/storage/src/options.rs
+++ b/src/storage/src/options.rs
@@ -60,9 +60,10 @@ pub struct StorageOptions {
     pub block_cache_size: usize,
     /// Whether to share block cache across column families
     pub share_block_cache: bool,
-    /// Shared block cache built once in `from_config` and reused by every
-    /// `Redis` instance through the shared `Arc<StorageOptions>`.
-    /// `None` means no shared cache; each instance falls back to its own.
+    /// Shared block cache created by the default/configuration path and reused
+    /// by every `Redis` instance through the shared `Arc<StorageOptions>`.
+    /// `None` means no explicit shared cache. When sharing is disabled,
+    /// each `Redis` instance builds one cache from `block_cache_size`.
     pub block_cache: Option<Arc<Cache>>,
     /// Maximum size for statistics
     pub statistics_max_size: usize,
@@ -84,6 +85,7 @@ pub struct StorageOptions {
 
 impl Default for StorageOptions {
     fn default() -> Self {
+        let block_cache_size = 8 << 30; // 8GB
         let mut options = Options::default();
         options.create_if_missing(true);
         options.create_missing_column_families(true);
@@ -96,9 +98,9 @@ impl Default for StorageOptions {
         Self {
             options,
             table_options: BlockBasedOptions::default(),
-            block_cache_size: 8 << 30, // 8GB
+            block_cache_size,
             share_block_cache: true,
-            block_cache: None,
+            block_cache: Some(Arc::new(Cache::new_lru_cache(block_cache_size))),
             statistics_max_size: 0,
             small_compaction_threshold: 5000,
             small_compaction_duration_threshold: 10000,
@@ -133,6 +135,7 @@ impl StorageOptions {
         Self {
             options: rocksdb_opts,
             block_cache_size: config.memory as usize,
+            share_block_cache: config.share_block_cache,
             block_cache,
             small_compaction_threshold: config.small_compaction_threshold,
             small_compaction_duration_threshold: config.small_compaction_duration_threshold,
@@ -144,13 +147,23 @@ impl StorageOptions {
     /// Set block cache size
     pub fn set_block_cache_size(&mut self, size: usize) -> &mut Self {
         self.block_cache_size = size;
+        self.rebuild_shared_block_cache();
         self
     }
 
     /// Set whether to share block cache
     pub fn set_share_block_cache(&mut self, share: bool) -> &mut Self {
         self.share_block_cache = share;
+        self.rebuild_shared_block_cache();
         self
+    }
+
+    fn rebuild_shared_block_cache(&mut self) {
+        self.block_cache = if self.share_block_cache && self.block_cache_size > 0 {
+            Some(Arc::new(Cache::new_lru_cache(self.block_cache_size)))
+        } else {
+            None
+        };
     }
 
     /// Set statistics maximum size
@@ -231,4 +244,51 @@ impl StorageOptions {
 pub enum OptionType {
     DB,
     ColumnFamily,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StorageOptions;
+
+    #[test]
+    fn from_config_preserves_disabled_share_block_cache() {
+        let config = conf::config::Config {
+            share_block_cache: false,
+            memory: 64 * 1024 * 1024,
+            ..conf::config::Config::default()
+        };
+
+        let options = StorageOptions::from_config(&config);
+
+        assert!(!options.share_block_cache);
+        assert!(options.block_cache.is_none());
+        assert_eq!(options.block_cache_size, 64 * 1024 * 1024);
+    }
+
+    #[test]
+    fn block_cache_setters_keep_the_derived_cache_consistent() {
+        let config = conf::config::Config {
+            memory: 4 * 1024 * 1024,
+            ..conf::config::Config::default()
+        };
+        let mut options = StorageOptions::from_config(&config);
+        let original_cache = options
+            .block_cache
+            .as_ref()
+            .expect("sharing should create a block cache")
+            .clone();
+
+        options.set_block_cache_size(8 * 1024 * 1024);
+        let resized_cache = options
+            .block_cache
+            .as_ref()
+            .expect("resizing a shared cache should rebuild it");
+        assert!(!std::sync::Arc::ptr_eq(&original_cache, resized_cache));
+
+        options.set_share_block_cache(false);
+        assert!(options.block_cache.is_none());
+
+        options.set_share_block_cache(true);
+        assert!(options.block_cache.is_some());
+    }
 }

--- a/src/storage/src/options.rs
+++ b/src/storage/src/options.rs
@@ -17,7 +17,9 @@
 
 //! Storage engine options and configurations
 
-use rocksdb::{BlockBasedOptions, Options};
+use std::sync::Arc;
+
+use rocksdb::{BlockBasedOptions, Cache, Options};
 
 use crate::error::{OptionNotDynamicallyModifiableSnafu, Result};
 
@@ -58,6 +60,10 @@ pub struct StorageOptions {
     pub block_cache_size: usize,
     /// Whether to share block cache across column families
     pub share_block_cache: bool,
+    /// Shared block cache built once in `from_config` and reused by every
+    /// `Redis` instance through the shared `Arc<StorageOptions>`.
+    /// `None` means no shared cache; each instance falls back to its own.
+    pub block_cache: Option<Arc<Cache>>,
     /// Maximum size for statistics
     pub statistics_max_size: usize,
     /// Threshold for small value compaction
@@ -92,6 +98,7 @@ impl Default for StorageOptions {
             table_options: BlockBasedOptions::default(),
             block_cache_size: 8 << 30, // 8GB
             share_block_cache: true,
+            block_cache: None,
             statistics_max_size: 0,
             small_compaction_threshold: 5000,
             small_compaction_duration_threshold: 10000,
@@ -113,9 +120,20 @@ impl StorageOptions {
     /// Build StorageOptions from a loaded [`conf::config::Config`].
     pub fn from_config(config: &conf::config::Config) -> Self {
         let rocksdb_opts = config.get_rocksdb_options();
+        // Build the shared block cache once when sharing is enabled and a
+        // memory budget is configured. Every `Redis` instance receives the
+        // same `Arc<StorageOptions>` and therefore reuses this single cache.
+        let block_cache = if config.share_block_cache && config.memory > 0 {
+            Some(Arc::new(rocksdb::Cache::new_lru_cache(
+                config.memory as usize,
+            )))
+        } else {
+            None
+        };
         Self {
             options: rocksdb_opts,
             block_cache_size: config.memory as usize,
+            block_cache,
             small_compaction_threshold: config.small_compaction_threshold,
             small_compaction_duration_threshold: config.small_compaction_duration_threshold,
             db_instance_num: config.db_instance_num,

--- a/src/storage/src/redis.rs
+++ b/src/storage/src/redis.rs
@@ -29,7 +29,8 @@ use once_cell::sync::OnceCell;
 use foyer::{Cache, CacheBuilder};
 use kstd::lock_mgr::LockMgr;
 use rocksdb::{
-    BlockBasedOptions, ColumnFamilyDescriptor, CompactOptions, DB, ReadOptions, WriteOptions,
+    BlockBasedOptions, Cache as BlockCache, ColumnFamilyDescriptor, CompactOptions, DB,
+    ReadOptions, WriteOptions,
 };
 use snafu::{OptionExt, ResultExt};
 
@@ -258,6 +259,8 @@ pub struct Redis {
     pub read_options: ReadOptions,
     pub compact_options: CompactOptions,
     pub(crate) db: Option<RocksDbOwner>,
+    /// The block cache selected once for this Redis instance and reused by all CFs.
+    block_cache: Option<Arc<BlockCache>>,
 
     // For background task
     pub storage: Arc<StorageOptions>,
@@ -294,6 +297,16 @@ impl Redis {
         compact_options.set_change_level(true);
         compact_options.set_exclusive_manual_compaction(false);
 
+        let block_cache = if storage.share_block_cache {
+            storage.block_cache.as_ref().map(Arc::clone)
+        } else if storage.block_cache_size > 0 {
+            Some(Arc::new(BlockCache::new_lru_cache(
+                storage.block_cache_size,
+            )))
+        } else {
+            None
+        };
+
         let statistics_store: Cache<String, KeyStatistics> =
             CacheBuilder::new(storage.statistics_max_size).build();
 
@@ -309,6 +322,7 @@ impl Redis {
             write_options: WriteOptions::default(),
             read_options: ReadOptions::default(),
             compact_options,
+            block_cache,
 
             statistics_store: Arc::new(statistics_store),
             scan_cursors_store: Mutex::new(CacheBuilder::new(5000).build()),
@@ -406,6 +420,7 @@ impl Redis {
                     name,
                     *use_bloom,
                     *block_size,
+                    self.block_cache.as_deref(),
                     Some(&db_once_cell),
                     &collector,
                 )
@@ -445,6 +460,7 @@ impl Redis {
         cf_name: &str,
         use_bloom_filter: bool,
         block_size: Option<usize>,
+        block_cache: Option<&BlockCache>,
         db_once_cell: Option<&Arc<OnceCell<Weak<DB>>>>,
         collector: &Arc<LogIndexAndSequenceCollector>,
     ) -> ColumnFamilyDescriptor {
@@ -476,19 +492,13 @@ impl Redis {
 
         // Set block cache.
         //
-        // When sharing is enabled, a single cache is built once in
-        // `StorageOptions::from_config` and shared by every `Redis` instance
-        // through the shared `Arc<StorageOptions>`. Otherwise each instance
-        // builds its own independent cache when `block_cache_size > 0`.
-        match &storage_options.block_cache {
-            Some(shared) => {
-                table_opts.set_block_cache(shared);
-            }
-            None if !storage_options.share_block_cache && storage_options.block_cache_size > 0 => {
-                let cache = rocksdb::Cache::new_lru_cache(storage_options.block_cache_size);
-                table_opts.set_block_cache(&cache);
-            }
-            _ => {}
+        // `Redis::new` selects this handle once per instance. Every CF opened by
+        // this Redis receives that same handle, while separate Redis instances
+        // receive distinct handles when sharing is disabled.
+        if let Some(block_cache) = block_cache {
+            table_opts.set_block_cache(block_cache);
+        } else if storage_options.block_cache_size == 0 {
+            table_opts.disable_cache();
         }
 
         // Set table properties collector factory for LogIndex tracking
@@ -1016,6 +1026,109 @@ macro_rules! get_db_and_cfs {
 
         (db, cfs)
     }};
+}
+
+#[cfg(test)]
+mod block_cache_tests {
+    use std::sync::Arc;
+
+    use kstd::lock_mgr::LockMgr;
+
+    use super::Redis;
+    use crate::{BgTaskHandler, StorageOptions, safe_cleanup_test_db, unique_test_db_path};
+
+    fn new_redis(options: Arc<StorageOptions>, index: i32) -> Redis {
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        Redis::new(
+            options,
+            index,
+            Arc::new(bg_task_handler),
+            Arc::new(LockMgr::new(64)),
+        )
+    }
+
+    #[test]
+    fn disabled_sharing_creates_one_distinct_cache_per_redis_instance() {
+        let options = Arc::new(StorageOptions {
+            block_cache_size: 4 * 1024 * 1024,
+            share_block_cache: false,
+            block_cache: None,
+            ..StorageOptions::default()
+        });
+
+        let first = new_redis(Arc::clone(&options), 0);
+        let second = new_redis(options, 1);
+        let first_cache = first
+            .block_cache
+            .as_ref()
+            .expect("the first Redis instance should own a block cache");
+        let second_cache = second
+            .block_cache
+            .as_ref()
+            .expect("the second Redis instance should own a block cache");
+
+        assert!(
+            !Arc::ptr_eq(first_cache, second_cache),
+            "different Redis instances must not share their per-instance caches"
+        );
+    }
+
+    #[test]
+    fn default_options_share_one_cache_across_redis_instances() {
+        let options = Arc::new(StorageOptions::default());
+        let shared_cache = options
+            .block_cache
+            .as_ref()
+            .expect("default options should configure a shared block cache")
+            .clone();
+
+        let first = new_redis(Arc::clone(&options), 0);
+        let second = new_redis(options, 1);
+        let first_cache = first
+            .block_cache
+            .as_ref()
+            .expect("the first Redis instance should use the shared block cache");
+        let second_cache = second
+            .block_cache
+            .as_ref()
+            .expect("the second Redis instance should use the shared block cache");
+
+        assert!(Arc::ptr_eq(first_cache, &shared_cache));
+        assert!(Arc::ptr_eq(second_cache, &shared_cache));
+    }
+
+    #[test]
+    fn zero_block_cache_size_disables_rocksdb_internal_cache_for_every_cf() {
+        let path = unique_test_db_path();
+        safe_cleanup_test_db(&path);
+        let options = Arc::new(StorageOptions {
+            block_cache_size: 0,
+            share_block_cache: true,
+            block_cache: None,
+            ..StorageOptions::default()
+        });
+        let mut redis = new_redis(options, 0);
+        redis
+            .open(path.to_str().expect("test DB path should be valid UTF-8"))
+            .expect("Redis should open with block cache disabled");
+        let db = redis.db.as_ref().expect("Redis should own RocksDB");
+
+        for cf_name in &redis.handles {
+            let cf = db
+                .cf_handle(cf_name)
+                .expect("every configured CF should be open");
+            let capacity = db
+                .property_int_value_cf(&cf, "rocksdb.block-cache-capacity")
+                .expect("block cache capacity property should be readable");
+            assert_eq!(
+                capacity, None,
+                "{cf_name} must not receive RocksDB's implicit internal block cache"
+            );
+        }
+
+        drop(redis);
+        safe_cleanup_test_db(&path);
+    }
 }
 
 #[cfg(test)]

--- a/src/storage/src/redis.rs
+++ b/src/storage/src/redis.rs
@@ -1029,109 +1029,7 @@ macro_rules! get_db_and_cfs {
 }
 
 #[cfg(test)]
-mod block_cache_tests {
-    use std::sync::Arc;
-
-    use kstd::lock_mgr::LockMgr;
-
-    use super::Redis;
-    use crate::{BgTaskHandler, StorageOptions, safe_cleanup_test_db, unique_test_db_path};
-
-    fn new_redis(options: Arc<StorageOptions>, index: i32) -> Redis {
-        let (bg_task_handler, _) = BgTaskHandler::new();
-        Redis::new(
-            options,
-            index,
-            Arc::new(bg_task_handler),
-            Arc::new(LockMgr::new(64)),
-        )
-    }
-
-    #[test]
-    fn disabled_sharing_creates_one_distinct_cache_per_redis_instance() {
-        let options = Arc::new(StorageOptions {
-            block_cache_size: 4 * 1024 * 1024,
-            share_block_cache: false,
-            block_cache: None,
-            ..StorageOptions::default()
-        });
-
-        let first = new_redis(Arc::clone(&options), 0);
-        let second = new_redis(options, 1);
-        let first_cache = first
-            .block_cache
-            .as_ref()
-            .expect("the first Redis instance should own a block cache");
-        let second_cache = second
-            .block_cache
-            .as_ref()
-            .expect("the second Redis instance should own a block cache");
-
-        assert!(
-            !Arc::ptr_eq(first_cache, second_cache),
-            "different Redis instances must not share their per-instance caches"
-        );
-    }
-
-    #[test]
-    fn default_options_share_one_cache_across_redis_instances() {
-        let options = Arc::new(StorageOptions::default());
-        let shared_cache = options
-            .block_cache
-            .as_ref()
-            .expect("default options should configure a shared block cache")
-            .clone();
-
-        let first = new_redis(Arc::clone(&options), 0);
-        let second = new_redis(options, 1);
-        let first_cache = first
-            .block_cache
-            .as_ref()
-            .expect("the first Redis instance should use the shared block cache");
-        let second_cache = second
-            .block_cache
-            .as_ref()
-            .expect("the second Redis instance should use the shared block cache");
-
-        assert!(Arc::ptr_eq(first_cache, &shared_cache));
-        assert!(Arc::ptr_eq(second_cache, &shared_cache));
-    }
-
-    #[test]
-    fn zero_block_cache_size_disables_rocksdb_internal_cache_for_every_cf() {
-        let path = unique_test_db_path();
-        safe_cleanup_test_db(&path);
-        let options = Arc::new(StorageOptions {
-            block_cache_size: 0,
-            share_block_cache: true,
-            block_cache: None,
-            ..StorageOptions::default()
-        });
-        let mut redis = new_redis(options, 0);
-        redis
-            .open(path.to_str().expect("test DB path should be valid UTF-8"))
-            .expect("Redis should open with block cache disabled");
-        let db = redis.db.as_ref().expect("Redis should own RocksDB");
-
-        for cf_name in &redis.handles {
-            let cf = db
-                .cf_handle(cf_name)
-                .expect("every configured CF should be open");
-            let capacity = db
-                .property_int_value_cf(&cf, "rocksdb.block-cache-capacity")
-                .expect("block cache capacity property should be readable");
-            assert_eq!(
-                capacity, None,
-                "{cf_name} must not receive RocksDB's implicit internal block cache"
-            );
-        }
-
-        drop(redis);
-        safe_cleanup_test_db(&path);
-    }
-}
-
-#[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod lifecycle_tests {
     use std::sync::{Arc, mpsc};
     use std::time::Duration;
@@ -1418,5 +1316,108 @@ mod type_check_state_tests {
             .check_type_state(&value, DataType::Set)
             .expect("check_type_state must not error for a live value");
         assert_eq!(state, TypeCheckState::Match);
+    }
+}
+
+#[cfg(test)]
+mod block_cache_tests {
+    use std::sync::Arc;
+
+    use kstd::lock_mgr::LockMgr;
+
+    use super::Redis;
+    use crate::{BgTaskHandler, StorageOptions, safe_cleanup_test_db, unique_test_db_path};
+
+    fn new_redis(options: Arc<StorageOptions>, index: i32) -> Redis {
+        let (bg_task_handler, _) = BgTaskHandler::new();
+        Redis::new(
+            options,
+            index,
+            Arc::new(bg_task_handler),
+            Arc::new(LockMgr::new(64)),
+        )
+    }
+
+    #[test]
+    fn disabled_sharing_creates_one_distinct_cache_per_redis_instance() {
+        let options = Arc::new(StorageOptions {
+            block_cache_size: 4 * 1024 * 1024,
+            share_block_cache: false,
+            block_cache: None,
+            ..StorageOptions::default()
+        });
+
+        let first = new_redis(Arc::clone(&options), 0);
+        let second = new_redis(options, 1);
+        let first_cache = first
+            .block_cache
+            .as_ref()
+            .expect("the first Redis instance should own a block cache");
+        let second_cache = second
+            .block_cache
+            .as_ref()
+            .expect("the second Redis instance should own a block cache");
+
+        assert!(
+            !Arc::ptr_eq(first_cache, second_cache),
+            "different Redis instances must not share their per-instance caches"
+        );
+    }
+
+    #[test]
+    fn default_options_share_one_cache_across_redis_instances() {
+        let options = Arc::new(StorageOptions::default());
+        let shared_cache = options
+            .block_cache
+            .as_ref()
+            .expect("default options should configure a shared block cache")
+            .clone();
+
+        let first = new_redis(Arc::clone(&options), 0);
+        let second = new_redis(options, 1);
+        let first_cache = first
+            .block_cache
+            .as_ref()
+            .expect("the first Redis instance should use the shared block cache");
+        let second_cache = second
+            .block_cache
+            .as_ref()
+            .expect("the second Redis instance should use the shared block cache");
+
+        assert!(Arc::ptr_eq(first_cache, &shared_cache));
+        assert!(Arc::ptr_eq(second_cache, &shared_cache));
+    }
+
+    #[test]
+    fn zero_block_cache_size_disables_rocksdb_internal_cache_for_every_cf() {
+        let path = unique_test_db_path();
+        safe_cleanup_test_db(&path);
+        let options = Arc::new(StorageOptions {
+            block_cache_size: 0,
+            share_block_cache: true,
+            block_cache: None,
+            ..StorageOptions::default()
+        });
+        let mut redis = new_redis(options, 0);
+        redis
+            .open(path.to_str().expect("test DB path should be valid UTF-8"))
+            .expect("Redis should open with block cache disabled");
+        let db = redis.db.as_ref().expect("Redis should own RocksDB");
+
+        for cf_name in &redis.handles {
+            let cf = db
+                .cf_handle(cf_name)
+                .expect("every configured CF should be open");
+            let capacity = db
+                .property_int_value_cf(&cf, "rocksdb.block-cache-capacity")
+                .expect("block cache capacity property should be readable");
+            assert_eq!(
+                capacity, None,
+                "{cf_name} must not receive RocksDB's implicit internal block cache"
+            );
+        }
+
+        drop(redis);
+        safe_cleanup_test_db(&path);
     }
 }

--- a/src/storage/src/redis.rs
+++ b/src/storage/src/redis.rs
@@ -474,10 +474,21 @@ impl Redis {
             table_opts.set_block_size(size);
         }
 
-        // Set block cache
-        if !storage_options.share_block_cache && storage_options.block_cache_size > 0 {
-            let cache = rocksdb::Cache::new_lru_cache(storage_options.block_cache_size);
-            table_opts.set_block_cache(&cache);
+        // Set block cache.
+        //
+        // When sharing is enabled, a single cache is built once in
+        // `StorageOptions::from_config` and shared by every `Redis` instance
+        // through the shared `Arc<StorageOptions>`. Otherwise each instance
+        // builds its own independent cache when `block_cache_size > 0`.
+        match &storage_options.block_cache {
+            Some(shared) => {
+                table_opts.set_block_cache(shared);
+            }
+            None if !storage_options.share_block_cache && storage_options.block_cache_size > 0 => {
+                let cache = rocksdb::Cache::new_lru_cache(storage_options.block_cache_size);
+                table_opts.set_block_cache(&cache);
+            }
+            _ => {}
         }
 
         // Set table properties collector factory for LogIndex tracking

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -146,6 +146,13 @@ impl Storage {
         }
     }
 
+    /// Return the immutable options shared by every opened Redis instance.
+    pub fn storage_options(&self) -> Option<Arc<StorageOptions>> {
+        self.insts
+            .first()
+            .map(|instance| Arc::clone(&instance.storage))
+    }
+
     /// Wait for shared top-level command access without blocking a runtime worker.
     ///
     /// The owned guard is `Send`, so a dispatcher may keep it while command


### PR DESCRIPTION
## Summary

Fixes #143 — the block-cache sharing was effectively dead code due to an inverted condition.

With the default `share_block_cache = true`, the old code did **not** create any shared cache:

```rust
if !storage_options.share_block_cache && storage_options.block_cache_size > 0 { ... }
```

so every RocksDB instance silently fell back to its own isolated (RocksDB-default) cache. This defeated the intent of sharing and wasted memory.

### Changes
- **conf** (`config.rs`): add the `share-block-cache` config key (default `true`) plus unit tests covering default / `yes` / `no` / invalid values. The new field is also serialized into the sample config automatically via `to_redis_style`.
- **storage** (`options.rs`): build the shared `Arc<Cache>` once in `StorageOptions::from_config` and store it on `StorageOptions`, so every `Redis` instance reuses the same cache through the shared `Arc<StorageOptions>`.
- **storage** (`redis.rs`): prefer the shared cache; only fall back to a per-instance cache when sharing is disabled and a `block_cache_size` is configured.

### Behavior
- `share-block-cache yes` (default): one cache of `memory` bytes is built once and shared across all instances/CFs.
- `share-block-cache no`: each instance builds its own independent cache of `block_cache_size` bytes.
- `StorageOptions::default()` keeps `block_cache: None`, so existing unit tests are unaffected.

## Test plan
- [x] `cargo test -p conf` — 30 passed (incl. 3 new `share-block-cache` parse tests)
- [x] `cargo check -p storage --tests --features test-fault-injection` — clean
- [x] `cargo clippy -p conf -p storage --tests --features test-fault-injection` — no new warnings from changed files

Fixes #143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to share the storage block cache across instances.
  * Supports `yes` and `no` values, with validation for invalid settings.
  * Shared caching is enabled by default when cache memory is configured.

* **Performance**
  * Improved cache reuse by allowing storage instances to share a common block cache.
  * Preserved independent caching behavior when shared caching is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->