### PR TITLE
feat(raft): persist and recover state machine applied metadata

### DIFF
--- a/src/raft/src/durable_state_machine_meta.rs
+++ b/src/raft/src/durable_state_machine_meta.rs
@@ -1,0 +1,168 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(clippy::result_large_err)]
+
+use std::sync::Arc;
+
+#[cfg(test)]
+use std::path::PathBuf;
+
+use conf::raft_type::KiwiNode;
+use openraft::{LogId, StorageError, StoredMembership};
+use rocksdb::{BoundColumnFamily, DB, WriteBatch, WriteOptions};
+use serde::{Deserialize, Serialize};
+
+use crate::log_store_rocksdb::{
+    SM_META_CF, cf_not_found_read, deserialize, io_read_err, io_write_err, serialize,
+};
+
+pub const SM_META_FORMAT_VERSION: u16 = 1;
+
+const SM_META_KEY: &[u8] = b"state_machine_meta";
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DurableStateMachineMeta {
+    pub format_version: u16,
+    pub last_applied: Option<LogId<u64>>,
+    pub last_membership: StoredMembership<u64, KiwiNode>,
+}
+
+impl DurableStateMachineMeta {
+    pub fn new(
+        last_applied: Option<LogId<u64>>,
+        last_membership: StoredMembership<u64, KiwiNode>,
+    ) -> Self {
+        Self {
+            format_version: SM_META_FORMAT_VERSION,
+            last_applied,
+            last_membership,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_hooks {
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+    use std::sync::LazyLock;
+
+    use parking_lot::Mutex;
+
+    pub static SM_META_SAVE_FAILURES: LazyLock<Mutex<HashSet<PathBuf>>> =
+        LazyLock::new(|| Mutex::new(HashSet::new()));
+}
+
+#[cfg(test)]
+pub struct SmMetaSaveFailureGuard {
+    db_path: PathBuf,
+}
+
+#[cfg(test)]
+impl Drop for SmMetaSaveFailureGuard {
+    fn drop(&mut self) {
+        test_hooks::SM_META_SAVE_FAILURES
+            .lock()
+            .remove(&self.db_path);
+    }
+}
+
+/// note(guozhihao-224) Inject one failure into the next save_meta for the DB.
+#[cfg(test)]
+#[doc(hidden)]
+#[must_use]
+pub fn fail_next_sm_meta_save(db: &DB) -> SmMetaSaveFailureGuard {
+    let db_path = db.path().to_path_buf();
+    assert!(
+        test_hooks::SM_META_SAVE_FAILURES
+            .lock()
+            .insert(db_path.clone()),
+        "sm_meta save failure already registered for {}",
+        db_path.display()
+    );
+    SmMetaSaveFailureGuard { db_path }
+}
+
+pub struct DurableStateMachineStore {
+    db: Arc<DB>,
+}
+
+impl DurableStateMachineStore {
+    pub fn new(db: Arc<DB>) -> Self {
+        Self { db }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn db(&self) -> Arc<DB> {
+        Arc::clone(&self.db)
+    }
+
+    fn cf(&self) -> Result<Arc<BoundColumnFamily<'_>>, StorageError<u64>> {
+        self.db
+            .cf_handle(SM_META_CF)
+            .ok_or_else(|| cf_not_found_read(SM_META_CF))
+    }
+
+    /// note(guozhihao-224) Synced WAL write; only called after the business
+    /// mutation for the same entries has committed.
+    pub fn save_meta(&self, meta: &DurableStateMachineMeta) -> Result<(), StorageError<u64>> {
+        #[cfg(test)]
+        if test_hooks::SM_META_SAVE_FAILURES
+            .lock()
+            .remove(&self.db.path().to_path_buf())
+        {
+            return Err(io_write_err(format!(
+                "injected sm_meta save failure for {}",
+                self.db.path().display()
+            )));
+        }
+
+        let cf = self.cf()?;
+        let bytes = serialize(meta)?;
+        let mut batch = WriteBatch::default();
+        batch.put_cf(&cf, SM_META_KEY, &bytes);
+
+        let mut opts = WriteOptions::default();
+        opts.set_sync(true);
+        self.db.write_opt(&batch, &opts).map_err(io_write_err)
+    }
+
+    pub fn load_meta(&self) -> Result<Option<DurableStateMachineMeta>, StorageError<u64>> {
+        let cf = self.cf()?;
+        match self.db.get_cf(&cf, SM_META_KEY).map_err(io_read_err)? {
+            None => Ok(None),
+            Some(bytes) => deserialize(&bytes).map(Some),
+        }
+    }
+
+    /// note(guozhihao-224) Reject unknown format versions; None when nothing
+    /// has been persisted yet (first start).
+    pub fn validate(&self) -> Result<Option<DurableStateMachineMeta>, StorageError<u64>> {
+        match self.load_meta()? {
+            None => Ok(None),
+            Some(meta) => {
+                if meta.format_version != SM_META_FORMAT_VERSION {
+                    return Err(io_read_err(format!(
+                        "unsupported state machine metadata format version {}, expected {}",
+                        meta.format_version, SM_META_FORMAT_VERSION
+                    )));
+                }
+                Ok(Some(meta))
+            }
+        }
+    }
+}

--- a/src/raft/src/durable_state_machine_meta.rs
+++ b/src/raft/src/durable_state_machine_meta.rs
@@ -55,48 +55,6 @@ impl DurableStateMachineMeta {
     }
 }
 
-#[cfg(test)]
-mod test_hooks {
-    use std::collections::HashSet;
-    use std::path::PathBuf;
-    use std::sync::LazyLock;
-
-    use parking_lot::Mutex;
-
-    pub static SM_META_SAVE_FAILURES: LazyLock<Mutex<HashSet<PathBuf>>> =
-        LazyLock::new(|| Mutex::new(HashSet::new()));
-}
-
-#[cfg(test)]
-pub struct SmMetaSaveFailureGuard {
-    db_path: PathBuf,
-}
-
-#[cfg(test)]
-impl Drop for SmMetaSaveFailureGuard {
-    fn drop(&mut self) {
-        test_hooks::SM_META_SAVE_FAILURES
-            .lock()
-            .remove(&self.db_path);
-    }
-}
-
-/// note(guozhihao-224) Inject one failure into the next save_meta for the DB.
-#[cfg(test)]
-#[doc(hidden)]
-#[must_use]
-pub fn fail_next_sm_meta_save(db: &DB) -> SmMetaSaveFailureGuard {
-    let db_path = db.path().to_path_buf();
-    assert!(
-        test_hooks::SM_META_SAVE_FAILURES
-            .lock()
-            .insert(db_path.clone()),
-        "sm_meta save failure already registered for {}",
-        db_path.display()
-    );
-    SmMetaSaveFailureGuard { db_path }
-}
-
 pub struct DurableStateMachineStore {
     db: Arc<DB>,
 }
@@ -165,4 +123,46 @@ impl DurableStateMachineStore {
             }
         }
     }
+}
+
+#[cfg(test)]
+pub struct SmMetaSaveFailureGuard {
+    db_path: PathBuf,
+}
+
+#[cfg(test)]
+impl Drop for SmMetaSaveFailureGuard {
+    fn drop(&mut self) {
+        test_hooks::SM_META_SAVE_FAILURES
+            .lock()
+            .remove(&self.db_path);
+    }
+}
+
+/// note(guozhihao-224) Inject one failure into the next save_meta for the DB.
+#[cfg(test)]
+#[doc(hidden)]
+#[must_use]
+pub fn fail_next_sm_meta_save(db: &DB) -> SmMetaSaveFailureGuard {
+    let db_path = db.path().to_path_buf();
+    assert!(
+        test_hooks::SM_META_SAVE_FAILURES
+            .lock()
+            .insert(db_path.clone()),
+        "sm_meta save failure already registered for {}",
+        db_path.display()
+    );
+    SmMetaSaveFailureGuard { db_path }
+}
+
+#[cfg(test)]
+mod test_hooks {
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+    use std::sync::LazyLock;
+
+    use parking_lot::Mutex;
+
+    pub static SM_META_SAVE_FAILURES: LazyLock<Mutex<HashSet<PathBuf>>> =
+        LazyLock::new(|| Mutex::new(HashSet::new()));
 }

--- a/src/raft/src/lib.rs
+++ b/src/raft/src/lib.rs
@@ -22,6 +22,7 @@
 pub mod capabilities;
 pub mod conversion;
 pub mod db_access; // Shim for backward compatibility with tests
+pub mod durable_state_machine_meta;
 pub mod grpc;
 pub mod leader_gate;
 pub mod log_store_rocksdb;

--- a/src/raft/src/log_store_rocksdb.rs
+++ b/src/raft/src/log_store_rocksdb.rs
@@ -52,6 +52,7 @@ use rocksdb::{ColumnFamilyDescriptor, DB, Direction, IteratorMode, Options, Writ
 const LOGS_CF: &str = "logs";
 const META_CF: &str = "meta";
 const STATE_CF: &str = "state";
+pub(crate) const SM_META_CF: &str = "sm_meta";
 
 const LAST_PURGED_KEY: &[u8] = b"last_purged_log_id";
 const VOTE_KEY: &[u8] = b"vote";
@@ -338,12 +339,17 @@ impl RocksdbLogStore {
 impl RocksdbLogStore {
     /// 从已有的 RocksDB 数据库创建日志存储实例
     pub fn new(db: Arc<DB>) -> Result<Self, StorageError<u64>> {
-        for cf_name in [LOGS_CF, META_CF, STATE_CF] {
+        for cf_name in [LOGS_CF, META_CF, STATE_CF, SM_META_CF] {
             if db.cf_handle(cf_name).is_none() {
                 return Err(cf_not_found_read(cf_name));
             }
         }
         Ok(Self { db })
+    }
+
+    /// 返回底层 RocksDB 句柄，供共享同一 DB 的 state machine 持久化 store 使用。
+    pub fn db(&self) -> Arc<DB> {
+        Arc::clone(&self.db)
     }
 
     /// 打开或创建指定路径的 RocksDB 日志存储
@@ -356,6 +362,7 @@ impl RocksdbLogStore {
             ColumnFamilyDescriptor::new(LOGS_CF, Options::default()),
             ColumnFamilyDescriptor::new(META_CF, Options::default()),
             ColumnFamilyDescriptor::new(STATE_CF, Options::default()),
+            ColumnFamilyDescriptor::new(SM_META_CF, Options::default()),
         ];
 
         let db = Arc::new(DB::open_cf_descriptors(&opts, path, cfs)?);
@@ -432,7 +439,7 @@ impl openraft::storage::RaftLogStorage<KiwiTypeConfig> for RocksdbLogStore {
 // 辅助函数
 
 /// 将任意错误包装为写操作的 StorageError::IO
-fn io_write_err(e: impl std::fmt::Display) -> StorageError<u64> {
+pub(crate) fn io_write_err(e: impl std::fmt::Display) -> StorageError<u64> {
     let io_err = std::io::Error::other(e.to_string());
     StorageError::IO {
         source: openraft::StorageIOError::write(&io_err),
@@ -440,7 +447,7 @@ fn io_write_err(e: impl std::fmt::Display) -> StorageError<u64> {
 }
 
 /// 将任意错误包装为读操作的 StorageError::IO
-fn io_read_err(e: impl std::fmt::Display) -> StorageError<u64> {
+pub(crate) fn io_read_err(e: impl std::fmt::Display) -> StorageError<u64> {
     let io_err = std::io::Error::other(e.to_string());
     StorageError::IO {
         source: openraft::StorageIOError::read(&io_err),
@@ -459,7 +466,7 @@ fn cf_not_found_write(name: &str) -> StorageError<u64> {
 }
 
 /// 将 CF 不存在包装为读操作的 StorageError::IO
-fn cf_not_found_read(name: &str) -> StorageError<u64> {
+pub(crate) fn cf_not_found_read(name: &str) -> StorageError<u64> {
     let io_err = std::io::Error::new(
         std::io::ErrorKind::NotFound,
         format!("Column family '{}' not found", name),
@@ -470,7 +477,7 @@ fn cf_not_found_read(name: &str) -> StorageError<u64> {
 }
 
 /// 序列化数据结构为字节序列
-fn serialize<T: Serialize>(data: &T) -> Result<Vec<u8>, StorageError<u64>> {
+pub(crate) fn serialize<T: Serialize>(data: &T) -> Result<Vec<u8>, StorageError<u64>> {
     serde_json::to_vec(data).map_err(|e| {
         let io_err = std::io::Error::new(std::io::ErrorKind::InvalidData, e);
         StorageError::IO {
@@ -480,7 +487,7 @@ fn serialize<T: Serialize>(data: &T) -> Result<Vec<u8>, StorageError<u64>> {
 }
 
 /// 反序列化字节序列为数据结构
-fn deserialize<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, StorageError<u64>> {
+pub(crate) fn deserialize<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, StorageError<u64>> {
     serde_json::from_slice(bytes).map_err(|e| {
         let io_err = std::io::Error::new(std::io::ErrorKind::InvalidData, e);
         StorageError::IO {
@@ -681,6 +688,7 @@ mod tests {
             ColumnFamilyDescriptor::new(LOGS_CF, Options::default()),
             ColumnFamilyDescriptor::new(META_CF, Options::default()),
             ColumnFamilyDescriptor::new(STATE_CF, Options::default()),
+            ColumnFamilyDescriptor::new(SM_META_CF, Options::default()),
         ];
 
         let db =

--- a/src/raft/src/node.rs
+++ b/src/raft/src/node.rs
@@ -16,14 +16,16 @@
 // limitations under the License.
 
 use conf::raft_type::{Binlog, BinlogResponse, KiwiNode, KiwiTypeConfig};
-use openraft::{Config, Raft, SnapshotPolicy};
+use openraft::storage::RaftLogStorage;
+use openraft::{Config, LogId, Raft, SnapshotPolicy, StoredMembership};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::OnceLock;
 
 use arc_swap::ArcSwap;
 
+use crate::durable_state_machine_meta::{DurableStateMachineMeta, DurableStateMachineStore};
 use crate::grpc::{
     create_admin_service, create_client_service, create_core_service, create_metrics_service,
 };
@@ -33,7 +35,7 @@ use crate::raft_proto::raft_admin_service_server::RaftAdminServiceServer;
 use crate::raft_proto::raft_client_service_server::RaftClientServiceServer;
 use crate::raft_proto::raft_core_service_server::RaftCoreServiceServer;
 use crate::raft_proto::raft_metrics_service_server::RaftMetricsServiceServer;
-use crate::state_machine::{KiwiStateMachine, PauseController};
+use crate::state_machine::{KiwiStateMachine, PauseController, load_current_snapshot};
 use storage::storage::Storage;
 
 #[derive(Debug, thiserror::Error)]
@@ -207,6 +209,72 @@ fn build_raft_config(config: &RaftConfig) -> Result<Arc<Config>, anyhow::Error> 
     Ok(Arc::new(raft_config.validate()?))
 }
 
+/// Recover and validate the durable applied frontier at startup.
+/// note(guozhihao-224) Corrupt or unknown-version metadata, a frontier ahead of
+/// the last log, or a snapshot ahead of the frontier all refuse startup. Without a
+/// durable frontier, bootstrap from a persisted snapshot; with neither, first start.
+async fn recover_applied_state(
+    log_store: &mut RocksdbLogStore,
+    durable_meta: &Arc<DurableStateMachineStore>,
+    snapshot_work_dir: &Path,
+) -> Result<(Option<LogId<u64>>, StoredMembership<u64, KiwiNode>), anyhow::Error> {
+    let snapshot = load_current_snapshot(snapshot_work_dir)
+        .map_err(|error| anyhow::anyhow!("failed to read current snapshot metadata: {error}"))?;
+
+    let frontier = durable_meta
+        .validate()
+        .map_err(|error| anyhow::anyhow!("durable state machine metadata is unusable: {error}"))?;
+
+    let (last_applied, last_membership) = match frontier {
+        Some(meta) => (meta.last_applied, meta.last_membership),
+        None => match &snapshot {
+            Some(snap) => {
+                let meta = DurableStateMachineMeta::new(
+                    snap.meta.last_log_id,
+                    snap.meta.last_membership.clone(),
+                );
+                durable_meta.save_meta(&meta).map_err(|error| {
+                    anyhow::anyhow!("failed to bootstrap applied frontier from snapshot: {error}")
+                })?;
+                log::info!(
+                    "Bootstrapped applied frontier from persisted snapshot: last_applied={:?}",
+                    meta.last_applied.map(|log_id| log_id.index)
+                );
+                (meta.last_applied, meta.last_membership)
+            }
+            None => (None, StoredMembership::default()),
+        },
+    };
+
+    let log_state = log_store
+        .get_log_state()
+        .await
+        .map_err(|error| anyhow::anyhow!("failed to read Raft log state: {error}"))?;
+    let last_log_index = log_state.last_log_id.map(|log_id| log_id.index);
+
+    if let Some(applied) = last_applied {
+        if last_log_index.is_none_or(|last| applied.index > last) {
+            return Err(anyhow::anyhow!(
+                "durable applied frontier {} is ahead of the last Raft log {:?}, refusing to start",
+                applied.index,
+                last_log_index
+            ));
+        }
+        if let Some(snap) = &snapshot
+            && let Some(snap_last) = snap.meta.last_log_id
+            && snap_last.index > applied.index
+        {
+            return Err(anyhow::anyhow!(
+                "persisted snapshot index {} is ahead of the durable applied frontier {}, refusing to start",
+                snap_last.index,
+                applied.index
+            ));
+        }
+    }
+
+    Ok((last_applied, last_membership))
+}
+
 pub async fn create_raft_node(
     config: RaftConfig,
     storage_swap: Arc<ArcSwap<Storage>>,
@@ -218,6 +286,27 @@ pub async fn create_raft_node(
     let snapshot_work_dir = config.data_dir.join("snapshots");
     fs::create_dir_all(&snapshot_work_dir)?;
 
+    let legacy_log_store_path = config.data_dir.join("raft_logs");
+    if legacy_log_store_path.try_exists()? {
+        return Err(anyhow::anyhow!(
+            "cannot safely migrate legacy in-memory Raft log state in place; use a new node ID and clean data-dir/raft-data-dir to rejoin from a healthy leader"
+        ));
+    }
+
+    let log_store_path = config.data_dir.join("raft_logs_rocksdb");
+    std::fs::create_dir_all(&log_store_path)?;
+    let mut log_store = RocksdbLogStore::open(&log_store_path)?;
+
+    // note(guozhihao-224) Validate the durable frontier before serving; a
+    // violation refuses startup.
+    let durable_meta = Arc::new(DurableStateMachineStore::new(log_store.db()));
+    let (last_applied, last_membership) =
+        recover_applied_state(&mut log_store, &durable_meta, &snapshot_work_dir).await?;
+    log::info!(
+        "Recovered applied frontier: last_applied={:?}",
+        last_applied.map(|log_id| log_id.index)
+    );
+
     // Per-instance LogIndex collectors / cf_trackers live in the Storage; the state
     // machine looks them up through storage_swap so it sees the right ones after a
     // snapshot install hot-swaps Storage.
@@ -228,20 +317,11 @@ pub async fn create_raft_node(
         snapshot_work_dir,
         Arc::clone(&pause_controller),
         append_log_fn,
-    );
+    )
+    .with_durable_meta(Arc::clone(&durable_meta))
+    .with_recovered_state(last_applied, last_membership);
 
     let network = KiwiNetworkFactory::new();
-
-    let legacy_log_store_path = config.data_dir.join("raft_logs");
-    if legacy_log_store_path.try_exists()? {
-        return Err(anyhow::anyhow!(
-            "cannot safely migrate legacy in-memory Raft log state in place; use a new node ID and clean data-dir/raft-data-dir to rejoin from a healthy leader"
-        ));
-    }
-
-    let log_store_path = config.data_dir.join("raft_logs_rocksdb");
-    std::fs::create_dir_all(&log_store_path)?;
-    let log_store = RocksdbLogStore::open(&log_store_path)?;
 
     let raft = Raft::new(
         config.node_id,
@@ -271,7 +351,7 @@ mod tests {
     use crate::state_machine::{StorageAccessPermit, snapshot_install_marker_path};
     use conf::raft_type::{BinlogEntry, OperateType};
     use openraft::storage::{RaftLogStorage, RaftLogStorageExt};
-    use openraft::{Entry, EntryPayload, LeaderId, LogId, Vote};
+    use openraft::{Entry, EntryPayload, LeaderId, LogId, SnapshotMeta, Vote};
     use storage::BaseMetaKey;
     use storage::ColumnFamilyIndex;
     use storage::format_strings_value::StringValue;
@@ -653,5 +733,154 @@ mod tests {
                 fixture.name()
             );
         }
+    }
+
+    fn write_snapshot_meta(snap_root: &std::path::Path, last_index: u64) {
+        std::fs::create_dir_all(snap_root).expect("snapshot root should be created");
+        let meta: SnapshotMeta<u64, KiwiNode> = SnapshotMeta {
+            last_log_id: Some(LogId::new(LeaderId::new(1, 1), last_index)),
+            last_membership: StoredMembership::default(),
+            snapshot_id: "snapshot-test".to_string(),
+        };
+        let json = serde_json::to_string_pretty(&meta).expect("snapshot meta should serialize");
+        std::fs::write(snap_root.join("current_snapshot_meta.json"), json)
+            .expect("snapshot meta file should be written");
+        std::fs::write(snap_root.join("current_snapshot.tar"), b"")
+            .expect("snapshot data file should be written");
+    }
+
+    #[tokio::test]
+    async fn fresh_db_no_snapshot_recovers_none() {
+        let temp_dir = TempDir::new().expect("temporary directory should be created");
+        let mut log_store = RocksdbLogStore::open(temp_dir.path().join("raft_logs_rocksdb"))
+            .expect("log store should open");
+        let store = Arc::new(DurableStateMachineStore::new(log_store.db()));
+
+        let (applied, _membership) =
+            recover_applied_state(&mut log_store, &store, &temp_dir.path().join("snapshots"))
+                .await
+                .expect("first start with no durable state should recover cleanly");
+        assert_eq!(applied, None, "first start must recover an empty frontier");
+        assert!(
+            store.load_meta().expect("load should work").is_none(),
+            "first start must not fabricate metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_sm_meta_with_snapshot_bootstraps_from_snapshot() {
+        let temp_dir = TempDir::new().expect("temporary directory should be created");
+        let mut log_store = RocksdbLogStore::open(temp_dir.path().join("raft_logs_rocksdb"))
+            .expect("log store should open");
+        log_store
+            .blocking_append([Entry {
+                log_id: LogId::new(LeaderId::new(1, 1), 5),
+                payload: EntryPayload::Blank,
+            }])
+            .await
+            .expect("a log entry should be appended");
+        let store = Arc::new(DurableStateMachineStore::new(log_store.db()));
+        write_snapshot_meta(&temp_dir.path().join("snapshots"), 5);
+
+        let (applied, _membership) =
+            recover_applied_state(&mut log_store, &store, &temp_dir.path().join("snapshots"))
+                .await
+                .expect("bootstrap from a persisted snapshot should recover");
+        assert_eq!(
+            applied.map(|l| l.index),
+            Some(5),
+            "bootstrap must recover the snapshot last log id"
+        );
+        let persisted = store
+            .load_meta()
+            .expect("load should work")
+            .expect("must be persisted");
+        assert_eq!(
+            persisted.last_applied.map(|l| l.index),
+            Some(5),
+            "bootstrap must persist the snapshot-derived frontier"
+        );
+    }
+
+    #[tokio::test]
+    async fn corrupt_sm_meta_fails_closed() {
+        let temp_dir = TempDir::new().expect("temporary directory should be created");
+        let mut log_store = RocksdbLogStore::open(temp_dir.path().join("raft_logs_rocksdb"))
+            .expect("log store should open");
+        let db = log_store.db();
+        {
+            let cf = db.cf_handle("sm_meta").expect("sm_meta CF should exist");
+            db.put_cf(&cf, b"state_machine_meta", b"not-valid-json")
+                .expect("corrupt bytes should be written");
+        }
+        let store = Arc::new(DurableStateMachineStore::new(db));
+
+        let error =
+            recover_applied_state(&mut log_store, &store, &temp_dir.path().join("snapshots"))
+                .await
+                .expect_err("corrupt metadata must refuse startup");
+        let _ = error;
+    }
+
+    #[tokio::test]
+    async fn unknown_format_version_fails_closed() {
+        let temp_dir = TempDir::new().expect("temporary directory should be created");
+        let mut log_store = RocksdbLogStore::open(temp_dir.path().join("raft_logs_rocksdb"))
+            .expect("log store should open");
+        let store = Arc::new(DurableStateMachineStore::new(log_store.db()));
+        store
+            .save_meta(&DurableStateMachineMeta {
+                format_version: 99,
+                last_applied: Some(LogId::new(LeaderId::new(1, 1), 7)),
+                last_membership: StoredMembership::default(),
+            })
+            .expect("meta should be persisted");
+
+        let error =
+            recover_applied_state(&mut log_store, &store, &temp_dir.path().join("snapshots"))
+                .await
+                .expect_err("unsupported format version must refuse startup");
+        let _ = error;
+    }
+
+    #[tokio::test]
+    async fn frontier_ahead_of_log_store_fails_closed() {
+        let temp_dir = TempDir::new().expect("temporary directory should be created");
+        let mut log_store = RocksdbLogStore::open(temp_dir.path().join("raft_logs_rocksdb"))
+            .expect("log store should open");
+        let store = Arc::new(DurableStateMachineStore::new(log_store.db()));
+        store
+            .save_meta(&DurableStateMachineMeta::new(
+                Some(LogId::new(LeaderId::new(1, 1), 100)),
+                StoredMembership::default(),
+            ))
+            .expect("meta should be persisted");
+
+        let error =
+            recover_applied_state(&mut log_store, &store, &temp_dir.path().join("snapshots"))
+                .await
+                .expect_err("frontier ahead of the last log must refuse startup");
+        let _ = error;
+    }
+
+    #[tokio::test]
+    async fn snapshot_ahead_of_frontier_fails_closed() {
+        let temp_dir = TempDir::new().expect("temporary directory should be created");
+        let mut log_store = RocksdbLogStore::open(temp_dir.path().join("raft_logs_rocksdb"))
+            .expect("log store should open");
+        let store = Arc::new(DurableStateMachineStore::new(log_store.db()));
+        store
+            .save_meta(&DurableStateMachineMeta::new(
+                Some(LogId::new(LeaderId::new(1, 1), 3)),
+                StoredMembership::default(),
+            ))
+            .expect("meta should be persisted");
+        write_snapshot_meta(&temp_dir.path().join("snapshots"), 5);
+
+        let error =
+            recover_applied_state(&mut log_store, &store, &temp_dir.path().join("snapshots"))
+                .await
+                .expect_err("snapshot ahead of the durable frontier must refuse startup");
+        let _ = error;
     }
 }

--- a/src/raft/src/state_machine.rs
+++ b/src/raft/src/state_machine.rs
@@ -53,6 +53,7 @@ use storage::{
 
 use conf::raft_type::{Binlog, BinlogResponse, KiwiNode, KiwiTypeConfig};
 
+use crate::durable_state_machine_meta::{DurableStateMachineMeta, DurableStateMachineStore};
 use crate::snapshot_archive::{pack_dir_to_vec, unpack_tar_to_dir, unpacked_checkpoint_root};
 
 fn storage_err_to_raft(e: storage::error::Error) -> StorageError<u64> {
@@ -306,7 +307,7 @@ fn persist_current_snapshot(
 }
 
 #[allow(clippy::result_large_err)]
-fn load_current_snapshot(
+pub(crate) fn load_current_snapshot(
     work_dir: &std::path::Path,
 ) -> Result<Option<Snapshot<KiwiTypeConfig>>, StorageError<u64>> {
     let data_path = work_dir.join(CURRENT_SNAPSHOT_DATA);
@@ -415,6 +416,7 @@ pub struct KiwiStateMachine {
     snapshot_publication_gate: Arc<tokio::sync::Mutex<()>>,
     /// Shared Raft append-log callback used to re-arm restored Storage after snapshot install.
     append_log_fn: Option<Arc<OnceLock<storage::AppendLogFn>>>,
+    durable_meta: Option<Arc<DurableStateMachineStore>>,
 }
 
 impl KiwiStateMachine {
@@ -443,7 +445,24 @@ impl KiwiStateMachine {
             snapshot_state_gate: Arc::new(tokio::sync::Mutex::new(())),
             snapshot_publication_gate: Arc::new(tokio::sync::Mutex::new(())),
             append_log_fn,
+            durable_meta: None,
         }
+    }
+
+    pub fn with_durable_meta(mut self, store: Arc<DurableStateMachineStore>) -> Self {
+        self.durable_meta = Some(store);
+        self
+    }
+
+    /// Seed the frontier recovered at startup so applied_state() stays a pure read.
+    pub fn with_recovered_state(
+        mut self,
+        last_applied: Option<LogId<u64>>,
+        last_membership: StoredMembership<u64, KiwiNode>,
+    ) -> Self {
+        self.last_applied = last_applied;
+        self.last_membership = last_membership;
+        self
     }
 
     /// Initialize cf_tracker from restored SST properties after snapshot install
@@ -518,6 +537,20 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
             // Reached only after the entry has been durably applied.
             self.last_applied = Some(log_id);
             responses.push(response);
+        }
+
+        // note(guozhihao-224) Persist the frontier only after every entry is
+        // durably applied; a failure is fatal and reports no success.
+        if let Some(store) = &self.durable_meta {
+            let meta =
+                DurableStateMachineMeta::new(self.last_applied, self.last_membership.clone());
+            store.save_meta(&meta).map_err(|error| {
+                log::error!(
+                    "fatal error persisting applied frontier: last_applied={:?}, error={error}",
+                    self.last_applied
+                );
+                io_err_to_raft(io::Error::other(error.to_string()))
+            })?;
         }
 
         Ok(responses)
@@ -718,6 +751,19 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
         self.last_applied = meta.last_log_id;
         self.last_membership = meta.last_membership.clone();
 
+        // note(guozhihao-224) Keep the frontier aligned with the installed
+        // snapshot; failure keeps the marker in place and storage paused.
+        if let Some(store) = &self.durable_meta {
+            let durable_meta =
+                DurableStateMachineMeta::new(self.last_applied, self.last_membership.clone());
+            store.save_meta(&durable_meta).map_err(|error| {
+                post_marker_error(
+                    "persisting the applied frontier after snapshot install",
+                    &error,
+                )
+            })?;
+        }
+
         persist_current_snapshot(&self.snapshot_work_dir, meta, &bytes).map_err(|error| {
             let context = format!(
                 "persisting the installed current snapshot under {}",
@@ -752,8 +798,20 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
             .lock_owned()
             .await;
         let _snapshot_state = Arc::clone(&self.snapshot_state_gate).lock_owned().await;
-        // On first access, lazily load from persisted snapshot to recover last_applied
-        // after restart (otherwise openraft would scan from index 0 and fail if logs were purged).
+        // note(guozhihao-224) On first access after restart the frontier is empty;
+        // recover from the durable store, falling back to the persisted snapshot only
+        // when no durable frontier exists, otherwise OpenRaft scans from index 0.
+        if self.last_applied.is_none()
+            && let Some(store) = &self.durable_meta
+            && let Some(meta) = store.load_meta()?
+        {
+            self.last_applied = meta.last_applied;
+            self.last_membership = meta.last_membership;
+            log::info!(
+                "Recovered last_applied={:?} from durable state machine metadata",
+                self.last_applied
+            );
+        }
         if self.last_applied.is_none()
             && let Some(snap) = load_current_snapshot(&self.snapshot_work_dir)?
         {
@@ -885,6 +943,9 @@ mod snapshot_gate_tests {
 
     use openraft::{Entry, LeaderId};
     use storage::{safe_cleanup_test_db, unique_test_db_path};
+
+    use crate::durable_state_machine_meta::DurableStateMachineStore;
+    use crate::log_store_rocksdb::RocksdbLogStore;
 
     use super::*;
 
@@ -1154,6 +1215,77 @@ mod snapshot_gate_tests {
         safe_cleanup_test_db(&db_path);
         safe_cleanup_test_db(&snapshot_work_dir);
     }
+
+    #[tokio::test]
+    async fn install_snapshot_persists_matching_frontier() {
+        let db_path = unique_test_db_path();
+        let snapshot_work_dir = unique_test_db_path();
+        std::fs::create_dir_all(&snapshot_work_dir)
+            .expect("snapshot work directory should be created");
+
+        let raft_log_path = unique_test_db_path();
+        let log_store = RocksdbLogStore::open(&raft_log_path).expect("raft log store should open");
+        let durable_store = Arc::new(DurableStateMachineStore::new(log_store.db()));
+
+        let mut storage = Storage::new(1, 0);
+        let options = Arc::new(StorageOptions::default());
+        let _storage_rx = storage
+            .open(options, &db_path)
+            .expect("test storage should open");
+        storage
+            .set(b"snapshot-key", b"snapshot-value")
+            .expect("test data should be written");
+        let storage_swap = Arc::new(ArcSwap::from_pointee(storage));
+        let controller = Arc::new(CountingPauseController::default());
+        let mut state_machine = KiwiStateMachine::new(
+            1,
+            Arc::clone(&storage_swap),
+            db_path.clone(),
+            snapshot_work_dir.clone(),
+            controller.clone(),
+            None,
+        )
+        .with_durable_meta(Arc::clone(&durable_store));
+
+        let mut builder = state_machine.get_snapshot_builder().await;
+        let snapshot = builder
+            .build_snapshot()
+            .await
+            .expect("test snapshot should build");
+        drop(builder);
+        let snapshot_meta = snapshot.meta.clone();
+        let snapshot_bytes = snapshot.snapshot.into_inner();
+
+        state_machine
+            .install_snapshot(
+                &snapshot_meta,
+                Box::new(std::io::Cursor::new(snapshot_bytes)),
+            )
+            .await
+            .expect("snapshot install should succeed");
+
+        let persisted = durable_store
+            .load_meta()
+            .expect("frontier should be persisted")
+            .expect("frontier must exist after install");
+        assert_eq!(
+            persisted.last_applied, snapshot_meta.last_log_id,
+            "frontier must match the installed snapshot last log id"
+        );
+        assert_eq!(
+            persisted.last_membership, snapshot_meta.last_membership,
+            "frontier membership must match the installed snapshot"
+        );
+
+        drop(state_machine);
+        let storage = storage_swap.load_full();
+        drop(storage_swap);
+        close_storage(storage).await;
+        drop(_storage_rx);
+        safe_cleanup_test_db(&db_path);
+        safe_cleanup_test_db(&snapshot_work_dir);
+        safe_cleanup_test_db(&raft_log_path);
+    }
 }
 
 #[cfg(test)]
@@ -1223,6 +1355,9 @@ mod apply_ordering_tests {
         ColumnFamilyIndex, fail_next_rocks_batch_commit, safe_cleanup_test_db, unique_test_db_path,
     };
 
+    use crate::durable_state_machine_meta::{DurableStateMachineStore, fail_next_sm_meta_save};
+    use crate::log_store_rocksdb::RocksdbLogStore;
+
     use super::*;
 
     struct NoopPermit;
@@ -1252,11 +1387,14 @@ mod apply_ordering_tests {
         db_path: PathBuf,
         snapshot_work_dir: PathBuf,
         storage_rx: Box<dyn std::any::Any + Send>,
+        sm_meta_store: Arc<DurableStateMachineStore>,
+        raft_log_path: PathBuf,
     }
 
     struct ClosedFixture {
         db_path: PathBuf,
         snapshot_work_dir: PathBuf,
+        raft_log_path: PathBuf,
     }
 
     impl Fixture {
@@ -1265,6 +1403,11 @@ mod apply_ordering_tests {
             let snapshot_work_dir = unique_test_db_path();
             std::fs::create_dir_all(&snapshot_work_dir)
                 .expect("snapshot work directory should be created");
+
+            let raft_log_path = unique_test_db_path();
+            let log_store =
+                RocksdbLogStore::open(&raft_log_path).expect("test raft log store should open");
+            let sm_meta_store = Arc::new(DurableStateMachineStore::new(log_store.db()));
 
             let mut storage = Storage::new(1, 0);
             let options = Arc::new(StorageOptions::default());
@@ -1279,7 +1422,8 @@ mod apply_ordering_tests {
                 snapshot_work_dir.clone(),
                 Arc::new(NoopPauseController),
                 None,
-            );
+            )
+            .with_durable_meta(Arc::clone(&sm_meta_store));
 
             Self {
                 state_machine,
@@ -1287,6 +1431,8 @@ mod apply_ordering_tests {
                 db_path,
                 snapshot_work_dir,
                 storage_rx: Box::new(storage_rx),
+                sm_meta_store,
+                raft_log_path,
             }
         }
 
@@ -1297,8 +1443,11 @@ mod apply_ordering_tests {
                 db_path,
                 snapshot_work_dir,
                 storage_rx,
+                sm_meta_store,
+                raft_log_path,
             } = self;
             drop(state_machine);
+            drop(sm_meta_store);
             let storage = storage_swap.load_full();
             drop(storage_swap);
             let mut storage = match Arc::try_unwrap(storage) {
@@ -1313,6 +1462,7 @@ mod apply_ordering_tests {
             ClosedFixture {
                 db_path,
                 snapshot_work_dir,
+                raft_log_path,
             }
         }
 
@@ -1356,6 +1506,7 @@ mod apply_ordering_tests {
             drop(reopened);
             safe_cleanup_test_db(&self.db_path);
             safe_cleanup_test_db(&self.snapshot_work_dir);
+            safe_cleanup_test_db(&self.raft_log_path);
         }
     }
 
@@ -1509,5 +1660,127 @@ mod apply_ordering_tests {
                 (b"after-failure", None),
             ])
             .await;
+    }
+
+    #[tokio::test]
+    async fn apply_persists_durable_frontier() {
+        let mut fx = Fixture::new();
+        assert!(
+            fx.sm_meta_store
+                .load_meta()
+                .expect("load should work")
+                .is_none()
+        );
+
+        fx.state_machine
+            .apply([entry_at(
+                5,
+                EntryPayload::Normal(string_put_binlog(b"durable-frontier", b"value")),
+            )])
+            .await
+            .expect("a valid binlog should apply");
+
+        let meta = fx
+            .sm_meta_store
+            .load_meta()
+            .expect("frontier should be persisted")
+            .expect("frontier must exist after apply");
+        assert_eq!(
+            meta.last_applied.map(|l| l.index),
+            Some(5),
+            "durable frontier must advance to the applied entry"
+        );
+
+        fx.close()
+            .await
+            .assert_reopened_values(&[(b"durable-frontier", Some("value"))])
+            .await;
+    }
+
+    /// note(guozhihao-224) Persist failure is fatal even though business data
+    /// is committed (allowed lagging-frontier window).
+    #[tokio::test]
+    async fn frontier_persist_failure_is_fatal() {
+        let mut fx = Fixture::new();
+        let key = b"frontier-fail";
+        let _failure = fail_next_sm_meta_save(&fx.sm_meta_store.db());
+
+        let err = fx
+            .state_machine
+            .apply([entry_at(
+                7,
+                EntryPayload::Normal(string_put_binlog(key, b"value")),
+            )])
+            .await
+            .expect_err("apply must fail when the frontier cannot be persisted");
+        let _ = err;
+
+        assert_eq!(
+            fx.sm_meta_store
+                .load_meta()
+                .expect("load should work")
+                .map(|m| m.last_applied.map(|l| l.index)),
+            None,
+            "durable frontier must not advance when its persistence fails"
+        );
+        // Business data is committed; the durable frontier lags. On restart this
+        // lag is the allowed window replayed idempotently (per-instance markers).
+        assert_eq!(
+            fx.storage_swap
+                .load_full()
+                .get(key)
+                .expect("business data is committed"),
+            "value"
+        );
+
+        fx.close()
+            .await
+            .assert_reopened_values(&[(key, Some("value"))])
+            .await;
+    }
+
+    /// note(guozhihao-224) Restart recovers the frontier, not a memory default.
+    #[tokio::test]
+    async fn applied_state_returns_durable_value() {
+        let mut fx = Fixture::new();
+        fx.state_machine
+            .apply([entry_at(
+                9,
+                EntryPayload::Normal(string_put_binlog(b"durable-read", b"v")),
+            )])
+            .await
+            .expect("binlog should apply");
+
+        let db_path = fx.db_path.clone();
+        let snapshot_work_dir = fx.snapshot_work_dir.clone();
+        let raft_log_path = fx.raft_log_path.clone();
+        fx.close().await;
+
+        let log_store =
+            RocksdbLogStore::open(&raft_log_path).expect("raft log store should reopen");
+        let store = Arc::new(DurableStateMachineStore::new(log_store.db()));
+        let mut reopened = KiwiStateMachine::new(
+            1,
+            Arc::new(ArcSwap::from_pointee(Storage::new(1, 0))),
+            db_path.clone(),
+            snapshot_work_dir.clone(),
+            Arc::new(NoopPauseController),
+            None,
+        )
+        .with_durable_meta(store);
+
+        let (applied, _membership) = reopened
+            .applied_state()
+            .await
+            .expect("applied_state should recover the durable frontier");
+        assert_eq!(
+            applied.map(|l| l.index),
+            Some(9),
+            "restarted state machine must recover the exact applied index"
+        );
+
+        safe_cleanup_test_db(&raft_log_path);
+        safe_cleanup_test_db(&db_path);
+        safe_cleanup_test_db(&snapshot_work_dir);
     }
 }

--- a/src/raft/tests/durable_state_machine_meta_test.rs
+++ b/src/raft/tests/durable_state_machine_meta_test.rs
@@ -1,0 +1,107 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(clippy::unwrap_used)]
+
+use openraft::{LeaderId, LogId, StoredMembership};
+use raft::durable_state_machine_meta::{DurableStateMachineMeta, DurableStateMachineStore};
+use raft::log_store_rocksdb::RocksdbLogStore;
+
+fn store_at(temp_dir: &tempfile::TempDir) -> DurableStateMachineStore {
+    let log_store = RocksdbLogStore::open(temp_dir.path().join("raft_logs_rocksdb"))
+        .expect("log store should open with all column families");
+    DurableStateMachineStore::new(log_store.db())
+}
+
+#[test]
+fn sm_meta_cf_exists_on_open() {
+    let temp_dir = tempfile::TempDir::new().expect("temporary directory should be created");
+    let log_store = RocksdbLogStore::open(temp_dir.path().join("raft_logs_rocksdb"))
+        .expect("log store should open with all column families");
+    let db = log_store.db();
+    assert!(
+        db.cf_handle("sm_meta").is_some(),
+        "sm_meta column family must exist after opening the log store"
+    );
+}
+
+#[test]
+fn roundtrip_saves_and_loads_meta() {
+    let temp_dir = tempfile::TempDir::new().expect("temporary directory should be created");
+    let store = store_at(&temp_dir);
+
+    let meta = DurableStateMachineMeta::new(
+        Some(LogId::new(LeaderId::new(1, 1), 5)),
+        StoredMembership::default(),
+    );
+    store.save_meta(&meta).expect("meta should be persisted");
+    assert_eq!(
+        store.load_meta().expect("meta should load back"),
+        Some(meta),
+        "round-tripped metadata must equal the saved value"
+    );
+}
+
+/// note(guozhihao-224) Corrupt bytes must error, not be treated as an empty frontier.
+#[test]
+fn corrupt_meta_load_fails_closed() {
+    let temp_dir = tempfile::TempDir::new().expect("temporary directory should be created");
+    let log_store = RocksdbLogStore::open(temp_dir.path().join("raft_logs_rocksdb"))
+        .expect("log store should open with all column families");
+    let db = log_store.db();
+    {
+        let cf = db
+            .cf_handle("sm_meta")
+            .expect("sm_meta column family should exist");
+        db.put_cf(&cf, b"state_machine_meta", b"not-valid-json")
+            .expect("raw bytes should be written");
+    }
+
+    let store = DurableStateMachineStore::new(db);
+    let err = store
+        .load_meta()
+        .expect_err("corrupt metadata must be rejected, not treated as empty");
+    let _ = err;
+}
+
+#[test]
+fn unknown_format_version_is_rejected() {
+    let temp_dir = tempfile::TempDir::new().expect("temporary directory should be created");
+    let store = store_at(&temp_dir);
+
+    let meta = DurableStateMachineMeta {
+        format_version: 99,
+        last_applied: Some(LogId::new(LeaderId::new(1, 1), 7)),
+        last_membership: StoredMembership::default(),
+    };
+    store.save_meta(&meta).expect("meta should be persisted");
+    let err = store
+        .validate()
+        .expect_err("unsupported format version must be rejected");
+    let _ = err;
+}
+
+#[test]
+fn validate_on_empty_store_returns_none() {
+    let temp_dir = tempfile::TempDir::new().expect("temporary directory should be created");
+    let store = store_at(&temp_dir);
+    assert_eq!(
+        store.validate().expect("empty store should validate"),
+        None,
+        "no metadata must yield None rather than an error"
+    );
+}

--- a/src/raft/tests/log_store_rocksdb_test.rs
+++ b/src/raft/tests/log_store_rocksdb_test.rs
@@ -48,6 +48,7 @@ fn create_test_db() -> (TempDir, Arc<DB>) {
         ColumnFamilyDescriptor::new("logs", Options::default()),
         ColumnFamilyDescriptor::new("meta", Options::default()),
         ColumnFamilyDescriptor::new("state", Options::default()),
+        ColumnFamilyDescriptor::new("sm_meta", Options::default()),
     ];
 
     let db = DB::open_cf_descriptors(&opts, temp_dir.path(), cfs).expect("Failed to open database");


### PR DESCRIPTION
## Summary
- Persist the durable global applied frontier (`last_applied` + membership) in a new `sm_meta` column family of the Raft log store.
- `apply()` persists the frontier after each successful batch; `install_snapshot()` keeps it aligned with the installed snapshot; a persist failure is fatal and reports no success.
- Startup recovers and cross-validates the frontier against the persisted snapshot and the log store, refusing to start (fail closed) on corrupt, unknown-version, or inconsistent metadata instead of guessing.

## Test plan
- [x] `cargo test --package raft` — 136 passed (lib + integration), incl. new persist / restart-recovery / fault-injection / snapshot-alignment tests
- [x] `cargo test --package storage` — all passed
- [x] `cargo check --package server`
- [x] `cargo clippy --all-features --workspace -- -D warnings -D clippy::unwrap_used`
- [x] `cargo fmt --all -- --check`, `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable persistence for state-machine progress and membership.
  * Raft nodes now recover applied-log state during startup and validate it against snapshots and logs.
  * Added snapshot-based bootstrapping when metadata is unavailable.
  * Added support for recovering state and configuring durable metadata storage.

* **Bug Fixes**
  * Startup now rejects corrupted, incompatible, or inconsistent persisted state instead of proceeding unsafely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->