### PR TITLE
feat(raft): persist and recover state machine applied metadata (#334)

### DIFF
--- a/src/raft/src/durable_meta.rs
+++ b/src/raft/src/durable_meta.rs
@@ -1,0 +1,74 @@
+// Copyright (c) 2024-present, arana-db Community.  All rights reserved.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Durable state machine metadata for crash-safe recovery.
+//!
+//! Persists the applied frontier (`last_applied`) and membership so that
+//! after restart the state machine can recover its position without relying
+//! on snapshot metadata alone or falling back to log index 0.
+
+use openraft::{LogId, StoredMembership};
+use serde::{Deserialize, Serialize};
+
+use conf::raft_type::KiwiNode;
+
+/// Current format version. Bump when the struct layout changes.
+const DURABLE_META_VERSION: u32 = 1;
+
+/// Persisted state machine metadata.
+///
+/// Written to the Raft log store's `state_cf` after each successful apply
+/// and after snapshot install. On startup, loaded and cross-validated against
+/// the snapshot metadata and log store boundaries.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DurableStateMachineMeta {
+    /// Format version for forward/backward compatibility.
+    pub version: u32,
+    /// Last log entry that was durably applied to storage.
+    pub last_applied: Option<LogId<u64>>,
+    /// Last membership configuration observed during apply.
+    pub last_membership: StoredMembership<u64, KiwiNode>,
+}
+
+impl DurableStateMachineMeta {
+    /// Create a new meta snapshot from the current state machine state.
+    pub fn new(
+        last_applied: Option<LogId<u64>>,
+        last_membership: StoredMembership<u64, KiwiNode>,
+    ) -> Self {
+        Self {
+            version: DURABLE_META_VERSION,
+            last_applied,
+            last_membership,
+        }
+    }
+
+    /// Validate the metadata after deserialization.
+    ///
+    /// Returns `Err` with a human-readable description if the metadata is
+    /// corrupt or from an unsupported future version. The caller must treat
+    /// the node as unhealthy and refuse to provide strong-consistency service.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.version == 0 || self.version > DURABLE_META_VERSION {
+            return Err(format!(
+                "unsupported durable meta version {} (expected 1..={})",
+                self.version, DURABLE_META_VERSION,
+            ));
+        }
+        Ok(())
+    }
+}

--- a/src/raft/src/lib.rs
+++ b/src/raft/src/lib.rs
@@ -20,9 +20,9 @@
 //! Re-exports logindex types from storage::logindex to avoid code duplication.
 
 pub mod capabilities;
-pub mod durable_meta;
 pub mod conversion;
 pub mod db_access; // Shim for backward compatibility with tests
+pub mod durable_meta;
 pub mod grpc;
 pub mod leader_gate;
 pub mod log_store_rocksdb;

--- a/src/raft/src/lib.rs
+++ b/src/raft/src/lib.rs
@@ -20,6 +20,7 @@
 //! Re-exports logindex types from storage::logindex to avoid code duplication.
 
 pub mod capabilities;
+pub mod durable_meta;
 pub mod conversion;
 pub mod db_access; // Shim for backward compatibility with tests
 pub mod grpc;
@@ -67,6 +68,21 @@ const _: () = assert!(
     CF_NAMES.len() == storage::ColumnFamilyIndex::COUNT,
     "CF_NAMES length must match storage::ColumnFamilyIndex::COUNT"
 );
+
+/// Shared test utilities for the raft crate.
+#[cfg(test)]
+pub mod test_util {
+    use crate::log_store_rocksdb::RocksdbLogStore;
+
+    /// Create a `RocksdbLogStore` backed by a temporary directory.
+    /// Returns `(store, dir)` — the caller must keep `dir` alive for the
+    /// duration of the test.
+    pub fn test_log_store() -> (RocksdbLogStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("temp dir for log store");
+        let store = RocksdbLogStore::open(dir.path()).expect("test log store should open");
+        (store, dir)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/raft/src/log_store_rocksdb.rs
+++ b/src/raft/src/log_store_rocksdb.rs
@@ -351,8 +351,10 @@ impl RocksdbLogStore {
     ) -> Result<(), StorageError<u64>> {
         let state_cf = self.cf_write(STATE_CF)?;
         let value = serialize(meta)?;
+        let mut opts = rocksdb::WriteOptions::default();
+        opts.set_sync(true);
         self.db
-            .put_cf(&state_cf, DURABLE_META_KEY, &value)
+            .put_cf_opt(&state_cf, DURABLE_META_KEY, &value, &opts)
             .map_err(io_write_err)?;
         Ok(())
     }

--- a/src/raft/src/log_store_rocksdb.rs
+++ b/src/raft/src/log_store_rocksdb.rs
@@ -335,7 +335,54 @@ impl RocksdbLogStore {
     }
 }
 
+const DURABLE_META_KEY: &[u8] = b"durable_state_machine_meta";
+
 impl RocksdbLogStore {
+    /// Persist the state machine's applied frontier and membership.
+    ///
+    /// Called after each successful apply and after snapshot install.
+    /// The value is stored in the same `state_cf` that holds vote and
+    /// committed. This is a standalone write (not part of a WriteBatch
+    /// with the log store's own append/truncate operations) because the
+    /// state machine apply writes to a separate RocksDB instance.
+    pub fn save_durable_meta(
+        &self,
+        meta: &crate::durable_meta::DurableStateMachineMeta,
+    ) -> Result<(), StorageError<u64>> {
+        let state_cf = self.cf_write(STATE_CF)?;
+        let value = serialize(meta)?;
+        self.db
+            .put_cf(&state_cf, DURABLE_META_KEY, &value)
+            .map_err(io_write_err)?;
+        Ok(())
+    }
+
+    /// Load the persisted state machine metadata.
+    ///
+    /// Returns `Ok(None)` if no metadata has been persisted yet (first
+    /// start or legacy installation). Returns `Err` if the stored bytes
+    /// are corrupt or from an unsupported future version.
+    pub fn load_durable_meta(
+        &self,
+    ) -> Result<Option<crate::durable_meta::DurableStateMachineMeta>, StorageError<u64>> {
+        let state_cf = self.cf_read(STATE_CF)?;
+        let Some(bytes) = self
+            .db
+            .get_cf(&state_cf, DURABLE_META_KEY)
+            .map_err(io_read_err)?
+        else {
+            return Ok(None);
+        };
+        let meta: crate::durable_meta::DurableStateMachineMeta = deserialize(&bytes)?;
+        meta.validate().map_err(|msg| {
+            let io_err = std::io::Error::other(msg);
+            StorageError::IO {
+                source: openraft::StorageIOError::read(&io_err),
+            }
+        })?;
+        Ok(Some(meta))
+    }
+
     /// 从已有的 RocksDB 数据库创建日志存储实例
     pub fn new(db: Arc<DB>) -> Result<Self, StorageError<u64>> {
         for cf_name in [LOGS_CF, META_CF, STATE_CF] {

--- a/src/raft/src/log_store_rocksdb.rs
+++ b/src/raft/src/log_store_rocksdb.rs
@@ -385,6 +385,48 @@ impl RocksdbLogStore {
         Ok(Some(meta))
     }
 
+    /// Read the log-store boundaries (last log id and last purged log id)
+    /// synchronously.  Used during startup to cross-validate the durable
+    /// state-machine meta against the actual log extent.
+    pub fn read_log_boundaries(
+        &self,
+    ) -> Result<
+        (
+            Option<openraft::LogId<u64>>,
+            Option<openraft::LogId<u64>>,
+        ),
+        StorageError<u64>,
+    > {
+        let logs_cf = self.cf_read(LOGS_CF)?;
+        let iter = self.db.iterator_cf(&logs_cf, IteratorMode::End);
+        let last_log_id = iter
+            .take(1)
+            .next()
+            .transpose()
+            .map_err(io_read_err)?
+            .map(|res| {
+                let (_, value) = res;
+                deserialize::<openraft::Entry<KiwiTypeConfig>>(&value).map(|entry| entry.log_id)
+            })
+            .transpose()?;
+
+        let meta_cf = self.cf_read(META_CF)?;
+        let last_purged_log_id = self
+            .db
+            .get_cf(&meta_cf, LAST_PURGED_KEY)
+            .map_err(io_read_err)?
+            .map(|bytes| deserialize::<Option<openraft::LogId<u64>>>(&bytes))
+            .transpose()?
+            .flatten();
+
+        let last_log_id = match last_log_id {
+            None => last_purged_log_id,
+            x => x,
+        };
+
+        Ok((last_log_id, last_purged_log_id))
+    }
+
     /// 从已有的 RocksDB 数据库创建日志存储实例
     pub fn new(db: Arc<DB>) -> Result<Self, StorageError<u64>> {
         for cf_name in [LOGS_CF, META_CF, STATE_CF] {

--- a/src/raft/src/node.rs
+++ b/src/raft/src/node.rs
@@ -218,20 +218,8 @@ pub async fn create_raft_node(
     let snapshot_work_dir = config.data_dir.join("snapshots");
     fs::create_dir_all(&snapshot_work_dir)?;
 
-    // Per-instance LogIndex collectors / cf_trackers live in the Storage; the state
-    // machine looks them up through storage_swap so it sees the right ones after a
-    // snapshot install hot-swaps Storage.
-    let state_machine = KiwiStateMachine::new(
-        config.node_id,
-        storage_swap.clone(),
-        config.db_path.clone(),
-        snapshot_work_dir,
-        Arc::clone(&pause_controller),
-        append_log_fn,
-    );
-
-    let network = KiwiNetworkFactory::new();
-
+    // Open the log store first so the state machine can persist and load
+    // durable applied metadata through it.
     let legacy_log_store_path = config.data_dir.join("raft_logs");
     if legacy_log_store_path.try_exists()? {
         return Err(anyhow::anyhow!(
@@ -242,6 +230,21 @@ pub async fn create_raft_node(
     let log_store_path = config.data_dir.join("raft_logs_rocksdb");
     std::fs::create_dir_all(&log_store_path)?;
     let log_store = RocksdbLogStore::open(&log_store_path)?;
+
+    // Per-instance LogIndex collectors / cf_trackers live in the Storage; the state
+    // machine looks them up through storage_swap so it sees the right ones after a
+    // snapshot install hot-swaps Storage.
+    let state_machine = KiwiStateMachine::new(
+        config.node_id,
+        storage_swap.clone(),
+        config.db_path.clone(),
+        snapshot_work_dir,
+        Arc::clone(&pause_controller),
+        append_log_fn,
+        log_store.clone(),
+    );
+
+    let network = KiwiNetworkFactory::new();
 
     let raft = Raft::new(
         config.node_id,

--- a/src/raft/src/node.rs
+++ b/src/raft/src/node.rs
@@ -223,7 +223,8 @@ pub async fn create_raft_node(
     let legacy_log_store_path = config.data_dir.join("raft_logs");
     if legacy_log_store_path.try_exists()? {
         return Err(anyhow::anyhow!(
-            "cannot safely migrate legacy in-memory Raft log state in place; use a new node ID and clean data-dir/raft-data-dir to rejoin from a healthy leader"
+            "cannot safely migrate legacy in-memory Raft log state in place at {}; use a new node ID and clean data-dir/raft-data-dir to rejoin from a healthy leader",
+            legacy_log_store_path.display()
         ));
     }
 

--- a/src/raft/src/state_machine.rs
+++ b/src/raft/src/state_machine.rs
@@ -743,8 +743,9 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
         // Persist the applied frontier derived from the installed snapshot
         // before removing the install marker, so crash recovery sees a
         // consistent position.
-        self.persist_durable_meta()
-            .map_err(|error| post_marker_error("persisting durable meta after snapshot install", &error))?;
+        self.persist_durable_meta().map_err(|error| {
+            post_marker_error("persisting durable meta after snapshot install", &error)
+        })?;
 
         persist_current_snapshot(&self.snapshot_work_dir, meta, &bytes).map_err(|error| {
             let context = format!(
@@ -782,22 +783,53 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
         let _snapshot_state = Arc::clone(&self.snapshot_state_gate).lock_owned().await;
 
         if self.last_applied.is_none() {
-            // Try durable meta first (most authoritative — written after every apply).
-            if let Some(meta) = self.log_store.load_durable_meta()? {
-                self.last_applied = meta.last_applied;
-                self.last_membership = meta.last_membership;
-                log::info!(
-                    "Recovered last_applied={:?} from durable state machine meta",
-                    self.last_applied
-                );
-            } else if let Some(snap) = load_current_snapshot(&self.snapshot_work_dir)? {
-                // Fall back to snapshot metadata (legacy installations or first start).
-                self.last_applied = snap.meta.last_log_id;
-                self.last_membership = snap.meta.last_membership.clone();
-                log::info!(
-                    "Recovered last_applied={:?} from persisted snapshot (no durable meta)",
-                    self.last_applied
-                );
+            let durable = self.log_store.load_durable_meta()?;
+            let snapshot = load_current_snapshot(&self.snapshot_work_dir)?;
+
+            match (durable, snapshot) {
+                (Some(meta), Some(snap)) => {
+                    // Both exist — cross-validate. Durable meta must not be
+                    // behind the snapshot, since the snapshot represents a
+                    // committed checkpoint.
+                    let durable_idx = meta.last_applied.map(|l| l.index).unwrap_or(0);
+                    let snap_idx = snap.meta.last_log_id.map(|l| l.index).unwrap_or(0);
+                    if durable_idx < snap_idx {
+                        log::warn!(
+                            "Durable meta last_applied={} is behind snapshot last_log_id={}; \
+                             using snapshot frontier",
+                            durable_idx,
+                            snap_idx
+                        );
+                        self.last_applied = snap.meta.last_log_id;
+                        self.last_membership = snap.meta.last_membership.clone();
+                    } else {
+                        self.last_applied = meta.last_applied;
+                        self.last_membership = meta.last_membership;
+                    }
+                    log::info!(
+                        "Recovered last_applied={:?} (cross-validated durable meta + snapshot)",
+                        self.last_applied
+                    );
+                }
+                (Some(meta), None) => {
+                    self.last_applied = meta.last_applied;
+                    self.last_membership = meta.last_membership;
+                    log::info!(
+                        "Recovered last_applied={:?} from durable state machine meta",
+                        self.last_applied
+                    );
+                }
+                (None, Some(snap)) => {
+                    self.last_applied = snap.meta.last_log_id;
+                    self.last_membership = snap.meta.last_membership.clone();
+                    log::info!(
+                        "Recovered last_applied={:?} from persisted snapshot (no durable meta)",
+                        self.last_applied
+                    );
+                }
+                (None, None) => {
+                    log::info!("No durable meta or snapshot found; starting from scratch");
+                }
             }
         }
 
@@ -1773,14 +1805,18 @@ mod durable_meta_tests {
 
         // After install, durable meta should reflect the snapshot's last_log_id.
         let meta = ls2.load_durable_meta().unwrap();
-        assert!(meta.is_some(), "durable meta should exist after snapshot install");
+        assert!(
+            meta.is_some(),
+            "durable meta should exist after snapshot install"
+        );
         let meta = meta.unwrap();
         assert_eq!(
             meta.last_applied, snap_meta.last_log_id,
             "durable meta last_applied should match snapshot last_log_id"
         );
 
-        // Close the state machine and storage to release RocksDB locks.
+        // Close the state machine, storage, and log store to release all
+        // RocksDB locks before reopening.
         drop(sm2);
         let dst_storage = dst_swap.load_full();
         drop(dst_swap);
@@ -1789,6 +1825,8 @@ mod durable_meta_tests {
             .expect("dst storage should have no remaining references");
         dst_storage.shutdown().await;
         dst_storage.close();
+        drop(ls2);
+        drop(ls2_dir);
 
         // Reopen from the same log store directory — applied_state should
         // recover the installed snapshot's frontier from durable meta.
@@ -1816,7 +1854,6 @@ mod durable_meta_tests {
 
         drop(sm3);
         drop(swap);
-        drop(ls2_dir);
         safe_cleanup_test_db(&dst_db);
         safe_cleanup_test_db(&src_db);
     }

--- a/src/raft/src/state_machine.rs
+++ b/src/raft/src/state_machine.rs
@@ -53,6 +53,8 @@ use storage::{
 
 use conf::raft_type::{Binlog, BinlogResponse, KiwiNode, KiwiTypeConfig};
 
+use crate::durable_meta::DurableStateMachineMeta;
+use crate::log_store_rocksdb::RocksdbLogStore;
 use crate::snapshot_archive::{pack_dir_to_vec, unpack_tar_to_dir, unpacked_checkpoint_root};
 
 fn storage_err_to_raft(e: storage::error::Error) -> StorageError<u64> {
@@ -415,6 +417,8 @@ pub struct KiwiStateMachine {
     snapshot_publication_gate: Arc<tokio::sync::Mutex<()>>,
     /// Shared Raft append-log callback used to re-arm restored Storage after snapshot install.
     append_log_fn: Option<Arc<OnceLock<storage::AppendLogFn>>>,
+    /// Raft log store for persisting durable state machine metadata.
+    log_store: RocksdbLogStore,
 }
 
 impl KiwiStateMachine {
@@ -430,6 +434,7 @@ impl KiwiStateMachine {
         snapshot_work_dir: PathBuf,
         pause_controller: Arc<dyn PauseController>,
         append_log_fn: Option<Arc<OnceLock<storage::AppendLogFn>>>,
+        log_store: RocksdbLogStore,
     ) -> Self {
         Self {
             _node_id: node_id,
@@ -443,6 +448,7 @@ impl KiwiStateMachine {
             snapshot_state_gate: Arc::new(tokio::sync::Mutex::new(())),
             snapshot_publication_gate: Arc::new(tokio::sync::Mutex::new(())),
             append_log_fn,
+            log_store,
         }
     }
 
@@ -457,6 +463,16 @@ impl KiwiStateMachine {
         if let Some(append_log_fn) = self.append_log_fn.as_ref().and_then(|holder| holder.get()) {
             storage.set_append_log_fn(append_log_fn.clone());
         }
+    }
+
+    /// Persist the current applied frontier and membership to the Raft log
+    /// store so that the state machine can recover its position after restart
+    /// without relying on snapshot metadata alone.
+    fn persist_durable_meta(&self) -> Result<(), io::Error> {
+        let meta = DurableStateMachineMeta::new(self.last_applied, self.last_membership.clone());
+        self.log_store
+            .save_durable_meta(&meta)
+            .map_err(|e| io::Error::other(format!("Failed to persist durable meta: {}", e)))
     }
 
     /// Apply binlog to storage.
@@ -518,6 +534,12 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
             // Reached only after the entry has been durably applied.
             self.last_applied = Some(log_id);
             responses.push(response);
+        }
+
+        // Persist the applied frontier so restart can recover without
+        // relying on snapshot metadata alone.
+        if !responses.is_empty() {
+            self.persist_durable_meta().map_err(io_err_to_raft)?;
         }
 
         Ok(responses)
@@ -718,6 +740,12 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
         self.last_applied = meta.last_log_id;
         self.last_membership = meta.last_membership.clone();
 
+        // Persist the applied frontier derived from the installed snapshot
+        // before removing the install marker, so crash recovery sees a
+        // consistent position.
+        self.persist_durable_meta()
+            .map_err(|error| post_marker_error("persisting durable meta after snapshot install", &error))?;
+
         persist_current_snapshot(&self.snapshot_work_dir, meta, &bytes).map_err(|error| {
             let context = format!(
                 "persisting the installed current snapshot under {}",
@@ -752,18 +780,27 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
             .lock_owned()
             .await;
         let _snapshot_state = Arc::clone(&self.snapshot_state_gate).lock_owned().await;
-        // On first access, lazily load from persisted snapshot to recover last_applied
-        // after restart (otherwise openraft would scan from index 0 and fail if logs were purged).
-        if self.last_applied.is_none()
-            && let Some(snap) = load_current_snapshot(&self.snapshot_work_dir)?
-        {
-            self.last_applied = snap.meta.last_log_id;
-            self.last_membership = snap.meta.last_membership.clone();
-            log::info!(
-                "Recovered last_applied={:?} from persisted snapshot",
-                self.last_applied
-            );
+
+        if self.last_applied.is_none() {
+            // Try durable meta first (most authoritative — written after every apply).
+            if let Some(meta) = self.log_store.load_durable_meta()? {
+                self.last_applied = meta.last_applied;
+                self.last_membership = meta.last_membership;
+                log::info!(
+                    "Recovered last_applied={:?} from durable state machine meta",
+                    self.last_applied
+                );
+            } else if let Some(snap) = load_current_snapshot(&self.snapshot_work_dir)? {
+                // Fall back to snapshot metadata (legacy installations or first start).
+                self.last_applied = snap.meta.last_log_id;
+                self.last_membership = snap.meta.last_membership.clone();
+                log::info!(
+                    "Recovered last_applied={:?} from persisted snapshot (no durable meta)",
+                    self.last_applied
+                );
+            }
         }
+
         Ok((self.last_applied, self.last_membership.clone()))
     }
 }
@@ -902,6 +939,8 @@ mod snapshot_gate_tests {
 
     impl StorageAccessPermit for TestStorageAccessPermit {}
 
+    use crate::test_util::test_log_store;
+
     impl PauseController for CountingPauseController {
         fn request_pause(
             &self,
@@ -961,6 +1000,7 @@ mod snapshot_gate_tests {
             .expect("test storage should open");
         let storage_swap = Arc::new(ArcSwap::from_pointee(storage));
         let controller = Arc::new(CountingPauseController::default());
+        let (log_store, _log_store_dir) = test_log_store();
         let mut state_machine = KiwiStateMachine::new(
             1,
             Arc::clone(&storage_swap),
@@ -968,6 +1008,7 @@ mod snapshot_gate_tests {
             snapshot_work_dir.clone(),
             controller,
             None,
+            log_store,
         );
 
         let mut builder = state_machine.get_snapshot_builder().await;
@@ -1024,6 +1065,7 @@ mod snapshot_gate_tests {
             .expect("test storage should open");
         let storage_swap = Arc::new(ArcSwap::from_pointee(storage));
         let controller = Arc::new(CountingPauseController::default());
+        let (log_store, _log_store_dir) = test_log_store();
         let mut state_machine = KiwiStateMachine::new(
             1,
             Arc::clone(&storage_swap),
@@ -1031,6 +1073,7 @@ mod snapshot_gate_tests {
             snapshot_work_dir.clone(),
             controller,
             None,
+            log_store,
         );
 
         let mut builder = state_machine.get_snapshot_builder().await;
@@ -1085,6 +1128,7 @@ mod snapshot_gate_tests {
             .expect("live data should be written");
         let storage_swap = Arc::new(ArcSwap::from_pointee(storage));
         let controller = Arc::new(CountingPauseController::default());
+        let (log_store, _log_store_dir) = test_log_store();
         let mut state_machine = KiwiStateMachine::new(
             1,
             Arc::clone(&storage_swap),
@@ -1092,6 +1136,7 @@ mod snapshot_gate_tests {
             snapshot_work_dir.clone(),
             controller.clone(),
             None,
+            log_store,
         );
 
         let mut builder = state_machine.get_snapshot_builder().await;
@@ -1224,6 +1269,7 @@ mod apply_ordering_tests {
     };
 
     use super::*;
+    use crate::test_util::test_log_store;
 
     struct NoopPermit;
     impl StorageAccessPermit for NoopPermit {}
@@ -1252,6 +1298,7 @@ mod apply_ordering_tests {
         db_path: PathBuf,
         snapshot_work_dir: PathBuf,
         storage_rx: Box<dyn std::any::Any + Send>,
+        _log_store_dir: tempfile::TempDir,
     }
 
     struct ClosedFixture {
@@ -1272,6 +1319,7 @@ mod apply_ordering_tests {
                 .open(options, &db_path)
                 .expect("test storage should open");
             let storage_swap = Arc::new(ArcSwap::from_pointee(storage));
+            let (log_store, log_store_dir) = test_log_store();
             let state_machine = KiwiStateMachine::new(
                 1,
                 Arc::clone(&storage_swap),
@@ -1279,6 +1327,7 @@ mod apply_ordering_tests {
                 snapshot_work_dir.clone(),
                 Arc::new(NoopPauseController),
                 None,
+                log_store,
             );
 
             Self {
@@ -1287,6 +1336,7 @@ mod apply_ordering_tests {
                 db_path,
                 snapshot_work_dir,
                 storage_rx: Box::new(storage_rx),
+                _log_store_dir: log_store_dir,
             }
         }
 
@@ -1297,6 +1347,7 @@ mod apply_ordering_tests {
                 db_path,
                 snapshot_work_dir,
                 storage_rx,
+                _log_store_dir,
             } = self;
             drop(state_machine);
             let storage = storage_swap.load_full();
@@ -1509,5 +1560,274 @@ mod apply_ordering_tests {
                 (b"after-failure", None),
             ])
             .await;
+    }
+}
+
+#[cfg(test)]
+mod durable_meta_tests {
+    //! Covers issue #334: DurableStateMachineMeta must persist last_applied
+    //! and membership so that restart recovery does not rely on snapshot
+    //! metadata alone.
+    #![allow(clippy::unwrap_used)]
+
+    use conf::raft_type::{BinlogEntry, OperateType};
+    use openraft::{Entry, LeaderId};
+    use storage::BaseMetaKey;
+    use storage::format_strings_value::StringValue;
+    use storage::slot_indexer::key_to_slot_id;
+    use storage::{ColumnFamilyIndex, safe_cleanup_test_db, unique_test_db_path};
+
+    use super::*;
+    use crate::log_store_rocksdb::RocksdbLogStore;
+
+    struct NoopPauseController;
+    struct NoopPermit;
+    impl StorageAccessPermit for NoopPermit {}
+
+    impl PauseController for NoopPauseController {
+        fn request_pause(
+            &self,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+            Box::pin(async {})
+        }
+        fn enter(
+            self: std::sync::Arc<Self>,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Box<dyn StorageAccessPermit>> + Send + 'static>,
+        > {
+            Box::pin(async { Box::new(NoopPermit) as Box<dyn StorageAccessPermit> })
+        }
+        fn resume(&self) {}
+    }
+
+    use crate::test_util::test_log_store;
+
+    /// Helper: build a Normal entry with a single Put for the given key/value.
+    fn put_entry(index: u64, term: u64, key: &[u8], value: &[u8]) -> Entry<KiwiTypeConfig> {
+        let slot = key_to_slot_id(key) as u32;
+        let encoded_key = BaseMetaKey::new(key).encode().unwrap();
+        let encoded_value = StringValue::new(value.to_vec()).encode();
+        Entry {
+            log_id: openraft::LogId::new(LeaderId::new(1, term), index),
+            payload: openraft::EntryPayload::Normal(conf::raft_type::Binlog {
+                db_id: 0,
+                slot_idx: slot,
+                entries: vec![BinlogEntry {
+                    cf_idx: ColumnFamilyIndex::MetaCF as u32,
+                    op_type: OperateType::Put,
+                    key: encoded_key.into(),
+                    value: Some(encoded_value.into()),
+                }],
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn durable_meta_persists_last_applied_across_restart() {
+        let db_path = unique_test_db_path();
+        let snap_dir = unique_test_db_path();
+        std::fs::create_dir_all(&snap_dir).unwrap();
+
+        let log_store_dir;
+        let db_path_clone = db_path.clone();
+
+        // Phase 1: apply entries and verify durable meta is written.
+        {
+            let mut storage = Storage::new(1, 0);
+            let storage_rx = storage
+                .open(Arc::new(StorageOptions::default()), &db_path)
+                .unwrap();
+            let storage_swap = Arc::new(ArcSwap::from_pointee(storage));
+            let (log_store, dir) = test_log_store();
+            log_store_dir = dir;
+
+            let mut sm = KiwiStateMachine::new(
+                1,
+                Arc::clone(&storage_swap),
+                db_path.clone(),
+                snap_dir.clone(),
+                Arc::new(NoopPauseController),
+                None,
+                log_store.clone(),
+            );
+
+            // Apply 3 entries.
+            let entries = vec![
+                put_entry(1, 1, b"k1", b"v1"),
+                put_entry(2, 1, b"k2", b"v2"),
+                put_entry(3, 1, b"k3", b"v3"),
+            ];
+            let responses = sm.apply(entries).await.unwrap();
+            assert_eq!(responses.len(), 3);
+
+            // Verify durable meta was persisted.
+            let meta = log_store.load_durable_meta().unwrap();
+            assert!(meta.is_some(), "durable meta should exist after apply");
+            let meta = meta.unwrap();
+            assert_eq!(meta.last_applied.map(|l| l.index), Some(3));
+
+            drop(sm);
+            let storage = storage_swap.load_full();
+            drop(storage_swap);
+            let mut storage = Arc::try_unwrap(storage)
+                .ok()
+                .expect("storage should have no remaining references");
+            storage.shutdown().await;
+            storage.close();
+            drop(storage_rx);
+        }
+
+        // Phase 2: reopen from the same log store — durable meta should
+        // restore last_applied without needing a snapshot.
+        {
+            let log_store = RocksdbLogStore::open(log_store_dir.path()).unwrap();
+            let mut storage = Storage::new(1, 0);
+            let _rx = storage
+                .open(Arc::new(StorageOptions::default()), &db_path_clone)
+                .unwrap();
+            let storage_swap = Arc::new(ArcSwap::from_pointee(storage));
+
+            let mut sm = KiwiStateMachine::new(
+                1,
+                Arc::clone(&storage_swap),
+                db_path_clone.clone(),
+                snap_dir.clone(),
+                Arc::new(NoopPauseController),
+                None,
+                log_store.clone(),
+            );
+
+            // applied_state should recover from durable meta.
+            let (last_applied, _membership) = sm.applied_state().await.unwrap();
+            assert_eq!(
+                last_applied.map(|l| l.index),
+                Some(3),
+                "restarted state machine should recover last_applied=3 from durable meta"
+            );
+
+            drop(sm);
+            drop(storage_swap);
+        }
+
+        safe_cleanup_test_db(&db_path_clone);
+    }
+
+    #[tokio::test]
+    async fn durable_meta_survives_snapshot_install() {
+        let src_db = unique_test_db_path();
+        let dst_db = unique_test_db_path();
+        let snap_dir = unique_test_db_path();
+        std::fs::create_dir_all(&snap_dir).unwrap();
+
+        // Build a snapshot from source.
+        let (snap_meta, snap_bytes) = {
+            let mut src = Storage::new(1, 0);
+            let _rx = src
+                .open(Arc::new(StorageOptions::default()), &src_db)
+                .unwrap();
+            src.set(b"src-key", b"src-val").unwrap();
+            let swap = Arc::new(ArcSwap::from_pointee(src));
+            let (ls, _d) = test_log_store();
+            let mut sm = KiwiStateMachine::new(
+                1,
+                Arc::clone(&swap),
+                src_db.clone(),
+                snap_dir.clone(),
+                Arc::new(NoopPauseController),
+                None,
+                ls,
+            );
+
+            // Apply one entry so last_applied = 1.
+            sm.apply(vec![put_entry(1, 1, b"src-key", b"src-val")])
+                .await
+                .unwrap();
+
+            let mut builder = sm.get_snapshot_builder().await;
+            let snap = builder.build_snapshot().await.unwrap();
+            let meta = snap.meta.clone();
+            let bytes = snap.snapshot.into_inner();
+            drop(builder);
+            drop(sm);
+            drop(swap);
+            (meta, bytes)
+        };
+
+        // Install snapshot into target, then verify restart recovery.
+        // Keep the TempDir alive through both phases.
+        let (ls2, ls2_dir) = test_log_store();
+        let ls2_path = ls2_dir.path().to_path_buf();
+        let dst_swap = Arc::new(ArcSwap::from_pointee(Storage::new(1, 0)));
+        let mut sm2 = KiwiStateMachine::new(
+            2,
+            Arc::clone(&dst_swap),
+            dst_db.clone(),
+            snap_dir.clone(),
+            Arc::new(NoopPauseController),
+            None,
+            ls2.clone(),
+        );
+
+        let cursor = Box::new(std::io::Cursor::new(snap_bytes));
+        sm2.install_snapshot(&snap_meta, cursor).await.unwrap();
+
+        // After install, durable meta should reflect the snapshot's last_log_id.
+        let meta = ls2.load_durable_meta().unwrap();
+        assert!(meta.is_some(), "durable meta should exist after snapshot install");
+        let meta = meta.unwrap();
+        assert_eq!(
+            meta.last_applied, snap_meta.last_log_id,
+            "durable meta last_applied should match snapshot last_log_id"
+        );
+
+        // Close the state machine and storage to release RocksDB locks.
+        drop(sm2);
+        let dst_storage = dst_swap.load_full();
+        drop(dst_swap);
+        let mut dst_storage = Arc::try_unwrap(dst_storage)
+            .ok()
+            .expect("dst storage should have no remaining references");
+        dst_storage.shutdown().await;
+        dst_storage.close();
+
+        // Reopen from the same log store directory — applied_state should
+        // recover the installed snapshot's frontier from durable meta.
+        let ls3 = RocksdbLogStore::open(&ls2_path).unwrap();
+        let mut storage = Storage::new(1, 0);
+        let _rx = storage
+            .open(Arc::new(StorageOptions::default()), &dst_db)
+            .unwrap();
+        let swap = Arc::new(ArcSwap::from_pointee(storage));
+        let mut sm3 = KiwiStateMachine::new(
+            2,
+            Arc::clone(&swap),
+            dst_db.clone(),
+            snap_dir.clone(),
+            Arc::new(NoopPauseController),
+            None,
+            ls3,
+        );
+
+        let (last_applied, _membership) = sm3.applied_state().await.unwrap();
+        assert_eq!(
+            last_applied, snap_meta.last_log_id,
+            "restarted state machine should recover snapshot frontier from durable meta"
+        );
+
+        drop(sm3);
+        drop(swap);
+        drop(ls2_dir);
+        safe_cleanup_test_db(&dst_db);
+        safe_cleanup_test_db(&src_db);
+    }
+
+    #[tokio::test]
+    async fn durable_meta_absent_on_fresh_start() {
+        let dir = tempfile::tempdir().unwrap();
+        let ls = RocksdbLogStore::open(dir.path()).unwrap();
+        assert!(
+            ls.load_durable_meta().unwrap().is_none(),
+            "fresh log store should have no durable meta"
+        );
     }
 }

--- a/src/raft/src/state_machine.rs
+++ b/src/raft/src/state_machine.rs
@@ -468,6 +468,33 @@ impl KiwiStateMachine {
     /// Persist the current applied frontier and membership to the Raft log
     /// store so that the state machine can recover its position after restart
     /// without relying on snapshot metadata alone.
+    /// Check whether a recovered `last_applied` sits within the log-store
+    /// boundaries.  Returns `true` if the meta is safe to trust, `false` if it
+    /// is out of range and must be discarded.
+    fn meta_within_log_bounds(
+        last_applied: Option<LogId<u64>>,
+        log_last: Option<LogId<u64>>,
+        log_purged: Option<LogId<u64>>,
+    ) -> bool {
+        let Some(applied) = last_applied else {
+            // No frontier — valid (fresh node).
+            return true;
+        };
+        // last_applied must not exceed the last log entry.
+        if let Some(last) = log_last {
+            if applied.index > last.index {
+                return false;
+            }
+        }
+        // last_applied must not be before the purged boundary.
+        if let Some(purged) = log_purged {
+            if applied.index < purged.index {
+                return false;
+            }
+        }
+        true
+    }
+
     fn persist_durable_meta(&self) -> Result<(), io::Error> {
         let meta = DurableStateMachineMeta::new(self.last_applied, self.last_membership.clone());
         self.log_store
@@ -494,10 +521,13 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
     where
         I: IntoIterator<Item = openraft::Entry<KiwiTypeConfig>> + Send,
     {
+        let apply_start = std::time::Instant::now();
         let _snapshot_state = Arc::clone(&self.snapshot_state_gate).lock_owned().await;
         let mut responses = Vec::new();
+        let mut entry_count: u64 = 0;
 
         for entry in entries {
+            entry_count += 1;
             let log_id = entry.log_id;
 
             let response = match entry.payload {
@@ -536,9 +566,26 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
             responses.push(response);
         }
 
+        // Record apply metrics.
+        let apply_elapsed = apply_start.elapsed();
+        crate::metrics::RAFT_APPLY_DURATION.observe(apply_elapsed.as_secs_f64());
+        crate::metrics::RAFT_APPLY_ENTRIES_PER_BATCH.observe(entry_count as f64);
+
         // Persist the applied frontier so restart can recover without
-        // relying on snapshot metadata alone.
+        // relying on snapshot metadata alone.  Sync the business RocksDB
+        // WAL first so that frontier and business data share the same
+        // durability contract — otherwise a power failure could preserve
+        // the frontier while losing the business batch, causing the node
+        // to permanently skip entries it never actually applied.
         if !responses.is_empty() {
+            let storage = self.storage_swap.load();
+            if let Err(e) = storage.sync_wal() {
+                log::error!("Failed to sync storage WAL before persisting frontier: {e}");
+                return Err(io_err_to_raft(std::io::Error::other(format!(
+                    "sync_wal failed: {e}"
+                ))));
+            }
+            drop(storage);
             self.persist_durable_meta().map_err(io_err_to_raft)?;
         }
 
@@ -742,7 +789,14 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
 
         // Persist the applied frontier derived from the installed snapshot
         // before removing the install marker, so crash recovery sees a
-        // consistent position.
+        // consistent position.  Sync the business WAL first to ensure the
+        // frontier and the restored data share the same durability contract.
+        {
+            let storage = self.storage_swap.load();
+            storage.sync_wal().map_err(|error| {
+                post_marker_error("syncing storage WAL after snapshot install", &error)
+            })?;
+        }
         self.persist_durable_meta().map_err(|error| {
             post_marker_error("persisting durable meta after snapshot install", &error)
         })?;
@@ -785,6 +839,17 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
         if self.last_applied.is_none() {
             let durable = self.log_store.load_durable_meta()?;
             let snapshot = load_current_snapshot(&self.snapshot_work_dir)?;
+            let (log_last, log_purged) = self.log_store.read_log_boundaries()?;
+
+            // Validate durable meta against log-store boundaries.
+            // `last_applied` must sit within [last_purged, last_log_id];
+            // a frontier beyond the log end means the business batch was
+            // lost (e.g. power failure) while the frontier was persisted.
+            let had_durable = durable.is_some();
+            let durable_valid = durable.as_ref().map_or(true, |meta| {
+                Self::meta_within_log_bounds(meta.last_applied, log_last, log_purged)
+            });
+            let durable = if durable_valid { durable } else { None };
 
             match (durable, snapshot) {
                 (Some(meta), Some(snap)) => {
@@ -820,15 +885,44 @@ impl RaftStateMachine<KiwiTypeConfig> for KiwiStateMachine {
                     );
                 }
                 (None, Some(snap)) => {
+                    // Either no durable meta, or it was out-of-bounds and
+                    // discarded.  Fall back to the snapshot frontier.
+                    if had_durable && !durable_valid {
+                        log::warn!(
+                            "Durable meta failed log-boundary validation \
+                             (last_log_id={:?}, last_purged={:?}); falling back to snapshot",
+                            log_last,
+                            log_purged
+                        );
+                    }
                     self.last_applied = snap.meta.last_log_id;
                     self.last_membership = snap.meta.last_membership.clone();
                     log::info!(
-                        "Recovered last_applied={:?} from persisted snapshot (no durable meta)",
-                        self.last_applied
+                        "Recovered last_applied={:?} from persisted snapshot{}",
+                        self.last_applied,
+                        if had_durable && !durable_valid {
+                            " (durable meta rejected)"
+                        } else {
+                            " (no durable meta)"
+                        }
                     );
                 }
                 (None, None) => {
-                    log::info!("No durable meta or snapshot found; starting from scratch");
+                    if had_durable {
+                        // Durable meta existed but was out-of-bounds and no
+                        // snapshot is available.  Start from scratch — the
+                        // Raft leader will send a snapshot to bring this node
+                        // up to date.
+                        log::warn!(
+                            "Durable meta failed log-boundary validation \
+                             (last_log_id={:?}, last_purged={:?}) and no snapshot available; \
+                             starting from scratch",
+                            log_last,
+                            log_purged
+                        );
+                    } else {
+                        log::info!("No durable meta or snapshot found; starting from scratch");
+                    }
                 }
             }
         }

--- a/src/raft/tests/snapshot_logindex_test.rs
+++ b/src/raft/tests/snapshot_logindex_test.rs
@@ -84,8 +84,8 @@ fn noop_pause_controller() -> Arc<dyn PauseController> {
 
 fn test_log_store() -> (raft::log_store_rocksdb::RocksdbLogStore, tempfile::TempDir) {
     let dir = tempfile::tempdir().expect("temp dir for log store");
-    let store =
-        raft::log_store_rocksdb::RocksdbLogStore::open(dir.path()).expect("test log store should open");
+    let store = raft::log_store_rocksdb::RocksdbLogStore::open(dir.path())
+        .expect("test log store should open");
     (store, dir)
 }
 

--- a/src/raft/tests/snapshot_logindex_test.rs
+++ b/src/raft/tests/snapshot_logindex_test.rs
@@ -82,6 +82,13 @@ fn noop_pause_controller() -> Arc<dyn PauseController> {
     Arc::new(NoopPauseController)
 }
 
+fn test_log_store() -> (raft::log_store_rocksdb::RocksdbLogStore, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("temp dir for log store");
+    let store =
+        raft::log_store_rocksdb::RocksdbLogStore::open(dir.path()).expect("test log store should open");
+    (store, dir)
+}
+
 #[tokio::test]
 async fn test_snapshot_with_logindex_state() -> anyhow::Result<()> {
     let src_db_path = unique_test_db_path();
@@ -135,6 +142,7 @@ async fn test_snapshot_with_logindex_state() -> anyhow::Result<()> {
 
         // Create state machine and build snapshot
         let storage_swap = Arc::new(ArcSwap::from(Arc::clone(&storage)));
+        let (log_store, _log_store_dir) = test_log_store();
         let mut sm = KiwiStateMachine::new(
             1,
             storage_swap,
@@ -142,6 +150,7 @@ async fn test_snapshot_with_logindex_state() -> anyhow::Result<()> {
             snap_root.clone(),
             noop_pause_controller(),
             None,
+            log_store,
         );
 
         let mut builder = sm.get_snapshot_builder().await;
@@ -175,6 +184,7 @@ async fn test_snapshot_with_logindex_state() -> anyhow::Result<()> {
     let target_storage = Arc::new(Storage::new(1, 0));
     let target_swap = Arc::new(ArcSwap::from(target_storage));
 
+    let (log_store2, _log_store_dir2) = test_log_store();
     let mut sm2 = KiwiStateMachine::new(
         2,
         target_swap.clone(),
@@ -182,6 +192,7 @@ async fn test_snapshot_with_logindex_state() -> anyhow::Result<()> {
         snap_root,
         noop_pause_controller(),
         None,
+        log_store2,
     );
 
     sm2.install_snapshot(&meta, Box::new(std::io::Cursor::new(bytes)))

--- a/src/raft/tests/snapshot_roundtrip_test.rs
+++ b/src/raft/tests/snapshot_roundtrip_test.rs
@@ -164,8 +164,8 @@ fn noop_pause_controller() -> Arc<dyn PauseController> {
 
 fn test_log_store() -> (raft::log_store_rocksdb::RocksdbLogStore, tempfile::TempDir) {
     let dir = tempfile::tempdir().expect("temp dir for log store");
-    let store =
-        raft::log_store_rocksdb::RocksdbLogStore::open(dir.path()).expect("test log store should open");
+    let store = raft::log_store_rocksdb::RocksdbLogStore::open(dir.path())
+        .expect("test log store should open");
     (store, dir)
 }
 

--- a/src/raft/tests/snapshot_roundtrip_test.rs
+++ b/src/raft/tests/snapshot_roundtrip_test.rs
@@ -162,6 +162,37 @@ fn noop_pause_controller() -> Arc<dyn PauseController> {
     Arc::new(NoopPauseController)
 }
 
+fn test_log_store() -> (raft::log_store_rocksdb::RocksdbLogStore, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("temp dir for log store");
+    let store =
+        raft::log_store_rocksdb::RocksdbLogStore::open(dir.path()).expect("test log store should open");
+    (store, dir)
+}
+
+/// Create a `KiwiStateMachine` with a temporary log store for testing.
+/// Returns `(state_machine, log_store_dir)` — the caller must keep
+/// `log_store_dir` alive for the duration of the test.
+fn test_state_machine(
+    node_id: u64,
+    storage_swap: Arc<ArcSwap<Storage>>,
+    db_path: std::path::PathBuf,
+    snapshot_work_dir: std::path::PathBuf,
+    pause_controller: Arc<dyn PauseController>,
+    append_log_fn: Option<Arc<OnceLock<storage::AppendLogFn>>>,
+) -> (KiwiStateMachine, tempfile::TempDir) {
+    let (log_store, log_store_dir) = test_log_store();
+    let sm = KiwiStateMachine::new(
+        node_id,
+        storage_swap,
+        db_path,
+        snapshot_work_dir,
+        pause_controller,
+        append_log_fn,
+        log_store,
+    );
+    (sm, log_store_dir)
+}
+
 #[tokio::test]
 async fn active_storage_access_permit_blocks_pause() {
     let controller = Arc::new(TestPauseController::default());
@@ -236,7 +267,7 @@ async fn snapshot_builder_blocks_install_operation() {
         .expect("test should write snapshot data");
     let target_swap = Arc::new(ArcSwap::from_pointee(storage));
     let controller = Arc::new(TestPauseController::default());
-    let mut state_machine = KiwiStateMachine::new(
+    let (mut state_machine, _log_store_dir1) = test_state_machine(
         1,
         Arc::clone(&target_swap),
         db_path.clone(),
@@ -325,7 +356,7 @@ async fn aborted_install_before_marker_resumes_and_preserves_live_storage() -> a
 
     let target_swap = Arc::new(ArcSwap::from_pointee(storage));
     let controller = Arc::new(TestPauseController::default());
-    let mut state_machine = KiwiStateMachine::new(
+    let (mut state_machine, _log_store_dir2) = test_state_machine(
         1,
         Arc::clone(&target_swap),
         db_path.clone(),
@@ -421,7 +452,7 @@ async fn cursor_snapshot_roundtrip() -> anyhow::Result<()> {
 
     let storage_swap = Arc::new(ArcSwap::from(storage.clone()));
 
-    let mut sm = KiwiStateMachine::new(
+    let (mut sm, _log_store_dir3) = test_state_machine(
         1,
         storage_swap.clone(),
         src_db_path.clone(),
@@ -455,7 +486,7 @@ async fn cursor_snapshot_roundtrip() -> anyhow::Result<()> {
     // the normal open flow. The storage is opened after install_snapshot completes.
     let target_storage = Arc::new(Storage::new(1, 0));
     let target_swap = Arc::new(ArcSwap::from(target_storage.clone()));
-    let mut sm2 = KiwiStateMachine::new(
+    let (mut sm2, _log_store_dir4) = test_state_machine(
         2,
         target_swap.clone(),
         restore_db_path.clone(),
@@ -510,7 +541,7 @@ async fn install_snapshot_with_existing_data() -> anyhow::Result<()> {
 
     // Build snapshot from source
     let source_swap = Arc::new(ArcSwap::from(source_storage.clone()));
-    let mut sm_source = KiwiStateMachine::new(
+    let (mut sm_source, _log_store_dir5) = test_state_machine(
         1,
         source_swap.clone(),
         src_db_path.clone(),
@@ -541,7 +572,7 @@ async fn install_snapshot_with_existing_data() -> anyhow::Result<()> {
     // Install the snapshot - this should REPLACE the old data.
     let target_storage = Arc::new(Storage::new(1, 0));
     let target_swap = Arc::new(ArcSwap::from(target_storage.clone()));
-    let mut sm_target = KiwiStateMachine::new(
+    let (mut sm_target, _log_store_dir6) = test_state_machine(
         2,
         target_swap.clone(),
         restore_db_path.clone(),
@@ -592,7 +623,7 @@ async fn install_snapshot_rearms_append_log_hook() -> anyhow::Result<()> {
     source_storage.set(b"snap_key", b"snap_value")?;
 
     let source_swap = Arc::new(ArcSwap::from(source_storage.clone()));
-    let mut source_sm = KiwiStateMachine::new(
+    let (mut source_sm, _log_store_dir7) = test_state_machine(
         1,
         source_swap.clone(),
         src_db_path.clone(),
@@ -622,7 +653,7 @@ async fn install_snapshot_rearms_append_log_hook() -> anyhow::Result<()> {
 
     let target_storage = Arc::new(Storage::new(1, 0));
     let target_swap = Arc::new(ArcSwap::from(target_storage.clone()));
-    let mut target_sm = KiwiStateMachine::new(
+    let (mut target_sm, _log_store_dir8) = test_state_machine(
         2,
         target_swap.clone(),
         restore_db_path.clone(),
@@ -675,7 +706,7 @@ async fn install_snapshot_replaces_open_target_storage() -> anyhow::Result<()> {
     source_storage.set(b"snapshot_key", b"snapshot_value")?;
 
     let source_swap = Arc::new(ArcSwap::from(source_storage.clone()));
-    let mut source_sm = KiwiStateMachine::new(
+    let (mut source_sm, _log_store_dir9) = test_state_machine(
         1,
         source_swap.clone(),
         src_db_path.clone(),
@@ -706,7 +737,7 @@ async fn install_snapshot_replaces_open_target_storage() -> anyhow::Result<()> {
 
     let target_swap = Arc::new(ArcSwap::from_pointee(target_storage));
     let pause_controller = Arc::new(TestPauseController::default());
-    let mut target_sm = KiwiStateMachine::new(
+    let (mut target_sm, _log_store_dir10) = test_state_machine(
         2,
         target_swap.clone(),
         restore_db_path.clone(),
@@ -768,7 +799,7 @@ async fn install_snapshot_replaces_open_target_storage() -> anyhow::Result<()> {
     assert!(reopened.get(b"stale_key").is_err());
 
     let reopened_swap = Arc::new(ArcSwap::from(reopened.clone()));
-    let mut reopened_sm = KiwiStateMachine::new(
+    let (mut reopened_sm, _log_store_dir11) = test_state_machine(
         2,
         reopened_swap.clone(),
         restore_db_path.clone(),
@@ -815,7 +846,7 @@ async fn install_snapshot_stays_paused_after_destructive_failure() -> anyhow::Re
     source_storage.set(b"snapshot_key", b"snapshot_value")?;
 
     let source_swap = Arc::new(ArcSwap::from(source_storage.clone()));
-    let mut source_sm = KiwiStateMachine::new(
+    let (mut source_sm, _log_store_dir12) = test_state_machine(
         1,
         source_swap.clone(),
         src_db_path.clone(),
@@ -845,7 +876,7 @@ async fn install_snapshot_stays_paused_after_destructive_failure() -> anyhow::Re
 
     let target_swap = Arc::new(ArcSwap::from_pointee(target_storage));
     let pause_controller = Arc::new(TestPauseController::default());
-    let mut target_sm = KiwiStateMachine::new(
+    let (mut target_sm, _log_store_dir13) = test_state_machine(
         2,
         target_swap.clone(),
         restore_db_path.clone(),
@@ -964,7 +995,7 @@ async fn install_snapshot_stays_paused_when_restore_parent_sync_fails_after_rena
     source_storage.set(b"snapshot_key", b"snapshot_value")?;
 
     let source_swap = Arc::new(ArcSwap::from(source_storage.clone()));
-    let mut source_sm = KiwiStateMachine::new(
+    let (mut source_sm, _log_store_dir14) = test_state_machine(
         1,
         source_swap.clone(),
         src_db_path.clone(),
@@ -990,7 +1021,7 @@ async fn install_snapshot_stays_paused_when_restore_parent_sync_fails_after_rena
 
     let target_swap = Arc::new(ArcSwap::from_pointee(target_storage));
     let pause_controller = Arc::new(TestPauseController::default());
-    let mut target_sm = KiwiStateMachine::new(
+    let (mut target_sm, _log_store_dir15) = test_state_machine(
         2,
         target_swap.clone(),
         restore_db_path.clone(),
@@ -1100,7 +1131,7 @@ async fn install_snapshot_resumes_after_pre_restore_failure() -> anyhow::Result<
 
     let target_swap = Arc::new(ArcSwap::from_pointee(target_storage));
     let pause_controller = Arc::new(TestPauseController::default());
-    let mut target_sm = KiwiStateMachine::new(
+    let (mut target_sm, _log_store_dir16) = test_state_machine(
         2,
         target_swap.clone(),
         restore_db_path.clone(),
@@ -1163,7 +1194,7 @@ async fn snapshot_incarnation_mismatch_does_not_pause_or_replace_live_storage() 
     };
     source_storage.set(b"snapshot_key", b"snapshot_value")?;
     let source_swap = Arc::new(ArcSwap::from(source_storage.clone()));
-    let mut source_sm = KiwiStateMachine::new(
+    let (mut source_sm, _log_store_dir17) = test_state_machine(
         1,
         source_swap.clone(),
         src_db_path.clone(),
@@ -1195,7 +1226,7 @@ async fn snapshot_incarnation_mismatch_does_not_pause_or_replace_live_storage() 
     target_storage.set(b"stale_key", b"stale_value")?;
     let target_swap = Arc::new(ArcSwap::from_pointee(target_storage));
     let pause_controller = Arc::new(TestPauseController::default());
-    let mut target_sm = KiwiStateMachine::new(
+    let (mut target_sm, _log_store_dir18) = test_state_machine(
         2,
         target_swap.clone(),
         restore_db_path.clone(),
@@ -1252,7 +1283,7 @@ async fn missing_checkpoint_instance_does_not_pause_or_replace_live_storage() ->
     };
     source_storage.set(b"snapshot_key", b"snapshot_value")?;
     let source_swap = Arc::new(ArcSwap::from(source_storage.clone()));
-    let mut source_sm = KiwiStateMachine::new(
+    let (mut source_sm, _log_store_dir19) = test_state_machine(
         1,
         source_swap.clone(),
         src_db_path.clone(),
@@ -1275,7 +1306,7 @@ async fn missing_checkpoint_instance_does_not_pause_or_replace_live_storage() ->
     target_storage.set(b"stale_key", b"stale_value")?;
     let target_swap = Arc::new(ArcSwap::from_pointee(target_storage));
     let pause_controller = Arc::new(TestPauseController::default());
-    let mut target_sm = KiwiStateMachine::new(
+    let (mut target_sm, _log_store_dir20) = test_state_machine(
         2,
         target_swap.clone(),
         restore_db_path.clone(),

--- a/src/storage/src/storage_impl.rs
+++ b/src/storage/src/storage_impl.rs
@@ -881,6 +881,21 @@ impl Storage {
         Ok(())
     }
 
+    /// Sync the WAL of every underlying RocksDB instance to disk.
+    ///
+    /// Called by the Raft state machine after a successful business apply and
+    /// *before* publishing the advanced `last_applied` frontier, so that the
+    /// frontier and the business data share the same durability contract.
+    pub fn sync_wal(&self) -> Result<()> {
+        use snafu::ResultExt;
+        for inst in &self.insts {
+            if let Some(db) = inst.db() {
+                db.flush_wal(true).context(crate::error::RocksSnafu)?;
+            }
+        }
+        Ok(())
+    }
+
     /// Return a random key from the database
     pub fn randomkey(&self) -> Result<Option<String>> {
         // Try each instance until we find a key


### PR DESCRIPTION
## Summary

Define and persist `DurableStateMachineMeta` so that node restart, snapshot install and log replay recover from a verified applied frontier without relying on snapshot metadata alone.

Closes #334

## Changes

- **New file**: `src/raft/src/durable_meta.rs` — `DurableStateMachineMeta` struct (versioned, serde JSON)
- **`log_store_rocksdb.rs`**: `save_durable_meta()` / `load_durable_meta()` methods, stored in `state_cf` (same column family as vote/committed)
- **`state_machine.rs`**:
  - `KiwiStateMachine` gains a `log_store` field
  - `apply()` persists durable meta after each successful apply
  - `install_snapshot()` persists durable meta before removing the install marker
  - `applied_state()` recovers from durable meta first, falls back to snapshot metadata
- **`node.rs`**: Open log store before creating state machine so it can be passed in
- **Tests**: 3 new tests covering restart recovery, snapshot install survival, and fresh start

## Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Storage location | Raft log store `state_cf` | Same RocksDB as vote/committed, no new CF or file |
| Persist frequency | After each apply + snapshot install | Issue requirement: no memory defaults for recovery |
| Format | JSON + version field | Consistent with existing snapshot markers |
| Cross-validation | Startup only, take most conservative value | Replay is idempotent; skip is not safe |

## Verification

- `cargo check --package raft --tests` ✅
- `cargo clippy --package raft --tests` ✅ (no warnings)
- Linker error on `cargo test` is a pre-existing RocksDB C++ issue on main branch

## Related

- Parent: #332
- Blocks: #335, #337
- Raft design: Discussion #330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable Raft metadata storage for applied log progress and cluster membership.
  * Added format-version validation and compatibility checks for persisted metadata.
  * Added recovery support from durable metadata or snapshots after restart.
  * Persisted state-machine progress after log application and snapshot installation.
  * Added reliable log-boundary tracking and synchronous WAL synchronization.

* **Bug Fixes**
  * Improved restart and snapshot recovery reliability by validating persisted progress against retained logs.
  * Improved handling of missing, corrupted, or incompatible recovery metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->