### PR TITLE
docs: close out WP8 governance

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -23,7 +23,7 @@
 [advisories]
 ignore = [
   # RUSTSEC-2026-0235: rkyv 0.7.46
-  # owner: WP8 / Issue #421
+  # owner: security-deps / Issue #430
   # potential_path: openraft -> byte-unit -> rust_decimal
   # current_status: unreachable optional dependency
   # Evidence: the locked offline all-targets all-features inverse tree is empty.

--- a/.planning/SDD.md
+++ b/.planning/SDD.md
@@ -4,10 +4,10 @@ title: Kiwi 架构设计与 SDD 开发计划
 status: accepted-design
 authority: sole-project-entry
 version: 4
-updated_at: 2026-08-11
+updated_at: 2026-08-19
 baseline_repository: arana-db/kiwi
 baseline_branch: main
-baseline_ref: 733888fc90ad8ef039947e87b08d7500a405954a
+baseline_ref: 9a8a64aca12a825912f299450e10fc6043eca610
 wp0_pr_number: 414
 wp0_pr_base_ref: 0c4795ec716299598686fc7c5e0fac03a30e044d
 wp0_pr_head_ref: e2bfc7deb481590a757f0034874b7f21a4a31aa2
@@ -16,18 +16,26 @@ wp0_merge_ref: 9820162ebdf2d26aa6349e704efe8737b2e73e4a
 wp0_exact_main_verification_ref: 688d905fec31b54aec76f36676f55efd8b5cfa17
 wp0_exact_main_verification_run: 30801285622
 wp0_exact_main_verification_status: passed
-github_snapshot_at: 2026-08-06T04:36:21Z
+wp8_pr_number: 422
+wp8_pr_base_ref: 733888fc90ad8ef039947e87b08d7500a405954a
+wp8_pr_head_ref: 2b03219cdd5e452e08c1b2144c3c90516190d41f
+wp8_merge_parent_ref: 733888fc90ad8ef039947e87b08d7500a405954a
+wp8_merge_ref: 9a8a64aca12a825912f299450e10fc6043eca610
+wp8_exact_main_verification_ref: 9a8a64aca12a825912f299450e10fc6043eca610
+wp8_exact_main_verification_run: 32129266046
+wp8_exact_main_verification_status: passed
+github_snapshot_at: 2026-08-19T07:28:08Z
 redis_oracle_tag: 8.8.1
 redis_oracle_ref: 77b6c308396c9700672390a210143a8496fb4b10
 required_runtime_mode: cache-off
 executable_scope: M0-M6
 long_term_scope: M0-M10
 current_work_package: WP8
-current_work_package_status: in-progress
-current_plan: docs/superpowers/plans/2026-08-07-vector-set-post-merge-remediation.md
+current_work_package_status: accepted
+current_plan: docs/superpowers/plans/2026-08-19-wp8-issue-closeout.md
 current_issue: 421
 current_pr: 422
-next_safe_action: execute-wp8-runtime-raw-resp-client-red-tests
+next_safe_action: await-next-authorized-work-package
 ---
 
 # Kiwi 架构设计与 SDD 开发计划
@@ -162,27 +170,22 @@ M7 到 M10 进入长期架构，但不进入当前实现：
 | D | Discussion、RFC、Proposal | 设计输入，必须显式采纳 |
 | E | 历史计划、旧周报、过期 Issue、草稿 | 背景，不形成当前任务 |
 
-### 3.2 2026-08-06T04:36:21Z 实时快照
+### 3.2 2026-08-19T07:28:08Z 实时快照
 
 - Repository：arana-db/kiwi。
 - Default branch：main。
-- main：733888fc90ad8ef039947e87b08d7500a405954a。
-- Open Issues：64；#415 是 WP1 Oracle provenance 实施 Issue，#418 跟踪 Vector differential，#421 是 WP8 primary Issue。
-- Discussions：18，其中 1 个关闭，没有 accepted answer。
-- PR #409：MERGED，对应 merge commit 0c4795ec716299598686fc7c5e0fac03a30e044d。
-- Issue #407：CLOSED，关闭时间 2026-08-02T04:44:40Z。
-- PR #412：MERGED，Head 9d1f83360eb52ed23b48b2e5cb1159c93e26e7af，merge commit cbcbadc27068634d851ab0ed63989d2214ab2408；Issue #143 已关闭。
+- main：9a8a64aca12a825912f299450e10fc6043eca610。
 - PR #414：MERGED，base 0c4795ec716299598686fc7c5e0fac03a30e044d，Head e2bfc7deb481590a757f0034874b7f21a4a31aa2，merge commit 9820162ebdf2d26aa6349e704efe8737b2e73e4a；Issue #413 已关闭。
 - PR #417：MERGED，merge commit 688d905fec31b54aec76f36676f55efd8b5cfa17；其 main push CI run 30801285622 成功，完成 WP0 exact-main verification。
 - PR #356：MERGED，最终 Head 4e404b61cec1ece8f8750e0a0631839cce7f4ddc，merge commit 733888fc90ad8ef039947e87b08d7500a405954a；VectorSet Phase 1 已进入当前主线。
-- main commit 733888fc90ad8ef039947e87b08d7500a405954a 的 push CI run 31070395799、CodeQL run 31070395803 和 Benchmark run 31070395773 已成功；这些 job 没有执行 Trusted Vector differential 或 required 三节点 Vector cluster gate。
-- PR #261：OPEN，Head fb092812234a54ad3757d35a62ad033136e422c7，GitHub 当前返回 mergeable/mergeStateStatus UNKNOWN，属于长期滞留 PR。
+- PR #422：MERGED，Base 733888fc90ad8ef039947e87b08d7500a405954a，最终 Head 2b03219cdd5e452e08c1b2144c3c90516190d41f，merge commit 9a8a64aca12a825912f299450e10fc6043eca610；其 main push `ci` run 32129266046 成功。
+- Issue #415 已关闭；Issue #418、#421 和 #430 保持 OPEN。#418 持有 Vector compatibility residual differences，#430 持有 `RUSTSEC-2026-0235` advisory 生命周期。
 
 该快照只用于编制本版本。开始任一工作包、创建 PR、复审或验收前必须重新查询实时状态。
 
 ### 3.3 开放 Issue 分类
 
-当前 64 个开放 Issue 继续按 SDD 用途分类；数量会随实时状态变化，不作为工作包授权：
+开放 Issue 继续按 SDD 用途分类；数量会随实时状态变化，不作为工作包授权：
 
 | 分类 | 处理 |
 |---|---|
@@ -218,9 +221,10 @@ Issue 数量和分类会变化，工作包只依赖明确列出的 Issue，不�
 | Graceful shutdown | [#408](https://github.com/arana-db/kiwi/issues/408) | WP3 child |
 | Real INFO state | [#410](https://github.com/arana-db/kiwi/issues/410) | WP7 related |
 | SDD control plane | [#413](https://github.com/arana-db/kiwi/issues/413) | WP0 primary |
-| Trusted Redis Oracle | [#415](https://github.com/arana-db/kiwi/issues/415) | WP1 implementation dependency；WP8 full-scope PR 内闭环 |
-| Vector differential | [#418](https://github.com/arana-db/kiwi/issues/418) | WP8 related |
+| Trusted Redis Oracle | [#415](https://github.com/arana-db/kiwi/issues/415) | WP8 内闭环并关闭，作为历史实现证据 |
+| Vector differential | [#418](https://github.com/arana-db/kiwi/issues/418) | OPEN；持有 Vector compatibility residual differences |
 | VectorSet lifecycle | [#421](https://github.com/arana-db/kiwi/issues/421) | WP8 primary |
+| rkyv advisory exception | [#430](https://github.com/arana-db/kiwi/issues/430) | OPEN；持有 `RUSTSEC-2026-0235` 和 feature-graph sentinel 生命周期 |
 
 [Issue #407](https://github.com/arana-db/kiwi/issues/407) 已关闭，
 [PR #409](https://github.com/arana-db/kiwi/pull/409) 已合并。后续只对账剩余
@@ -325,8 +329,8 @@ flowchart LR
 
 - RocksDB 是业务数据、类型、编码和 TTL etime 的唯一持久化权威。
 - 主数据库使用七个 CF：default/meta/string、hash、set、list、zset-data、zset-score、vector-data。
-- CF 名称、index、comparator、compaction filter、batch 路由和 Raft checkpoint 列表分散硬编码。
-- 当前每个 instance 有只保存 version、storage incarnation 和 next generation 的 StorageManifest v1；它尚不能表达全局 topology、CF/comparator/codec、snapshot compatibility 和可恢复 migration。
+- PR #422 已将当前七 CF 的名称/index、comparator、compaction filter、batch 路由、Raft checkpoint、snapshot、TTL、compaction 和枚举消费者纳入单一 manifest closure checker；WP8 的 Vector CF consumer gap 已闭合，WP2 后续新增格式、CF 或消费者时仍必须重新证明闭包。
+- PR #422 已实现 Root/Instance StorageManifest v2，并完成真实 Base 六 CF→七 CF、Vector-v1 七 CF manifest v1→v2 staged migration、phase interruption/retry/reopen 和受控 rollback pairing；WP2/WP5 后续 StorageManifest、topology 或恢复格式演进仍需新增兼容与迁移证据。
 - ExpirationManager 是进程内索引，启动时不从 RocksDB 重建。
 - CompactSpecificKey 当前只记录日志并返回成功，未执行真实物理清理。
 
@@ -337,15 +341,15 @@ flowchart LR
 - Raft log、vote 和 committed state 使用普通 RocksDB write/put 后即确认完成，尚缺显式 stable-storage 语义证明。
 - Snapshot install 已有 staged restore、pause、install marker、RocksDB reopen 和切换骨架。
 - Snapshot archive 当前完整驻留内存。
-- Snapshot writer 当前使用 v2，reader 拒绝真实 Base v1 和未来版本；Base v1 compatibility、install phase recovery 和完整 manifest pairing 尚未闭合。
+- PR #422 已验证 Base v1 snapshot/legacy profile 到 Head v2 的正向兼容、SnapshotInstallMarker phase recovery、manifest/source-profile pairing，以及未知未来 manifest、snapshot 和 source profile 拒绝；WP8 scoped 版本矩阵已闭合，WP2/WP5 后续 snapshot 或恢复格式演进仍需保持已知历史版本正向与未知未来版本负向证明。
 
 ### 4.5 当前生命周期和验证事实
 
 - RuntimeManager 当前先停止 storage runtime，再停止 network runtime。
 - network、StorageServer、cluster gRPC 和 Raft bridge 的长期任务没有统一 supervisor。
 - Storage 到 Raft bridge 使用无界 channel。
-- Redis 8.8.1 compatibility manifest 已登记 Vector 命令和 known differences，但正常 CI 排除 Vector differential，尚无可信 Oracle 执行证据。
-- CI 尚未形成完整 Oracle、raw RESP differential、TCL、deterministic Raft simulator、process crash matrix 和真实磁盘 upgrade/rollback 矩阵。
+- PR #422 已在 required Linux CI 中使用可信 Redis 8.8.1 独立重建 Oracle 非零执行 Vector raw RESP2/RESP3 differential、final-state validation 和三节点 fail-closed gate；manifest 继续显式登记尚未解除的 compatibility differences。
+- 更广泛的全命令 TCL、deterministic Raft simulator、process crash matrix 和 M6 级故障证据仍由 WP1、WP6、WP7 管理，不能由 WP8 的 Vector scoped 证据替代。
 - Embedded Redis Hot Tier 当前没有生产依赖、loader、FFI 或 Cache ON 数据路径。
 
 ## 5. 目标系统架构
@@ -500,12 +504,12 @@ Standalone 和 Cluster 不能形成两套 Redis 可观察语义、磁盘格式�
 | `INV-09` | 所有长期任务必须有 owner、cancellation token、JoinHandle 和确定性 join。 | 多个长期任务仍由裸 `tokio::spawn` 启动。 | owner、取消和 join 责任未统一。 | WP3 | lifecycle registry 和退出测试证明无 detached task。 |
 | `INV-10` | shutdown 必须先停止 admission，再 drain 依赖，最后关闭 RocksDB。 | 当前 manager 先停止 storage，再停止 network。 | 关闭顺序与依赖方向相反。 | WP3 | 并发 shutdown 测试证明 admission→drain→RocksDB 顺序。 |
 | `INV-11` | persisted etime 是 TTL 权威；内存索引只能是可丢失优化。 | etime 已持久化，expiration manager 是辅助索引。 | restart、compaction、generation 和 stale-index 证据不足。 | WP5 | 删除内存索引后重建、重启和 TTL differential 通过。 |
-| `INV-12` | 所有 CF 消费者由同一可验证 manifest 闭合。 | VectorDataCF 已加入，当前 per-instance manifest v1 只保存 incarnation/generation，CF 列表仍分散在创建、扫描、TTL、compaction 和 snapshot 路径。 | 缺少 Root/Instance manifest v2 和消费者闭包检查。 | WP2、WP8 | manifest consumer-closure checker 和新增 CF 变异测试通过。 |
-| `INV-13` | 未知 disk、snapshot、comparator 或 manifest 版本默认 fail closed。 | snapshot v2 和 marker 对未知版本 fail closed，但真实 Base v1 snapshot 尚未进入显式兼容范围。 | 已知历史版本兼容与未知未来版本拒绝需要同时证明。 | WP2、WP5、WP8 | Base v1 正向恢复和未知/未来版本负向测试通过。 |
+| `INV-12` | 所有 CF 消费者由同一可验证 manifest 闭合。 | PR #422 已把当前七 CF、Root/Instance StorageManifest v2、checkpoint/snapshot、TTL、compaction 和枚举消费者纳入单一 manifest closure checker。 | WP8 的当前 Vector CF gap 已闭合；未来 WP2 新增格式、CF 或消费者时仍必须重新证明闭包。 | WP2、WP8 | manifest consumer-closure checker 和新增 CF 变异测试通过。 |
+| `INV-13` | 未知 disk、snapshot、comparator 或 manifest 版本默认 fail closed。 | PR #422 已验证真实 Base v1 snapshot/legacy profile 正向迁移，以及未知未来 manifest、snapshot 和 source profile 拒绝。 | WP8 scoped 版本矩阵已闭合；WP2/WP5 后续格式演进仍需保持已知历史版本正向与未知未来版本负向证明。 | WP2、WP5、WP8 | Base v1 正向恢复和未知/未来版本负向测试通过。 |
 | `INV-14` | Snapshot build、install、普通 apply、reopen 和 shutdown 必须由同一 gate 建立顺序。 | 各路径有局部锁和 staged install。 | 缺少覆盖全部状态转换的统一 gate。 | WP3、WP5 | 并发 build/install/apply/reopen/shutdown 矩阵无竞态和旧状态可见。 |
 | `INV-15` | 旧 Storage、Redis、DB、CF、iterator 或 snapshot handle 不得跨 reopen/swap 继续使用。 | reopen 和 install 会替换部分顶层对象。 | 跨层缓存 handle 的失效证明不足。 | WP2、WP5 | generation/handle 负向测试证明旧对象全部拒绝使用。 |
 | `INV-16` | 每个 Binlog 必须有明确 db、instance、slot/group 和 generation 语义。 | db_id 固定为 0，slot 从 key 推导，instance 由本机 topology 推导，缺少 group/generation。 | replay、迁移和 stale generation 语义未定义。 | WP2、WP4、WP5 | 编码 round-trip、cluster replay 和 generation rejection 通过。 |
-| `INV-17` | Redis 兼容结论必须来自固定 Oracle、raw response 和最终状态的可复现实验。 | 已固定 Redis 8.8.1 tag/commit 和 provenance 合同。 | Vector differential 被正常 CI 排除，独立重建和 runtime identity 尚未完成。 | WP1、WP6、WP7、WP8 | exact Oracle 重建 hash equality、raw RESP2/RESP3 differential 与兼容矩阵通过。 |
+| `INV-17` | Redis 兼容结论必须来自固定 Oracle、raw response 和最终状态的可复现实验。 | PR #422 exact-main run 32129266046 已绑定 Redis 8.8.1 exact source、独立重建 hash equality、runtime identity、raw RESP2/RESP3 frame、final state 和固定 Vector required registry。 | Vector scoped gap 已闭合；更广泛的 Redis Core/TCL/fault coverage 仍属于 WP1、WP6、WP7。 | WP1、WP6、WP7、WP8 | exact Oracle 重建 hash equality、raw RESP2/RESP3 differential 与兼容矩阵通过。 |
 | `INV-18` | 非幂等写结果未知时标记 SUBMIT_UNKNOWN，不盲目重试。 | 当前没有端到端 typed SUBMIT_UNKNOWN，相关失败压成通用错误。 | 断线、超时和提交后响应丢失仍可能混同普通失败。 | WP4、WP7 | fault history 区分 safe failure、success 和 SUBMIT_UNKNOWN。 |
 | `INV-19` | INFO 和 metrics 只消费真实 provider，不维护硬编码影子状态。 | INFO 仍包含硬编码版本、平台、PID、端口和 uptime。 | runtime、storage 和 Raft provider 未闭合。 | WP7 | provider contract 测试和真实进程 INFO/metrics 对账通过。 |
 | `INV-20` | M6 前 Embedded Redis Hot Tier 保持 frozen。 | D009 和当前 scope 已冻结 M7/M8 热层实施，生产路径中不存在 Hot Tier。 | 无实现 Gap；必须持续防止实现 PR 隐式解除冻结。 | WP7 | M6 gate、用户批准和新 Decision 同时存在后才可解除。 |
@@ -1416,21 +1420,28 @@ Requirement：
 
 ### WP8：VectorSet 合并后生命周期、兼容性与门禁闭环
 
-状态：in-progress。
+状态：accepted。
 
 Primary Issue handling：
 
 - Primary Issue：[#421](https://github.com/arana-db/kiwi/issues/421)。
 - [PR #356](https://github.com/arana-db/kiwi/pull/356) 是已合并事实和缺口来源，不作为当前开放 Issue。
-- 只有 #415、#418、#421 的 required acceptance 与本工作包退出门禁全部闭合时，聚合 PR 才能使用 `Fixes`。
+- PR #422 已完成 WP8 required acceptance；#415 已关闭，仍有效的 compatibility differences 由 OPEN #418 持有，`RUSTSEC-2026-0235` advisory 生命周期由 OPEN #430 持有。治理 PR 在新的 exact-main 成功前继续使用 `Refs #421`，不得提前自动关闭 primary Issue。
 
 Implementation PR：[#422](https://github.com/arana-db/kiwi/pull/422)。
+
+合并证据：
+
+- PR 固定区间：733888fc90ad8ef039947e87b08d7500a405954a..2b03219cdd5e452e08c1b2144c3c90516190d41f；
+- merge 固定区间：733888fc90ad8ef039947e87b08d7500a405954a..9a8a64aca12a825912f299450e10fc6043eca610；
+- WP8 exact-main verification：status=passed，ref=9a8a64aca12a825912f299450e10fc6043eca610，run=32129266046。
 
 Parent / Related：
 
 - [PR #356](https://github.com/arana-db/kiwi/pull/356)；
 - [Issue #415](https://github.com/arana-db/kiwi/issues/415)；
 - [Issue #418](https://github.com/arana-db/kiwi/issues/418)；
+- [Issue #430](https://github.com/arana-db/kiwi/issues/430)；
 - [Issue #325](https://github.com/arana-db/kiwi/issues/325)；
 - [Issue #340](https://github.com/arana-db/kiwi/issues/340)；
 - [Issue #342](https://github.com/arana-db/kiwi/issues/342)；
@@ -1455,7 +1466,7 @@ Requirement：
 依赖：
 
 - WP0 accepted；
-- exact main 包含 PR #356，即 733888fc90ad8ef039947e87b08d7500a405954a 或其后继；
+- exact main 包含 PR #422，即 9a8a64aca12a825912f299450e10fc6043eca610 或其后继；
 - D019 明确授权在一个 Draft PR 中聚合 #415 Trusted Oracle 和 WP8 产品闭环；
 - 复用 WP1-WP7 已定义的 Oracle、manifest/topology、runtime、Raft、snapshot、Redis semantics 和 fault-gate 合同，并按本文限定范围逐项实施和验收；D019 不要求这些工作包的无关范围先行 accepted；
 - 用户已确认 [VectorSet 合并后全量闭环设计](../docs/superpowers/specs/2026-08-06-vector-set-post-merge-remediation-design.md)；[VectorSet 合并后全量闭环实施总计划](../docs/superpowers/plans/2026-08-07-vector-set-post-merge-remediation.md) 和三个逐文件工作流计划已建立。
@@ -1488,7 +1499,7 @@ Requirement：
 - Trusted Oracle primary/rebuild 完整 artifact manifest 和 binary SHA-256 相等，正式 runtime 只来自 rebuild artifact，cleanup 成功后才发布 provenance；
 - Vector RESP2/RESP3 differential 和三节点 cluster gate 非零执行且零 skip/xfail；
 - rkyv reachability 变化会使 CI 失败；所有 required checks 绑定 exact Head；
-- 无未处理 P0/P1，#415、#418、#421 和所有 known difference/skip 残留完成对账。
+- 无未处理 P0/P1；#415 required acceptance 已完成，#418 继续持有未到 `remove_when` 的 compatibility differences，#430 继续持有 advisory exception，#421 的 required acceptance、known difference 和 skip 残留均已完成对账。
 
 验证门禁：
 
@@ -1696,19 +1707,20 @@ docs/sdd/WP-N/
 
 | 字段 | 当前值 |
 |---|---|
-| Baseline | main@733888fc90ad8ef039947e87b08d7500a405954a |
+| Baseline | main@9a8a64aca12a825912f299450e10fc6043eca610 |
 | Current milestone | M0-M6 / WP8 |
 | Current work package | WP8 |
-| Status | in-progress |
-| Current plan | [WP8 VectorSet 合并后全量闭环实施总计划](../docs/superpowers/plans/2026-08-07-vector-set-post-merge-remediation.md) |
+| Status | accepted |
+| Current plan | [WP8 与 Issue #421 合并后收口实施计划](../docs/superpowers/plans/2026-08-19-wp8-issue-closeout.md) |
 | Current Issue | [#421](https://github.com/arana-db/kiwi/issues/421) |
 | Current PR | [#422](https://github.com/arana-db/kiwi/pull/422) |
 | WP0 exact-main verification | passed |
+| WP8 exact-main verification | passed |
 | Required mode | Cache OFF |
 | M7/M8 | frozen |
-| Next safe action | 提交并顺序集成 WP8 Runtime/Protocol Task 1-5，然后在独立 worktree 启动 Trusted Oracle/CI/Security 实施计划 |
+| Next safe action | 等待下一个经明确批准的工作包；M7/M8 继续 frozen |
 
-PR #417 已修复 WP0 固定提交区间验证；main@688d905fec31b54aec76f36676f55efd8b5cfa17 的 ci run 30801285622 成功，当前 baseline commit 733888fc90ad8ef039947e87b08d7500a405954a 是其后继。WP0 已进入 accepted。PR #356 随后把 Vector Set Phase 1 合入主线，用户通过 D019 授权用 Draft PR #422 聚合 #415、#418、#421 的全量闭环。Storage/Recovery Task 1→7 已完成、集成并通过 exact-ref migration/rollback/snapshot 矩阵；独立 `codex/wp8-runtime-protocol` worktree 已从聚合 Head 建立。Runtime/Protocol Task 1 的无分配 `Bytes` admission 纯函数、Task 2 的 Cmd hook/双层 `GatedCmd` 顺序、Task 3 的 ParsedCommand Bytes 保留/Config 必填传播/真实 TCP storage spy/admission-before-copy 合同、Task 4 的 VADD typed parse outcome、Redis `arity=-5` dispatcher 边界、unknown trailing option 精确错误和 argv-shape heuristic 删除，以及 Task 5 的 function-scoped raw RESP2/RESP3 client、完整 frame reader、collection 零联网和五命令 Issue #421 operational-limit governance，均已完成 tests-first、变异验证和 changed-path 回归；正式双端 raw differential 仍由后续 verifier-supervised Trusted Oracle/CI runner 执行。下一安全动作是提交并顺序集成 Runtime/Protocol Task 1-5，然后启动 Trusted Oracle/CI/Security 实施计划。
+PR #422 以 Base 733888fc90ad8ef039947e87b08d7500a405954a、最终 Head 2b03219cdd5e452e08c1b2144c3c90516190d41f 合并为 main@9a8a64aca12a825912f299450e10fc6043eca610；该 merge 与 PR Head tree 一致，`ci` run 32129266046 在 exact main 上完成 Trusted Oracle 独立重建、Vector raw RESP2/RESP3 与 final-state differential、storage/snapshot migration、runtime admission、三节点 fail-closed 和供应链门禁。Issue #415 已关闭；五条 operational-limit differences 的 active owner 迁移到保持 OPEN 的 #418，`RUSTSEC-2026-0235` advisory owner 迁移到保持 OPEN 的 #430。WP8 的 Requirement、实现证据和残留风险已对账并进入 accepted；Issue #421 只在本治理 PR 合并且新的 exact-main `ci` 成功后按 closeout 评论关闭。M7/M8 和 Vector Set Phase 2 继续 frozen，不因 WP8 accepted 自动解冻。
 
 ## 18. 决策门禁
 

--- a/docs/superpowers/plans/2026-08-19-wp8-issue-closeout.md
+++ b/docs/superpowers/plans/2026-08-19-wp8-issue-closeout.md
@@ -49,7 +49,8 @@ compat manifest 只迁移 issue owner，audit config 只迁移 advisory owner，
   branch、`push` event、completed/success、Head 等于 recorded exact-main ref。
 - [ ] 添加以下失败变异：
   - accepted 但 exact-main status 不是 passed；
-  - PR Base/Head/merge 任一 SHA 漂移；
+  - PR Base/Head/merge parent/merge 任一 SHA 漂移；
+  - Base→Head ancestry、merge 唯一 parent、Head tree=merge tree 或 merge subject 漂移；
   - exact-main ref/run 缺失或格式错误；
   - run 的 workflow/path/event/branch/head/conclusion 任一漂移；
   - WP8 block 或当前状态表 evidence projection 与 front matter 漂移；
@@ -64,13 +65,14 @@ Markdown 链接错误不是有效 RED。
 **文件：** `scripts/validate_sdd.py`
 
 - [ ] 增加 WP8 identity/evidence field constants 和精确 immutable values：PR 422、
-  Base `733888fc...`、Head `2b03219...`、merge `9a8a64a...`。
+  Base/merge parent `733888fc...`、Head `2b03219...`、merge `9a8a64a...`。
 - [ ] 校验 SHA/decimal/status 格式；当 WP8 是 verified/accepted/released 时要求
   exact-main `passed`。
 - [ ] 复用现有 GitHub run loader 模式增加 WP8 run 校验；normal validation 在线
   读取 recorded run，self-test 注入 payload，不访问网络。
-- [ ] 校验 merge/exact-main 提交在本地可解析，baseline_ref 不早于 recorded
-  exact-main ref；不改变 WP0 immutable evidence。
+- [ ] 校验 Base→Head ancestry、merge 唯一 parent=Base、Head tree=merge tree、merge
+  subject 含 `(#422)`；merge→verification 允许 equality，verification→baseline 必须是
+  ancestry；不改变 WP0 immutable evidence。
 - [ ] 校验 WP8 block 和当前状态表的 evidence projection 恰好一次且与 front matter
   相同。
 - [ ] 重跑 self-test，预期新增和既有失败变异全部 GREEN。
@@ -89,6 +91,11 @@ Markdown 链接错误不是有效 RED。
 - [ ] 调整退出门禁的 Issue 对账文本：#415/#421 required acceptance 已完成；#418
   保持开放并拥有 residual differences；不得声称 #418 已关闭。
 - [ ] 更新第 17 节当前表与叙述，删除“下一步提交 Task 1-5/启动 Oracle”的过期事实。
+- [ ] scoped 更新实时快照、Issue registry、INV-12/INV-13/INV-17 和“normal CI 排除
+  differential”等陈旧描述，只写 PR #422 已证明的事实，不把 WP2/WP6 未来范围伪装
+  为完成；新增 open #430 owner。
+- [ ] `next_safe_action` 精确使用 `await-next-authorized-work-package`，表中对应“等待下
+  一个经明确批准的工作包；M7/M8 继续 frozen”。
 - [ ] 不修改 `.planning/STATE.md` / `KANBAN.md`，除非 validator 证明跳转页本身漂移。
 - [ ] 运行 normal validator，预期 `current.status=accepted`、`baseline_ref=9a8a64a...`、
   `errors=0`。
@@ -118,8 +125,9 @@ Markdown 链接错误不是有效 RED。
 - `tools/compat/tests/ci_contract.rs`
 - `.cargo/audit.toml`
 
-- [ ] 先让 `validate_rkyv_audit_governance` 要求 `owner: Issue #430`，并增加把 #430
-  退回 WP8/#421 的 mutant。
+- [ ] 先让 `validate_rkyv_audit_governance` 只检查 advisory 紧邻 comment block，要求
+  唯一 `owner: security-deps / Issue #430`，并增加把 #430 退回 WP8/#421、删除/重复
+  owner，以及在无关位置追加伪 #430 owner 的 mutants。
 - [ ] 运行精确 test，预期 RED：旧 owner 仍是 WP8 / #421。
 - [ ] 只改 owner comment；advisory ignore、potential path、unreachable status 和
   remove_when 保持不变。
@@ -134,8 +142,9 @@ Markdown 链接错误不是有效 RED。
 - [ ] `cargo fmt --all -- --check`
 - [ ] `cargo clippy -p kiwi-compat --all-targets -- -D warnings`
 - [ ] `git diff --check origin/main...HEAD`
-- [ ] `rg -n "issues/421|owner: WP8 / Issue #421"`，人工区分允许的历史文档引用和禁止
-  的 active manifest/audit owner。
+- [ ] `git grep -n -E 'issues/421|Issue #421' -- tests/compat/redis-8.8.1/manifest.yaml
+  .cargo/audit.toml` 预期无输出（退出码 1）；历史文档、WP8 Primary Issue 身份和负向
+  mutants 不要求全仓零匹配。
 - [ ] 使用 Test Guard 检查新增 self-test/mutant 是否真实执行权威入口、能杀死旧实现、
   没有仅 substring 的伪绑定。
 
@@ -151,7 +160,8 @@ Markdown 链接错误不是有效 RED。
 
 ## Task 8：exact-main 与 #421 关闭
 
-- [ ] 获取治理 PR merge SHA，等待该 SHA 或其 exact main 后继的 `ci` push run 成功。
+- [ ] 获取治理 PR merge SHA，等待该 SHA 或其 exact main 后继的 `ci` push run 成功；
+  该新 SHA/run 只写入 #421 closeout 评论，不覆盖 SDD 中 PR #422 的 immutable run。
 - [ ] 复核 main 上 active manifest/audit owner 已分别为 #418/#430，且两 Issue OPEN。
 - [ ] 在 #421 留一条证据评论：PR #422、治理 PR、两次 exact-main run、WP8 accepted
   SDD、五条差异到 #418、advisory 到 #430、验收逐项映射。

--- a/docs/superpowers/plans/2026-08-19-wp8-issue-closeout.md
+++ b/docs/superpowers/plans/2026-08-19-wp8-issue-closeout.md
@@ -1,0 +1,159 @@
+# WP8 与 Issue #421 合并后收口实施计划
+
+> **执行要求：** 使用 `subagent-driven-development` 隔离治理与存储诊断工作流；
+> 本计划的每个行为变更先用 `test-driven-development` 观察 RED，并在提交/PR/合并前
+> 使用 `verification-before-completion`。不得修改另一个 worktree 或根工作区。
+
+**目标：** 把已经合并并通过 exact-main CI 的 WP8 提升为可机器验证的
+`accepted`，把 active #421 owner 引用迁移到仍开放的 #418/#430，并在治理 PR
+合并及新 exact-main 验证后关闭 #421。
+
+**架构：** `.planning/SDD.md` 记录 WP8 immutable PR 与 exact-main evidence；
+`scripts/validate_sdd.py` 对 accepted evidence、投影和 GitHub Actions run fail closed；
+compat manifest 只迁移 issue owner，audit config 只迁移 advisory owner，不改变产品或
+安全合同。
+
+**基线：** `main@9a8a64aca12a825912f299450e10fc6043eca610`。
+
+**设计：**
+`docs/superpowers/specs/2026-08-19-wp8-issue-closeout-design.md`。
+
+---
+
+## 文件所有权
+
+- `.planning/SDD.md`：WP8 accepted 状态和 evidence projection。
+- `scripts/validate_sdd.py`：WP8 evidence normal/self-test 合同。
+- `tests/compat/redis-8.8.1/manifest.yaml`：五条 operational-limit issue 迁移。
+- `tools/compat/tests/manifest.rs`：迁移后的语义与回退 mutant。
+- `.cargo/audit.toml`：`RUSTSEC-2026-0235` owner 迁到 #430。
+- `tools/compat/tests/ci_contract.rs`：审计 owner 和回退 mutant。
+- `.planning/STATE.md`、`.planning/KANBAN.md`：只读确认继续作为 SDD 跳转页；没有
+  独立状态时不修改。
+- 本计划和对应设计文档：批准范围与执行证据。
+
+## 已建立的基线
+
+- [x] `python -I -B scripts/validate_sdd.py --self-test`：39 个失败路径变异通过。
+- [x] `python -I -B scripts/validate_sdd.py`：`errors=0`。
+- [x] `cargo test -p kiwi-compat --test manifest`：49 passed。
+- [x] `cargo test -p kiwi-compat --test ci_contract`：26 passed。
+
+## Task 1：WP8 evidence RED self-tests
+
+**文件：** `scripts/validate_sdd.py`
+
+- [ ] 新增构造“WP8 accepted + 完整 evidence”的纯文本 helper，避免每个 mutant 手写
+  不一致状态。
+- [ ] 新增固定 run payload loader，成功 payload 必须是：`ci` workflow、`main`
+  branch、`push` event、completed/success、Head 等于 recorded exact-main ref。
+- [ ] 添加以下失败变异：
+  - accepted 但 exact-main status 不是 passed；
+  - PR Base/Head/merge 任一 SHA 漂移；
+  - exact-main ref/run 缺失或格式错误；
+  - run 的 workflow/path/event/branch/head/conclusion 任一漂移；
+  - WP8 block 或当前状态表 evidence projection 与 front matter 漂移；
+  - baseline_ref 仍停留在 PR #422 之前。
+- [ ] 运行 `python -I -B scripts/validate_sdd.py --self-test`。
+
+预期 RED：至少一个 accepted-without-evidence mutant 被旧 validator 接受。fixture 或
+Markdown 链接错误不是有效 RED。
+
+## Task 2：实现 WP8 immutable/exact-main validator
+
+**文件：** `scripts/validate_sdd.py`
+
+- [ ] 增加 WP8 identity/evidence field constants 和精确 immutable values：PR 422、
+  Base `733888fc...`、Head `2b03219...`、merge `9a8a64a...`。
+- [ ] 校验 SHA/decimal/status 格式；当 WP8 是 verified/accepted/released 时要求
+  exact-main `passed`。
+- [ ] 复用现有 GitHub run loader 模式增加 WP8 run 校验；normal validation 在线
+  读取 recorded run，self-test 注入 payload，不访问网络。
+- [ ] 校验 merge/exact-main 提交在本地可解析，baseline_ref 不早于 recorded
+  exact-main ref；不改变 WP0 immutable evidence。
+- [ ] 校验 WP8 block 和当前状态表的 evidence projection 恰好一次且与 front matter
+  相同。
+- [ ] 重跑 self-test，预期新增和既有失败变异全部 GREEN。
+
+## Task 3：写回 accepted SDD 状态
+
+**文件：** `.planning/SDD.md`
+
+- [ ] 更新 `updated_at` 和 `baseline_ref`。
+- [ ] 添加设计规定的七个 WP8 evidence 字段及 `wp8_pr_number`。
+- [ ] 把 front matter 和 WP8 block 状态改为 `accepted`。
+- [ ] `current_plan` 指向本计划；保留 current Issue 421 / PR 422 作为历史身份。
+- [ ] 把实施前 `next_safe_action` 改为选择下一个经批准工作包。
+- [ ] 在 WP8 block 增加 post-merge evidence 段，精确投影 PR Base/Head、merge、
+  exact-main run 和 accepted 结论。
+- [ ] 调整退出门禁的 Issue 对账文本：#415/#421 required acceptance 已完成；#418
+  保持开放并拥有 residual differences；不得声称 #418 已关闭。
+- [ ] 更新第 17 节当前表与叙述，删除“下一步提交 Task 1-5/启动 Oracle”的过期事实。
+- [ ] 不修改 `.planning/STATE.md` / `KANBAN.md`，除非 validator 证明跳转页本身漂移。
+- [ ] 运行 normal validator，预期 `current.status=accepted`、`baseline_ref=9a8a64a...`、
+  `errors=0`。
+
+## Task 4：Vector operational-limit owner RED/GREEN
+
+**文件：**
+
+- `tools/compat/tests/manifest.rs`
+- `tests/compat/redis-8.8.1/manifest.yaml`
+
+- [ ] 先把权威测试改为：VADD、VEMB、VISMEMBER、VREM、VSIM 各有一条 issue=#418
+  且 reason 含对应 admission term 的 operational-limit difference；全 manifest 不得
+  有 issue=#421。
+- [ ] 加回退 mutant：把其中一条 #418 operational-limit URL 改回 #421，validator/
+  断言必须失败。对 VADD/VEMB/VSIM 要用 reason 前缀定位，不能误匹配同命令已有的
+  其他 #418 difference。
+- [ ] 运行精确测试，预期 RED：旧 manifest 仍把五条指向 #421。
+- [ ] 只改五个 issue URL 为 #418；reason、remove_when、owner、affected、introduced、
+  last_verified_ref 不变。
+- [ ] 重跑 `cargo test -p kiwi-compat --test manifest`，预期 GREEN。
+
+## Task 5：rkyv advisory owner RED/GREEN
+
+**文件：**
+
+- `tools/compat/tests/ci_contract.rs`
+- `.cargo/audit.toml`
+
+- [ ] 先让 `validate_rkyv_audit_governance` 要求 `owner: Issue #430`，并增加把 #430
+  退回 WP8/#421 的 mutant。
+- [ ] 运行精确 test，预期 RED：旧 owner 仍是 WP8 / #421。
+- [ ] 只改 owner comment；advisory ignore、potential path、unreachable status 和
+  remove_when 保持不变。
+- [ ] 重跑 `cargo test -p kiwi-compat --test ci_contract`，预期 GREEN。
+
+## Task 6：本地验证与 Test Guard
+
+- [ ] `python -I -B scripts/validate_sdd.py --self-test`
+- [ ] `python -I -B scripts/validate_sdd.py`
+- [ ] `cargo test -p kiwi-compat --test manifest`
+- [ ] `cargo test -p kiwi-compat --test ci_contract`
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy -p kiwi-compat --all-targets -- -D warnings`
+- [ ] `git diff --check origin/main...HEAD`
+- [ ] `rg -n "issues/421|owner: WP8 / Issue #421"`，人工区分允许的历史文档引用和禁止
+  的 active manifest/audit owner。
+- [ ] 使用 Test Guard 检查新增 self-test/mutant 是否真实执行权威入口、能杀死旧实现、
+  没有仅 substring 的伪绑定。
+
+## Task 7：独立复审、提交和 PR
+
+- [ ] 规格复审：状态/证据/owner 迁移与批准设计一致，P0/P1/P2 全零。
+- [ ] 质量复审：validator fail-closed、mutant 区分度、无生产行为变化，P0/P1/P2 全零。
+- [ ] 仅提交计划列出的文件；检查 `git status --short` 与 committed diff。
+- [ ] push `codex/wp8-issue-closeout`，创建独立 PR，body 使用 `Refs #421`，不得让 PR
+  merge 自动提前关闭 Issue。
+- [ ] 等待 exact Head 全部 required/visible checks 成功，复核 mergeability 和 review
+  threads，再合并。
+
+## Task 8：exact-main 与 #421 关闭
+
+- [ ] 获取治理 PR merge SHA，等待该 SHA 或其 exact main 后继的 `ci` push run 成功。
+- [ ] 复核 main 上 active manifest/audit owner 已分别为 #418/#430，且两 Issue OPEN。
+- [ ] 在 #421 留一条证据评论：PR #422、治理 PR、两次 exact-main run、WP8 accepted
+  SDD、五条差异到 #418、advisory 到 #430、验收逐项映射。
+- [ ] 以 completed 关闭 #421，并重新读取 Issue 状态确认。
+- [ ] 不关闭或改变 #418、#430、#325、#340、#342。

--- a/docs/superpowers/specs/2026-08-19-wp8-issue-closeout-design.md
+++ b/docs/superpowers/specs/2026-08-19-wp8-issue-closeout-design.md
@@ -70,6 +70,7 @@ closed。
 wp8_pr_number: 422
 wp8_pr_base_ref: 733888fc90ad8ef039947e87b08d7500a405954a
 wp8_pr_head_ref: 2b03219cdd5e452e08c1b2144c3c90516190d41f
+wp8_merge_parent_ref: 733888fc90ad8ef039947e87b08d7500a405954a
 wp8_merge_ref: 9a8a64aca12a825912f299450e10fc6043eca610
 wp8_exact_main_verification_ref: 9a8a64aca12a825912f299450e10fc6043eca610
 wp8_exact_main_verification_run: 32129266046
@@ -95,14 +96,19 @@ wp8_exact_main_verification_status: passed
 
 - 所有 WP8 SHA 字段是完整 lowercase Git SHA；PR/run 是正十进制；
 - PR number、Base、Head 和 merge SHA 与本次已合并事实精确相等；
-- exact-main status 是 `passed`，ref 等于或晚于 merge，且当前仓库可解析这些提交；
+- Base 是 Head 的祖先；merge 的唯一 parent 等于 Base；PR Head tree 等于 merge
+  tree；merge subject 包含 `(#422)`；
+- exact-main status 是 `passed`，merge 是 verification ref 的祖先（允许二者相等），
+  verification ref 是 baseline ref 的祖先，且当前仓库可解析这些提交；
 - recorded run 是 `ci` workflow 的 `main` push，`head_sha` 等于 recorded exact-main
   ref，状态 completed 且 conclusion success；
 - WP8 block 与当前状态表中的 evidence projection 与 front matter 一致。
 
-self-test 必须从有效快照分别变异 status、SHA、run identity、投影文本和 owner，证明
-这些失败路径真实由 validator 拒绝。测试不能联网依赖真实 GitHub；run loader 使用
-注入的固定 payload。normal validation 可以沿用现有 GitHub run 在线复核路径。
+self-test 必须从有效快照分别变异 status、SHA、Git ancestry/tree/subject、run identity
+和投影文本，证明这些失败路径真实由 validator 拒绝。测试不能联网依赖真实 GitHub；
+run loader 使用注入的固定 payload。normal validation 可以沿用现有 GitHub run 在线
+复核路径。manifest 与 audit owner mutants 分别属于 Rust contract tests，Python SDD
+validator 不读取或复制这两个合同。
 
 ## 4. Active 追踪迁移
 
@@ -125,9 +131,16 @@ operational-limit difference 全部改为 #418。只允许改 issue URL；以下
 
 ### 4.2 Advisory exemption
 
-`.cargo/audit.toml` 的 owner 改为 `Issue #430`。potential path、unreachable 状态和
-`remove_when` 不变。`ci_contract` 必须要求 #430 owner 且拒绝恢复成 WP8 / #421。
+`.cargo/audit.toml` 的 owner 精确改为 `security-deps / Issue #430`。potential path、
+unreachable 状态和 `remove_when` 不变。`ci_contract` 必须在 advisory 的紧邻治理
+comment block 内要求该唯一 owner，且拒绝恢复成 WP8 / #421 或在无关位置追加伪 owner。
 #430 保持 OPEN，直到豁免按其验收条件真正移除。
+
+### 4.3 STATE / KANBAN
+
+`.planning/STATE.md` 与 `.planning/KANBAN.md` 已经是指向 SDD 的历史兼容跳转页。本次
+只读验证两者继续满足 pointer 合同，不复制 accepted、SHA、run 或 Issue 状态；真实
+writeback 只发生在唯一权威 `.planning/SDD.md`。
 
 ## 5. Issue 关闭顺序
 
@@ -139,6 +152,10 @@ operational-limit difference 全部改为 #418。只允许改 issue URL；以下
 6. 在 #421 评论 PR #422、治理 PR、两个 exact-main run、#418/#430 迁移去向和
    验收映射，然后以 completed 关闭。
 
+`wp8_exact_main_verification_*` 永久记录 PR #422 实现验收的 merge/run；治理 PR
+合并后的新 SHA/run 在合并前不可预知，因此记录在 #421 最终 closeout 评论，不覆盖
+SDD 中的 PR #422 immutable evidence，也不引入第二个 writeback PR。
+
 任何一步失败都保持 #421 OPEN；不得用旧的 run `32129266046` 代替治理 PR 合并后的
 新 exact-main 验证。
 
@@ -146,7 +163,8 @@ operational-limit difference 全部改为 #418。只允许改 issue URL；以下
 
 - SDD normal/self-test、manifest、CI contract 和 diff checks 全部通过。
 - WP8 accepted 状态缺任一 immutable/exact-main 字段都会失败。
-- 五条 operational-limit difference 全部且仅迁到 #418；没有 active #421 引用。
+- 五条 operational-limit difference 全部且仅迁到 #418；manifest/audit 等 active
+  owner 不再引用 #421。历史设计、WP8 Primary Issue 身份和负向 mutant 可以保留 #421。
 - rkyv 豁免 owner 是开放的 #430，reachability sentinel 与 remove condition 未放宽。
 - 独立规格复审与质量/Test Guard 复审均为 P0=0/P1=0/P2=0。
 - 治理 PR exact Head 和合并后的 exact main 均为绿色。

--- a/docs/superpowers/specs/2026-08-19-wp8-issue-closeout-design.md
+++ b/docs/superpowers/specs/2026-08-19-wp8-issue-closeout-design.md
@@ -134,7 +134,7 @@ operational-limit difference 全部改为 #418。只允许改 issue URL；以下
 `.cargo/audit.toml` 的 owner 精确改为 `security-deps / Issue #430`。potential path、
 unreachable 状态和 `remove_when` 不变。`ci_contract` 必须在 advisory 的紧邻治理
 comment block 内要求该唯一 owner，且拒绝恢复成 WP8 / #421 或在无关位置追加伪 owner。
-#430 保持 OPEN，直到豁免按其验收条件真正移除。
+Issue #430 保持 OPEN，直到豁免按其验收条件真正移除。
 
 ### 4.3 STATE / KANBAN
 

--- a/docs/superpowers/specs/2026-08-19-wp8-issue-closeout-design.md
+++ b/docs/superpowers/specs/2026-08-19-wp8-issue-closeout-design.md
@@ -1,0 +1,153 @@
+# WP8 与 Issue #421 合并后收口设计
+
+## 文档状态
+
+- 日期：2026-08-19
+- 状态：用户已批准，待实施与独立复审
+- 仓库：`arana-db/kiwi`
+- 实施基线：`main@9a8a64aca12a825912f299450e10fc6043eca610`
+- 实现 PR：[PR #422](https://github.com/arana-db/kiwi/pull/422)
+- PR Base：`733888fc90ad8ef039947e87b08d7500a405954a`
+- PR Head：`2b03219cdd5e452e08c1b2144c3c90516190d41f`
+- Merge / exact-main SHA：`9a8a64aca12a825912f299450e10fc6043eca610`
+- Exact-main CI：run `32129266046`
+- Primary Issue：[Issue #421](https://github.com/arana-db/kiwi/issues/421)
+- 保持开放的后续追踪：[Issue #418](https://github.com/arana-db/kiwi/issues/418)、[Issue #430](https://github.com/arana-db/kiwi/issues/430)
+
+本文只收口 PR #422 合并后的治理事实，不修改 VectorSet 生产行为、兼容边界、
+存储格式、CI 执行逻辑或依赖图。Issue #421 只有在本设计对应的治理 PR 合并、
+新 exact-main 验证成功且追踪引用全部迁移后才允许关闭。
+
+## 1. 问题
+
+PR #422 已合并且 exact-main CI 成功，但唯一 SDD 控制面仍把 WP8 标记为
+`in-progress`，并保留实施前的下一动作。与此同时：
+
+1. 五条仍有效的 Vector operational-limit known differences 继续把 #421 当作
+   owner；关闭 #421 会使 active `remove_when` 指向已关闭 Issue。
+2. `RUSTSEC-2026-0235` 的临时审计豁免继续把 WP8 / #421 当作 owner；该豁免的
+   生命周期独立于已经完成的 VectorSet 工作包。
+3. 当前 validator 只对 WP0 的 immutable PR 和 exact-main 证据做机器校验；WP8
+   即使被手工改成 `accepted`，也没有防止缺失或漂移证据的失败路径。
+
+因此，代码已经完成并不等于 Issue 可以安全关闭。必须先把“完成事实”“残留差异
+owner”“长期安全豁免 owner”拆开，并让 SDD validator 对 WP8 的接受状态 fail
+closed。
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+- 把 WP8 状态从 `in-progress` 提升为 `accepted`，并记录 PR #422 immutable
+  Base/Head、merge SHA、exact-main SHA、CI run 和 `passed` 结论。
+- 让 normal validator 和 self-test 约束 WP8 接受证据；删除、篡改或把成功 run
+  指向非 main/non-push/non-CI/non-success 时必须失败。
+- 把 VADD、VEMB、VISMEMBER、VREM、VSIM 的五条 operational-limit differences
+  从 #421 迁移到仍开放的 #418，不改变 reason、`remove_when`、owner、affected 或
+  Redis exact-ref。
+- 把 `RUSTSEC-2026-0235` 临时豁免的 owner 从 WP8 / #421 迁移到专门且开放的
+  #430，并让 CI contract 固定该 owner。
+- 更新当前状态和下一安全动作，使仓库不再声称 WP8 仍在实施。
+- 在治理 PR 合并并完成新的 exact-main 验证后，为 #421 留下可核查证据并关闭。
+
+### 2.2 非目标
+
+- 不关闭 #418、#430、#325、#340 或 #342。
+- 不删除任何 known difference 或审计豁免。
+- 不修改 Vector 命令、资源上限、raw differential、Oracle、cluster gate 或
+  migration 生产实现。
+- 不把 #418 的剩余差异伪装成 WP8 未完成；#418 是长期兼容追踪，不是 #421 的
+  关闭阻塞，只要 active 引用已经迁移并且 Issue 保持开放。
+- 不改写 WP0 immutable evidence。
+
+## 3. 状态与证据合同
+
+### 3.1 SDD front matter
+
+新增以下 WP8 evidence 字段：
+
+```text
+wp8_pr_number: 422
+wp8_pr_base_ref: 733888fc90ad8ef039947e87b08d7500a405954a
+wp8_pr_head_ref: 2b03219cdd5e452e08c1b2144c3c90516190d41f
+wp8_merge_ref: 9a8a64aca12a825912f299450e10fc6043eca610
+wp8_exact_main_verification_ref: 9a8a64aca12a825912f299450e10fc6043eca610
+wp8_exact_main_verification_run: 32129266046
+wp8_exact_main_verification_status: passed
+```
+
+同时更新：
+
+- `updated_at: 2026-08-19`；
+- `baseline_ref` 为上述 exact-main SHA；
+- `current_work_package: WP8`；
+- `current_work_package_status: accepted`；
+- `current_plan` 指向本设计对应的收口计划；
+- `current_issue: 421` 与 `current_pr: 422` 保留为已完成工作包的历史身份；
+- `next_safe_action` 改为选择下一个经批准的工作包，而不是继续执行 PR #422。
+
+保留 current Issue/PR 并不表示它们仍开放；它们用于把 accepted WP8 绑定到完成它
+的 GitHub 对象。开放/关闭状态以 GitHub 实时证据为准。
+
+### 3.2 Validator
+
+当 WP8 状态为 `verified`、`accepted` 或 `released` 时，validator 必须要求：
+
+- 所有 WP8 SHA 字段是完整 lowercase Git SHA；PR/run 是正十进制；
+- PR number、Base、Head 和 merge SHA 与本次已合并事实精确相等；
+- exact-main status 是 `passed`，ref 等于或晚于 merge，且当前仓库可解析这些提交；
+- recorded run 是 `ci` workflow 的 `main` push，`head_sha` 等于 recorded exact-main
+  ref，状态 completed 且 conclusion success；
+- WP8 block 与当前状态表中的 evidence projection 与 front matter 一致。
+
+self-test 必须从有效快照分别变异 status、SHA、run identity、投影文本和 owner，证明
+这些失败路径真实由 validator 拒绝。测试不能联网依赖真实 GitHub；run loader 使用
+注入的固定 payload。normal validation 可以沿用现有 GitHub run 在线复核路径。
+
+## 4. Active 追踪迁移
+
+### 4.1 Vector compatibility
+
+manifest 中 issue 等于 `https://github.com/arana-db/kiwi/issues/421` 的五条
+operational-limit difference 全部改为 #418。只允许改 issue URL；以下字段必须
+保持字节语义不变：
+
+- command 和 classification；
+- owner；
+- reason；
+- `remove_when`；
+- introduced / affected；
+- Redis exact `last_verified_ref`。
+
+`tools/compat/tests/manifest.rs` 必须查找 #418，并额外证明五条迁移后的 difference
+仍是 operational-limit 条目，而不是误匹配同一命令下原有的其他 #418 difference。
+测试还应加入回退到 #421 的 mutant，确保关闭后不会重新引入 active 引用。
+
+### 4.2 Advisory exemption
+
+`.cargo/audit.toml` 的 owner 改为 `Issue #430`。potential path、unreachable 状态和
+`remove_when` 不变。`ci_contract` 必须要求 #430 owner 且拒绝恢复成 WP8 / #421。
+#430 保持 OPEN，直到豁免按其验收条件真正移除。
+
+## 5. Issue 关闭顺序
+
+1. 治理 PR 通过本地验证与双重独立复审。
+2. 提交、push、创建 PR；等待 exact Head 的 required/visible checks 成功。
+3. 合并治理 PR。
+4. 等待新 main 的 `ci` workflow 成功，并记录新的 main SHA 与 run。
+5. 实时复核仓库不再存在 active #421 owner 引用；历史文档中的 Issue 链接允许保留。
+6. 在 #421 评论 PR #422、治理 PR、两个 exact-main run、#418/#430 迁移去向和
+   验收映射，然后以 completed 关闭。
+
+任何一步失败都保持 #421 OPEN；不得用旧的 run `32129266046` 代替治理 PR 合并后的
+新 exact-main 验证。
+
+## 6. 验收标准
+
+- SDD normal/self-test、manifest、CI contract 和 diff checks 全部通过。
+- WP8 accepted 状态缺任一 immutable/exact-main 字段都会失败。
+- 五条 operational-limit difference 全部且仅迁到 #418；没有 active #421 引用。
+- rkyv 豁免 owner 是开放的 #430，reachability sentinel 与 remove condition 未放宽。
+- 独立规格复审与质量/Test Guard 复审均为 P0=0/P1=0/P2=0。
+- 治理 PR exact Head 和合并后的 exact main 均为绿色。
+- #421 最终关闭；#418、#430、#325、#340、#342 状态不因本工作改变。

--- a/scripts/validate_sdd.py
+++ b/scripts/validate_sdd.py
@@ -79,6 +79,7 @@ CURRENT_FIELDS = (
     "current_plan",
     "current_issue",
     "current_pr",
+    "next_safe_action",
 )
 
 WP0_EVIDENCE_FIELDS = (
@@ -110,7 +111,42 @@ EXPECTED_WP0_VERIFICATION_WORKFLOW = {
     "name": "ci",
     "path": ".github/workflows/ci.yml",
 }
+EXPECTED_WP8_VERIFICATION_WORKFLOW = {
+    "name": "ci",
+    "path": ".github/workflows/ci.yml",
+}
+
+WP8_EVIDENCE_FIELDS = (
+    "wp8_pr_base_ref",
+    "wp8_pr_head_ref",
+    "wp8_merge_parent_ref",
+    "wp8_merge_ref",
+)
+
+WP8_IDENTITY_FIELDS = ("wp8_pr_number",)
+
+WP8_VERIFICATION_FIELDS = (
+    "wp8_exact_main_verification_ref",
+    "wp8_exact_main_verification_run",
+    "wp8_exact_main_verification_status",
+)
+
+EXPECTED_WP8_IMMUTABLE_EVIDENCE = {
+    "wp8_pr_number": "422",
+    "wp8_pr_base_ref": "733888fc90ad8ef039947e87b08d7500a405954a",
+    "wp8_pr_head_ref": "2b03219cdd5e452e08c1b2144c3c90516190d41f",
+    "wp8_merge_parent_ref": "733888fc90ad8ef039947e87b08d7500a405954a",
+    "wp8_merge_ref": "9a8a64aca12a825912f299450e10fc6043eca610",
+}
 GithubRunLoader = Callable[[str], dict[str, object]]
+
+WP8_CLOSEOUT_PLAN = "docs/superpowers/plans/2026-08-19-wp8-issue-closeout.md"
+WP8_ACCEPTED_EVIDENCE_FIXTURE = {
+    **EXPECTED_WP8_IMMUTABLE_EVIDENCE,
+    "wp8_exact_main_verification_ref": "9a8a64aca12a825912f299450e10fc6043eca610",
+    "wp8_exact_main_verification_run": "32129266046",
+    "wp8_exact_main_verification_status": "passed",
+}
 
 ALLOWED_WP_STATUSES = {
     "proposed",
@@ -334,6 +370,15 @@ def validate_wp0_immutable_evidence(
             errors.append(f"{field} must remain {expected}, found {actual}")
 
 
+def validate_wp8_immutable_evidence(
+    fields: dict[str, str], errors: list[str]
+) -> None:
+    for field, expected in EXPECTED_WP8_IMMUTABLE_EVIDENCE.items():
+        actual = fields.get(field, "")
+        if actual != expected:
+            errors.append(f"{field} must remain {expected}, found {actual}")
+
+
 def fetch_github_actions_run(run_id: str) -> dict[str, object]:
     headers = {
         "Accept": "application/vnd.github+json",
@@ -401,6 +446,50 @@ def validate_wp0_exact_main_run(
         )
         return
     validate_wp0_github_run_evidence(fields, run, errors)
+
+
+def validate_wp8_github_run_evidence(
+    fields: dict[str, str], run: dict[str, object], errors: list[str]
+) -> None:
+    run_id = fields.get("wp8_exact_main_verification_run", "")
+    expected: dict[str, object] = {
+        "id": int(run_id),
+        "status": "completed",
+        "conclusion": "success",
+        "event": "push",
+        "head_branch": EXPECTED_BASELINE_BRANCH,
+        "head_sha": fields.get("wp8_exact_main_verification_ref", ""),
+        **EXPECTED_WP8_VERIFICATION_WORKFLOW,
+    }
+    for field, expected_value in expected.items():
+        actual = run.get(field)
+        if actual != expected_value:
+            errors.append(
+                "WP8 exact-main GitHub Actions run "
+                f"{field} must be {expected_value!r}, found {actual!r}"
+            )
+
+
+def validate_wp8_exact_main_run(
+    fields: dict[str, str],
+    errors: list[str],
+    loader: GithubRunLoader | None = None,
+) -> None:
+    if fields.get("wp8_exact_main_verification_status") != "passed":
+        return
+    run_id = fields.get("wp8_exact_main_verification_run", "")
+    if not re.fullmatch(r"[1-9][0-9]*", run_id):
+        return
+    load_run = loader or fetch_github_actions_run
+    try:
+        run = load_run(run_id)
+    except Exception as error:
+        errors.append(
+            f"unable to validate WP8 exact-main GitHub Actions run {run_id}: "
+            f"{type(error).__name__}: {error}"
+        )
+        return
+    validate_wp8_github_run_evidence(fields, run, errors)
 
 
 def validate_current_plan(
@@ -587,11 +676,100 @@ def validate_current_state(
                 "verification evidence"
             )
 
+    wp8_status = statuses.get("WP8", "")
+    wp8_requires_evidence = wp8_status in {"verified", "accepted", "released"}
+    wp8_verification_ref = fields.get("wp8_exact_main_verification_ref", "")
+    wp8_verification_run = fields.get("wp8_exact_main_verification_run", "")
+    wp8_verification_status = fields.get("wp8_exact_main_verification_status", "")
+    if wp8_requires_evidence:
+        for field in (
+            WP8_IDENTITY_FIELDS + WP8_EVIDENCE_FIELDS + WP8_VERIFICATION_FIELDS
+        ):
+            if field not in fields:
+                errors.append(f"front matter field {field} must occur exactly once")
+
+        wp8_pr_number = fields.get("wp8_pr_number", "")
+        if not re.fullmatch(r"[1-9][0-9]*", wp8_pr_number):
+            errors.append("wp8_pr_number must be a positive decimal GitHub PR number")
+        validate_wp8_immutable_evidence(fields, errors)
+        for field in WP8_EVIDENCE_FIELDS:
+            if not re.fullmatch(r"[0-9a-f]{40}", fields.get(field, "")):
+                errors.append(
+                    f"{field} must be a full 40-character lowercase Git SHA"
+                )
+
+        if wp8_verification_status not in {"pending", "passed"}:
+            errors.append(
+                "wp8_exact_main_verification_status must be pending or passed"
+            )
+        if wp8_verification_status == "pending":
+            if wp8_verification_ref != "none" or wp8_verification_run != "none":
+                errors.append(
+                    "pending WP8 exact-main verification must not claim a ref or run"
+                )
+        elif wp8_verification_status == "passed":
+            if not re.fullmatch(r"[0-9a-f]{40}", wp8_verification_ref):
+                errors.append(
+                    "passed WP8 exact-main verification requires a full Git SHA"
+                )
+            if not re.fullmatch(r"[1-9][0-9]*", wp8_verification_run):
+                errors.append(
+                    "passed WP8 exact-main verification requires a GitHub Actions run"
+                )
+
+        if wp8_verification_status != "passed":
+            errors.append(
+                f"WP8 status {wp8_status} requires passed exact-main verification "
+                "evidence"
+            )
+
+        wp8_block = blocks.get("WP8", "")
+        wp8_projection = (
+            (
+                "- PR 固定区间：",
+                f"- PR 固定区间：{fields.get('wp8_pr_base_ref', '')}.."
+                f"{fields.get('wp8_pr_head_ref', '')}；",
+            ),
+            (
+                "- merge 固定区间：",
+                f"- merge 固定区间：{fields.get('wp8_merge_parent_ref', '')}.."
+                f"{fields.get('wp8_merge_ref', '')}；",
+            ),
+            (
+                "- WP8 exact-main verification：",
+                "- WP8 exact-main verification："
+                f"status={wp8_verification_status}，ref={wp8_verification_ref}，"
+                f"run={wp8_verification_run}。",
+            ),
+        )
+        wp8_lines = wp8_block.splitlines()
+        for prefix, expected_line in wp8_projection:
+            matching_lines = [line for line in wp8_lines if line.startswith(prefix)]
+            if matching_lines != [expected_line]:
+                errors.append(
+                    "WP8 evidence projection must contain exactly one line matching "
+                    f"immutable front matter: expected={expected_line!r}, "
+                    f"found={matching_lines}"
+                )
+
+        if (
+            current_work_package == "WP8"
+            and current_status == "accepted"
+            and fields.get("next_safe_action")
+            != "await-next-authorized-work-package"
+        ):
+            errors.append(
+                "WP8 accepted next_safe_action must be "
+                "await-next-authorized-work-package"
+            )
+
     table_expectations = {
         "Current work package": current_work_package,
         "Status": current_status,
         "WP0 exact-main verification": verification_status,
     }
+    if wp8_requires_evidence:
+        table_expectations["WP8 exact-main verification"] = wp8_verification_status
     for label, expected in table_expectations.items():
         matches = re.findall(rf"(?m)^\| {re.escape(label)} \| (.*?) \|$", sdd)
         if len(matches) != 1:
@@ -947,6 +1125,167 @@ def validate_wp0_git_evidence(
         )
 
 
+def validate_wp8_git_evidence(
+    root: Path, fields: dict[str, str], errors: list[str]
+) -> None:
+    refs = {
+        "PR base": fields.get("wp8_pr_base_ref", ""),
+        "PR head": fields.get("wp8_pr_head_ref", ""),
+        "merge parent": fields.get("wp8_merge_parent_ref", ""),
+        "merge": fields.get("wp8_merge_ref", ""),
+    }
+    available: dict[str, bool] = {}
+    for label, ref in refs.items():
+        check = subprocess.run(
+            ["git", "-C", str(root), "cat-file", "-e", f"{ref}^{{commit}}"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+        available[label] = check.returncode == 0
+        if check.returncode != 0:
+            errors.append(f"WP8 {label} ref is not available as a Git commit: {ref}")
+
+    pr_base_ref = refs["PR base"]
+    pr_head_ref = refs["PR head"]
+    if available["PR base"] and available["PR head"]:
+        ancestry = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(root),
+                "merge-base",
+                "--is-ancestor",
+                pr_base_ref,
+                pr_head_ref,
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+        if ancestry.returncode != 0:
+            errors.append("WP8 PR base ref must be an ancestor of the PR head ref")
+
+    merge_parent_ref = refs["merge parent"]
+    merge_ref = refs["merge"]
+    parents = subprocess.run(
+        ["git", "-C", str(root), "rev-list", "--parents", "-n", "1", merge_ref],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    expected_lineage = [merge_ref, merge_parent_ref]
+    actual_lineage = parents.stdout.strip().split()
+    if parents.returncode != 0 or actual_lineage != expected_lineage:
+        errors.append(
+            "WP8 squash-merge evidence must bind the merge commit and its parent "
+            f"exactly: expected={expected_lineage}, found={actual_lineage}"
+        )
+
+    if available["PR head"] and available["merge"]:
+        head_tree = subprocess.run(
+            ["git", "-C", str(root), "show", "-s", "--format=%T", pr_head_ref],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+        merge_tree = subprocess.run(
+            ["git", "-C", str(root), "show", "-s", "--format=%T", merge_ref],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+        if (
+            head_tree.returncode != 0
+            or merge_tree.returncode != 0
+            or head_tree.stdout.strip() != merge_tree.stdout.strip()
+        ):
+            errors.append(
+                "WP8 PR head tree must match the squash-merge tree: "
+                f"head={head_tree.stdout.strip()!r}, "
+                f"merge={merge_tree.stdout.strip()!r}"
+            )
+
+    subject = subprocess.run(
+        ["git", "-C", str(root), "show", "-s", "--format=%s", merge_ref],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    expected_pr_marker = f"(#{fields.get('wp8_pr_number', '')})"
+    if subject.returncode != 0 or expected_pr_marker not in subject.stdout.strip():
+        errors.append(
+            "WP8 merge commit subject must identify the implementation PR: "
+            f"expected marker={expected_pr_marker}, found={subject.stdout.strip()!r}"
+        )
+
+    if fields.get("wp8_exact_main_verification_status") != "passed":
+        return
+    verification_ref = fields.get("wp8_exact_main_verification_ref", "")
+    verification_check = subprocess.run(
+        ["git", "-C", str(root), "cat-file", "-e", f"{verification_ref}^{{commit}}"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    if verification_check.returncode != 0:
+        errors.append(
+            "passed WP8 exact-main verification ref is not available as a Git "
+            f"commit: {verification_ref}"
+        )
+        return
+
+    verification_ancestry = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(root),
+            "merge-base",
+            "--is-ancestor",
+            merge_ref,
+            verification_ref,
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    if verification_ancestry.returncode != 0:
+        errors.append(
+            "WP8 exact-main verification ref must descend from the recorded WP8 "
+            "merge commit"
+        )
+
+    baseline_ref = fields.get("baseline_ref", "")
+    baseline_ancestry = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(root),
+            "merge-base",
+            "--is-ancestor",
+            verification_ref,
+            baseline_ref,
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    if baseline_ancestry.returncode != 0:
+        errors.append(
+            "passed WP8 exact-main verification requires baseline_ref to advance "
+            "to the verification ref or a later main commit"
+        )
+
+
 def validate_artifacts(
     root: Path,
     sdd: str,
@@ -1144,9 +1483,12 @@ def validate(
     validate_current_state(sdd, fields, errors, current_plan_path)
     if check_github_run:
         validate_wp0_exact_main_run(fields, errors, github_run_loader)
+        validate_wp8_exact_main_run(fields, errors, github_run_loader)
     validate_wp0_gate_contract(sdd, errors)
     invariant_count = validate_invariants(sdd, errors)
     validate_artifacts(root, sdd, fields, errors, check_git_diff)
+    if check_git_diff and fields.get("wp8_exact_main_verification_status") == "passed":
+        validate_wp8_git_evidence(root, fields, errors)
     if check_markdown:
         effective_markdown_paths = markdown_paths
         if effective_markdown_paths is None:
@@ -1358,6 +1700,164 @@ def set_current_wp8_external_plan_text(sdd: str, plan_path: str) -> str:
     return updated
 
 
+def set_wp8_accepted_evidence_text(sdd: str) -> str:
+    updated = sdd
+    if re.search(r"(?m)^wp8_pr_number: ", updated):
+        for field, value in WP8_ACCEPTED_EVIDENCE_FIXTURE.items():
+            updated = replace_once(
+                updated,
+                rf"(?m)^{re.escape(field)}: .+$",
+                f"{field}: {value}",
+                f"WP8 accepted {field}",
+            )
+    else:
+        updated = replace_once(
+            updated,
+            r"(?m)^(wp0_exact_main_verification_status: .+)$",
+            lambda match: "\n".join(
+                [match.group(1)]
+                + [
+                    f"{field}: {value}"
+                    for field, value in WP8_ACCEPTED_EVIDENCE_FIXTURE.items()
+                ]
+            ),
+            "WP8 accepted evidence fields",
+        )
+    for field, value in (
+        ("baseline_ref", WP8_ACCEPTED_EVIDENCE_FIXTURE["wp8_merge_ref"]),
+        ("current_work_package", "WP8"),
+        ("current_work_package_status", "accepted"),
+        ("current_plan", WP8_CLOSEOUT_PLAN),
+        ("current_issue", "421"),
+        ("current_pr", "422"),
+        ("next_safe_action", "await-next-authorized-work-package"),
+    ):
+        updated = replace_once(
+            updated,
+            rf"(?m)^{re.escape(field)}: .+$",
+            f"{field}: {value}",
+            f"WP8 accepted {field}",
+        )
+
+    wp8_start = updated.find("### WP8：")
+    support_tracks = updated.find("### 支持轨道", wp8_start)
+    if wp8_start < 0 or support_tracks < 0:
+        raise AssertionError("WP8 accepted mutation requires WP8 and support-track headings")
+    prefix = updated[:wp8_start]
+    wp8 = updated[wp8_start:support_tracks]
+    suffix = updated[support_tracks:]
+    wp8 = replace_once(
+        wp8,
+        r"(?m)^状态：[a-z-]+。$",
+        "状态：accepted。",
+        "WP8 accepted block status",
+    )
+    implementation_pr = (
+        "Implementation PR：[#422](https://github.com/arana-db/kiwi/pull/422)。"
+    )
+    evidence = "\n".join(
+        (
+            "合并证据：",
+            "",
+            "- PR 固定区间："
+            f"{WP8_ACCEPTED_EVIDENCE_FIXTURE['wp8_pr_base_ref']}.."
+            f"{WP8_ACCEPTED_EVIDENCE_FIXTURE['wp8_pr_head_ref']}；",
+            "- merge 固定区间："
+            f"{WP8_ACCEPTED_EVIDENCE_FIXTURE['wp8_merge_parent_ref']}.."
+            f"{WP8_ACCEPTED_EVIDENCE_FIXTURE['wp8_merge_ref']}；",
+            "- WP8 exact-main verification："
+            "status=passed，ref="
+            f"{WP8_ACCEPTED_EVIDENCE_FIXTURE['wp8_exact_main_verification_ref']}，"
+            f"run={WP8_ACCEPTED_EVIDENCE_FIXTURE['wp8_exact_main_verification_run']}。",
+        )
+    )
+    if re.search(r"(?m)^- WP8 exact-main verification：", wp8):
+        for projection_prefix, line in (
+            (
+                "PR 固定区间",
+                "- PR 固定区间："
+                f"{WP8_ACCEPTED_EVIDENCE_FIXTURE['wp8_pr_base_ref']}.."
+                f"{WP8_ACCEPTED_EVIDENCE_FIXTURE['wp8_pr_head_ref']}；",
+            ),
+            (
+                "merge 固定区间",
+                "- merge 固定区间："
+                f"{WP8_ACCEPTED_EVIDENCE_FIXTURE['wp8_merge_parent_ref']}.."
+                f"{WP8_ACCEPTED_EVIDENCE_FIXTURE['wp8_merge_ref']}；",
+            ),
+            (
+                "WP8 exact-main verification",
+                "- WP8 exact-main verification：status=passed，ref="
+                f"{WP8_ACCEPTED_EVIDENCE_FIXTURE['wp8_exact_main_verification_ref']}，"
+                f"run={WP8_ACCEPTED_EVIDENCE_FIXTURE['wp8_exact_main_verification_run']}。",
+            ),
+        ):
+            wp8 = replace_once(
+                wp8,
+                rf"(?m)^- {re.escape(projection_prefix)}：.+$",
+                line,
+                f"WP8 accepted {projection_prefix} projection",
+            )
+    else:
+        wp8 = replace_once(
+            wp8,
+            rf"(?m)^{re.escape(implementation_pr)}$",
+            f"{implementation_pr}\n\n{evidence}",
+            "WP8 accepted evidence projection",
+        )
+    updated = prefix + wp8 + suffix
+
+    for label, value in (
+        (
+            "Baseline",
+            f"main@{WP8_ACCEPTED_EVIDENCE_FIXTURE['wp8_merge_ref']}",
+        ),
+        ("Status", "accepted"),
+        (
+            "Current plan",
+            "[WP8 与 Issue #421 合并后收口实施计划]"
+            "(../docs/superpowers/plans/2026-08-19-wp8-issue-closeout.md)",
+        ),
+        (
+            "Next safe action",
+            "等待下一个经明确批准的工作包；M7/M8 继续 frozen",
+        ),
+    ):
+        updated = replace_once(
+            updated,
+            rf"(?m)^\| {re.escape(label)} \| .* \|$",
+            f"| {label} | {value} |",
+            f"WP8 accepted current-state table {label}",
+        )
+    if re.search(r"(?m)^\| WP8 exact-main verification \|", updated):
+        updated = replace_once(
+            updated,
+            r"(?m)^\| WP8 exact-main verification \| .* \|$",
+            "| WP8 exact-main verification | passed |",
+            "WP8 accepted verification table row",
+        )
+    else:
+        updated = replace_once(
+            updated,
+            r"(?m)^(\| WP0 exact-main verification \| passed \|)$",
+            lambda match: (
+                f"{match.group(1)}\n| WP8 exact-main verification | passed |"
+            ),
+            "WP8 accepted verification table row",
+        )
+    return updated
+
+
+def prepare_wp8_accepted_candidate(root: Path, candidate: Path) -> None:
+    plan = candidate / WP8_CLOSEOUT_PLAN
+    plan.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(root / WP8_CLOSEOUT_PLAN, plan)
+    sdd_path = candidate / ".planning/SDD.md"
+    sdd_path.write_text(
+        set_wp8_accepted_evidence_text(read_text(sdd_path)), encoding="utf-8"
+    )
+
+
 def expect_failure(
     root: Path,
     mutation,
@@ -1392,6 +1892,198 @@ def run_self_tests(root: Path) -> None:
     fields = parse_front_matter(read_text(root / ".planning/SDD.md"), field_errors)
     if field_errors:
         raise AssertionError(f"baseline front matter must parse: {field_errors}")
+
+    with tempfile.TemporaryDirectory(prefix="kiwi-sdd-wp8-accepted-") as temporary:
+        candidate = Path(temporary)
+        copy_contract(root, candidate)
+        prepare_wp8_accepted_candidate(root, candidate)
+        accepted_errors, _ = validate(
+            candidate,
+            check_git_diff=False,
+            check_markdown=False,
+            check_github_run=False,
+        )
+        if accepted_errors:
+            raise AssertionError(
+                "the complete WP8 accepted fixture must pass before mutations: "
+                f"{accepted_errors}"
+            )
+
+        wp0_run: dict[str, object] = {
+            "id": int(fields["wp0_exact_main_verification_run"]),
+            "status": "completed",
+            "conclusion": "success",
+            "event": "push",
+            "head_branch": "main",
+            "head_sha": fields["wp0_exact_main_verification_ref"],
+            "name": "ci",
+            "path": ".github/workflows/ci.yml",
+        }
+        wp8_run: dict[str, object] = {
+            "id": int(
+                WP8_ACCEPTED_EVIDENCE_FIXTURE[
+                    "wp8_exact_main_verification_run"
+                ]
+            ),
+            "status": "completed",
+            "conclusion": "success",
+            "event": "push",
+            "head_branch": "main",
+            "head_sha": WP8_ACCEPTED_EVIDENCE_FIXTURE[
+                "wp8_exact_main_verification_ref"
+            ],
+            "name": "ci",
+            "path": ".github/workflows/ci.yml",
+        }
+        loaded_runs: list[str] = []
+
+        def load_wp0_and_wp8_runs(run_id: str) -> dict[str, object]:
+            loaded_runs.append(run_id)
+            if run_id == fields["wp0_exact_main_verification_run"]:
+                return dict(wp0_run)
+            if run_id == WP8_ACCEPTED_EVIDENCE_FIXTURE[
+                "wp8_exact_main_verification_run"
+            ]:
+                return dict(wp8_run)
+            raise AssertionError(f"unexpected GitHub Actions run requested: {run_id}")
+
+        run_errors, _ = validate(
+            candidate,
+            check_git_diff=False,
+            check_markdown=False,
+            github_run_loader=load_wp0_and_wp8_runs,
+        )
+        expected_loaded_runs = [
+            fields["wp0_exact_main_verification_run"],
+            WP8_ACCEPTED_EVIDENCE_FIXTURE["wp8_exact_main_verification_run"],
+        ]
+        if loaded_runs != expected_loaded_runs or run_errors:
+            raise AssertionError(
+                "the validate entry point must load matching WP0 and WP8 exact-main "
+                f"evidence once each: loaded={loaded_runs}, errors={run_errors}"
+            )
+
+        for field, invalid_value in {
+            "id": int(
+                WP8_ACCEPTED_EVIDENCE_FIXTURE[
+                    "wp8_exact_main_verification_run"
+                ]
+            )
+            + 1,
+            "status": "in_progress",
+            "conclusion": "failure",
+            "event": "pull_request",
+            "head_branch": "codex/wp8-issue-closeout",
+            "head_sha": WP8_ACCEPTED_EVIDENCE_FIXTURE["wp8_pr_head_ref"],
+            "name": "Benchmark",
+            "path": ".github/workflows/benchmark.yml",
+        }.items():
+            invalid_wp8_run = dict(wp8_run)
+            invalid_wp8_run[field] = invalid_value
+
+            def load_invalid_wp8_run(run_id: str) -> dict[str, object]:
+                if run_id == fields["wp0_exact_main_verification_run"]:
+                    return dict(wp0_run)
+                return dict(invalid_wp8_run)
+
+            invalid_run_errors, _ = validate(
+                candidate,
+                check_git_diff=False,
+                check_markdown=False,
+                github_run_loader=load_invalid_wp8_run,
+            )
+            if not any(
+                f"WP8 exact-main GitHub Actions run {field} must" in error
+                for error in invalid_run_errors
+            ):
+                raise AssertionError(
+                    "the validate entry point must reject WP8 GitHub Actions run "
+                    f"{field} mismatch: {invalid_run_errors}"
+                )
+
+    def wp8_accepted_without_passed_evidence(candidate: Path) -> None:
+        prepare_wp8_accepted_candidate(root, candidate)
+        path = candidate / ".planning/SDD.md"
+        text = replace_once(
+            read_text(path),
+            r"(?m)^wp8_exact_main_verification_status: passed$",
+            "wp8_exact_main_verification_status: pending",
+            "WP8 accepted pending verification status",
+        )
+        text = replace_once(
+            text,
+            r"(?m)^- WP8 exact-main verification：status=passed，",
+            "- WP8 exact-main verification：status=pending，",
+            "WP8 accepted pending verification projection",
+        )
+        text = replace_once(
+            text,
+            r"(?m)^\| WP8 exact-main verification \| passed \|$",
+            "| WP8 exact-main verification | pending |",
+            "WP8 accepted pending verification table",
+        )
+        path.write_text(text, encoding="utf-8")
+
+    expect_failure(
+        root,
+        wp8_accepted_without_passed_evidence,
+        "WP8 status accepted requires passed exact-main verification evidence",
+    )
+
+    def remove_wp8_evidence_field(candidate: Path) -> None:
+        prepare_wp8_accepted_candidate(root, candidate)
+        path = candidate / ".planning/SDD.md"
+        path.write_text(
+            read_text(path).replace(
+                "wp8_pr_head_ref: "
+                f"{WP8_ACCEPTED_EVIDENCE_FIXTURE['wp8_pr_head_ref']}\n",
+                "",
+                1,
+            ),
+            encoding="utf-8",
+        )
+
+    expect_failure(
+        root,
+        remove_wp8_evidence_field,
+        "front matter field wp8_pr_head_ref must occur exactly once",
+    )
+
+    def drift_wp8_evidence_projection(candidate: Path) -> None:
+        prepare_wp8_accepted_candidate(root, candidate)
+        path = candidate / ".planning/SDD.md"
+        text = replace_once(
+            read_text(path),
+            r"(?m)^- WP8 exact-main verification：.+。$",
+            "- WP8 exact-main verification：status=passed，ref="
+            f"{WP8_ACCEPTED_EVIDENCE_FIXTURE['wp8_merge_parent_ref']}，"
+            f"run={WP8_ACCEPTED_EVIDENCE_FIXTURE['wp8_exact_main_verification_run']}。",
+            "WP8 accepted evidence projection drift",
+        )
+        path.write_text(text, encoding="utf-8")
+
+    expect_failure(
+        root,
+        drift_wp8_evidence_projection,
+        "WP8 evidence projection must contain exactly one line",
+    )
+
+    def restore_stale_wp8_next_action(candidate: Path) -> None:
+        prepare_wp8_accepted_candidate(root, candidate)
+        path = candidate / ".planning/SDD.md"
+        text = replace_once(
+            read_text(path),
+            r"(?m)^next_safe_action: await-next-authorized-work-package$",
+            "next_safe_action: execute-wp8-runtime-raw-resp-client-red-tests",
+            "stale WP8 next safe action",
+        )
+        path.write_text(text, encoding="utf-8")
+
+    expect_failure(
+        root,
+        restore_stale_wp8_next_action,
+        "WP8 accepted next_safe_action must be await-next-authorized-work-package",
+    )
 
     external_plan = "docs/superpowers/plans/2026-08-07-vector-set-post-merge-remediation.md"
     with tempfile.TemporaryDirectory(prefix="kiwi-sdd-wp8-plan-test-") as temporary:
@@ -1726,6 +2418,56 @@ def run_self_tests(root: Path) -> None:
             f"{advanced_baseline_errors}"
         )
 
+    wp8_git_fields = {
+        **WP8_ACCEPTED_EVIDENCE_FIXTURE,
+        "baseline_ref": WP8_ACCEPTED_EVIDENCE_FIXTURE[
+            "wp8_exact_main_verification_ref"
+        ],
+    }
+    wp8_git_errors: list[str] = []
+    validate_wp8_git_evidence(root, wp8_git_fields, wp8_git_errors)
+    if wp8_git_errors:
+        raise AssertionError(
+            "the exact PR #422 merge ref must satisfy WP8 Git evidence, including "
+            f"verification-ref equality: {wp8_git_errors}"
+        )
+
+    for field, value, expected_fragment in (
+        (
+            "wp8_merge_parent_ref",
+            WP8_ACCEPTED_EVIDENCE_FIXTURE["wp8_pr_head_ref"],
+            "WP8 squash-merge evidence must bind the merge commit and its parent exactly",
+        ),
+        (
+            "wp8_pr_head_ref",
+            WP8_ACCEPTED_EVIDENCE_FIXTURE["wp8_pr_base_ref"],
+            "WP8 PR head tree must match the squash-merge tree",
+        ),
+        (
+            "wp8_exact_main_verification_ref",
+            WP8_ACCEPTED_EVIDENCE_FIXTURE["wp8_pr_base_ref"],
+            "WP8 exact-main verification ref must descend from the recorded WP8 merge commit",
+        ),
+        (
+            "baseline_ref",
+            WP8_ACCEPTED_EVIDENCE_FIXTURE["wp8_pr_base_ref"],
+            "passed WP8 exact-main verification requires baseline_ref to advance",
+        ),
+        (
+            "wp8_merge_ref",
+            WP8_ACCEPTED_EVIDENCE_FIXTURE["wp8_pr_head_ref"],
+            "WP8 merge commit subject must identify the implementation PR",
+        ),
+    ):
+        mutant_fields = dict(wp8_git_fields)
+        mutant_fields[field] = value
+        mutant_errors: list[str] = []
+        validate_wp8_git_evidence(root, mutant_fields, mutant_errors)
+        if not any(expected_fragment in error for error in mutant_errors):
+            raise AssertionError(
+                f"WP8 Git evidence accepted {field} mutant: {mutant_errors}"
+            )
+
     valid_run: dict[str, object] = {
         "id": 30750372362,
         "status": "completed",
@@ -1793,7 +2535,9 @@ def run_self_tests(root: Path) -> None:
 
         def load_valid_run(run_id: str) -> dict[str, object]:
             loaded_runs.append(run_id)
-            return dict(valid_run)
+            if run_id == "30750372362":
+                return dict(valid_run)
+            return dict(wp8_run)
 
         valid_run_errors, _ = validate(
             candidate,
@@ -1801,23 +2545,31 @@ def run_self_tests(root: Path) -> None:
             check_markdown=False,
             github_run_loader=load_valid_run,
         )
-        if loaded_runs != ["30750372362"] or valid_run_errors:
+        if loaded_runs != ["30750372362", "32129266046"] or valid_run_errors:
             raise AssertionError(
-                "the validate entry point must load and accept matching exact-main "
-                f"evidence once: loaded={loaded_runs}, errors={valid_run_errors}"
+                "the validate entry point must load and accept matching WP0 and WP8 "
+                "exact-main evidence once each: "
+                f"loaded={loaded_runs}, errors={valid_run_errors}"
             )
 
         for field, invalid_value in invalid_run_values.items():
             invalid_run = dict(valid_run)
             invalid_run[field] = invalid_value
+
+            def load_invalid_wp0_run(run_id: str) -> dict[str, object]:
+                if run_id == "30750372362":
+                    return dict(invalid_run)
+                return dict(wp8_run)
+
             invalid_run_errors, _ = validate(
                 candidate,
                 check_git_diff=False,
                 check_markdown=False,
-                github_run_loader=lambda _run_id, run=invalid_run: run,
+                github_run_loader=load_invalid_wp0_run,
             )
             if not any(
-                f"run {field} must" in error for error in invalid_run_errors
+                f"WP0 exact-main GitHub Actions run {field} must" in error
+                for error in invalid_run_errors
             ):
                 raise AssertionError(
                     "the validate entry point must reject GitHub Actions run "
@@ -2287,7 +3039,7 @@ def run_self_tests(root: Path) -> None:
 
     print(
         "SDD validator self-tests passed "
-        "(39 failure-path mutations, 1 prose guard, "
+        "(WP0/WP8 failure-path mutations, 1 prose guard, "
         "immutable Git/live-run/state regressions, 1 reachable promotion path)"
     )
 

--- a/tests/compat/redis-8.8.1/manifest.yaml
+++ b/tests/compat/redis-8.8.1/manifest.yaml
@@ -93,7 +93,7 @@ commands:
         affected: standalone_cache_off; resp2/resp3
         last_verified_ref: redis-source:77b6c308396c9700672390a210143a8496fb4b10
       - owner: cmd-vector
-        issue: https://github.com/arana-db/kiwi/issues/421
+        issue: https://github.com/arana-db/kiwi/issues/418
         reason: "Operational-limit difference: Kiwi applies max_dimension, max_vector_bytes, VALUES raw token byte, and max_element_bytes admission before Redis command and storage semantics"
         remove_when: Redis-compatible admission boundary is defined and raw RESP2/RESP3 differential covers below, at, and above the boundary while pre-storage safety remains enforced
         introduced: 2026-08-11
@@ -153,7 +153,7 @@ commands:
         affected: standalone_cache_off; resp2/resp3
         last_verified_ref: redis-source:77b6c308396c9700672390a210143a8496fb4b10
       - owner: cmd-vector
-        issue: https://github.com/arana-db/kiwi/issues/421
+        issue: https://github.com/arana-db/kiwi/issues/418
         reason: "Operational-limit difference: Kiwi applies max_element_bytes admission before Redis VEMB command and storage semantics"
         remove_when: Redis-compatible admission boundary is defined and raw RESP2/RESP3 differential covers below, at, and above the boundary while pre-storage safety remains enforced
         introduced: 2026-08-11
@@ -193,7 +193,7 @@ commands:
     tests: [wire-differential, final-state]
     known_differences:
       - owner: cmd-vector
-        issue: https://github.com/arana-db/kiwi/issues/421
+        issue: https://github.com/arana-db/kiwi/issues/418
         reason: "Operational-limit difference: Kiwi applies max_element_bytes admission before Redis VISMEMBER command and storage semantics"
         remove_when: Redis-compatible admission boundary is defined and raw RESP2/RESP3 differential covers below, at, and above the boundary while pre-storage safety remains enforced
         introduced: 2026-08-11
@@ -213,7 +213,7 @@ commands:
     tests: [wire-differential, final-state]
     known_differences:
       - owner: cmd-vector
-        issue: https://github.com/arana-db/kiwi/issues/421
+        issue: https://github.com/arana-db/kiwi/issues/418
         reason: "Operational-limit difference: Kiwi applies max_element_bytes admission before Redis VREM command and storage semantics"
         remove_when: Redis-compatible admission boundary is defined and raw RESP2/RESP3 differential covers below, at, and above the boundary while pre-storage safety remains enforced
         introduced: 2026-08-11
@@ -247,7 +247,7 @@ commands:
         affected: standalone_cache_off; resp2/resp3
         last_verified_ref: redis-source:77b6c308396c9700672390a210143a8496fb4b10
       - owner: cmd-vector
-        issue: https://github.com/arana-db/kiwi/issues/421
+        issue: https://github.com/arana-db/kiwi/issues/418
         reason: "Operational-limit difference: Kiwi applies max_dimension, max_vector_bytes, and max_element_bytes admission before Redis VSIM command and storage semantics"
         remove_when: Redis-compatible admission boundary is defined and raw RESP2/RESP3 differential covers below, at, and above the boundary while pre-storage safety remains enforced
         introduced: 2026-08-11

--- a/tools/compat/tests/ci_contract.rs
+++ b/tools/compat/tests/ci_contract.rs
@@ -970,23 +970,51 @@ fn validate_rkyv_sentinel_source(source: &str) -> Result<(), String> {
 }
 
 fn validate_rkyv_audit_governance(source: &str) -> Result<(), String> {
-    let advisory_ignore_count = source
-        .lines()
-        .filter(|line| line.trim() == "\"RUSTSEC-2026-0235\",")
-        .count();
-    if advisory_ignore_count != 1 {
+    let lines = source.lines().collect::<Vec<_>>();
+    let advisory_lines = lines
+        .iter()
+        .enumerate()
+        .filter(|(_, line)| line.trim() == "\"RUSTSEC-2026-0235\",")
+        .collect::<Vec<_>>();
+    if advisory_lines.len() != 1 {
         return Err(format!(
-            "audit governance must ignore RUSTSEC-2026-0235 exactly once, got {advisory_ignore_count}"
+            "audit governance must ignore RUSTSEC-2026-0235 exactly once, got {}",
+            advisory_lines.len()
         ));
     }
+    let advisory_index = advisory_lines[0].0;
+    let mut block_start = advisory_index;
+    while block_start > 0 && lines[block_start - 1].trim_start().starts_with('#') {
+        block_start -= 1;
+    }
+    let governance_block = &lines[block_start..advisory_index];
+
+    let owner_lines = governance_block
+        .iter()
+        .filter(|line| line.trim_start().starts_with("# owner:"))
+        .collect::<Vec<_>>();
+    if owner_lines.len() != 1 || owner_lines[0].trim() != "# owner: security-deps / Issue #430" {
+        return Err(
+            "RUSTSEC-2026-0235 owner must be exactly security-deps / Issue #430 in its governance block"
+                .to_string(),
+        );
+    }
     for required in [
-        "owner: WP8 / Issue #421",
-        "potential_path: openraft -> byte-unit -> rust_decimal",
-        "current_status: unreachable optional dependency",
-        "remove_when:",
+        "# RUSTSEC-2026-0235: rkyv 0.7.46",
+        "# potential_path: openraft -> byte-unit -> rust_decimal",
+        "# current_status: unreachable optional dependency",
+        "# remove_when: rkyv@0.7.46 becomes reachable, or dependencies permit an",
+        "# advisory-free version without this exception.",
     ] {
-        if !source.contains(required) {
-            return Err(format!("audit governance is missing {required}"));
+        if governance_block
+            .iter()
+            .filter(|line| line.trim() == required)
+            .count()
+            != 1
+        {
+            return Err(format!(
+                "RUSTSEC-2026-0235 governance block must contain exactly one {required}"
+            ));
         }
     }
     if source.contains("Raft wire serialization") {
@@ -1219,6 +1247,72 @@ fn rkyv_audit_ignore_has_owner_path_status_and_removal_condition() {
     let source = normalized_fixture(include_str!("../../../.cargo/audit.toml"));
     validate_rkyv_audit_governance(&source)
         .expect("rkyv advisory ignore must carry accurate governance");
+
+    let restored_wp8_owner = source.replacen(
+        "# owner: security-deps / Issue #430",
+        "# owner: WP8 / Issue #421",
+        1,
+    );
+    assert!(
+        validate_rkyv_audit_governance(&restored_wp8_owner).is_err(),
+        "audit governance accepted the retired WP8 / Issue #421 owner"
+    );
+
+    let missing_owner = source.replacen("  # owner: security-deps / Issue #430\n", "", 1);
+    assert!(
+        validate_rkyv_audit_governance(&missing_owner).is_err(),
+        "audit governance accepted a missing advisory owner"
+    );
+
+    let duplicate_owner = source.replacen(
+        "  # owner: security-deps / Issue #430\n",
+        "  # owner: security-deps / Issue #430\n  # owner: security-deps / Issue #430\n",
+        1,
+    );
+    assert!(
+        validate_rkyv_audit_governance(&duplicate_owner).is_err(),
+        "audit governance accepted duplicate advisory owners"
+    );
+
+    let unrelated_owner = format!("{restored_wp8_owner}\n# owner: security-deps / Issue #430\n");
+    assert!(
+        validate_rkyv_audit_governance(&unrelated_owner).is_err(),
+        "an unrelated Issue #430 comment must not govern RUSTSEC-2026-0235"
+    );
+
+    let continuation_mutants = [
+        (
+            "removed",
+            source.replacen("  # advisory-free version without this exception.\n", "", 1),
+        ),
+        (
+            "tampered",
+            source.replacen(
+                "  # advisory-free version without this exception.",
+                "  # advisory-bearing version may retain this exception.",
+                1,
+            ),
+        ),
+    ];
+    for (name, mutant) in &continuation_mutants {
+        assert_ne!(
+            mutant, &source,
+            "{name} remove_when continuation mutant must alter the fixture"
+        );
+    }
+    let accepted_continuation_mutants = continuation_mutants
+        .iter()
+        .filter_map(|(name, mutant)| {
+            validate_rkyv_audit_governance(mutant)
+                .is_ok()
+                .then_some(*name)
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        accepted_continuation_mutants.is_empty(),
+        "audit governance accepted invalid remove_when continuation mutants: \
+         {accepted_continuation_mutants:?}"
+    );
 
     let removed_advisory = source.replacen("  \"RUSTSEC-2026-0235\",\n", "", 1);
     assert!(

--- a/tools/compat/tests/manifest.rs
+++ b/tools/compat/tests/manifest.rs
@@ -443,6 +443,7 @@ fn rejects_known_difference_governance_fields_when_missing() {
 fn repository_vector_operational_limits_are_explicitly_governed() {
     const ISSUE_418: &str = "https://github.com/arana-db/kiwi/issues/418";
     const ISSUE_421: &str = "https://github.com/arana-db/kiwi/issues/421";
+    const ISSUE_999: &str = "https://github.com/arana-db/kiwi/issues/999";
     const OPERATIONAL_LIMIT_PREFIX: &str = "Operational-limit difference:";
 
     fn validate_operational_limits(yaml: &str) -> Result<(), String> {
@@ -556,6 +557,17 @@ fn repository_vector_operational_limits_are_explicitly_governed() {
     assert!(
         validate_operational_limits(&reverted).is_err(),
         "restoring one operational-limit owner to Issue #421 must fail"
+    );
+
+    let mut foreign_owner = yaml.to_owned();
+    foreign_owner.replace_range(issue_index..issue_index + ISSUE_418.len(), ISSUE_999);
+    assert!(
+        !foreign_owner.contains(ISSUE_421),
+        "the foreign-owner mutant must not rely on the Issue #421 substring scan"
+    );
+    assert!(
+        validate_operational_limits(&foreign_owner).is_err(),
+        "an operational-limit difference owned by an unapproved Issue must fail"
     );
 }
 

--- a/tools/compat/tests/manifest.rs
+++ b/tools/compat/tests/manifest.rs
@@ -441,66 +441,121 @@ fn rejects_known_difference_governance_fields_when_missing() {
 
 #[test]
 fn repository_vector_operational_limits_are_explicitly_governed() {
-    let manifest = parse_valid(include_str!(
-        "../../../tests/compat/redis-8.8.1/manifest.yaml"
-    ));
-    let expected = [
-        (
-            "VADD",
-            &[
-                "max_dimension",
-                "max_vector_bytes",
-                "max_element_bytes",
-                "raw",
-            ][..],
-        ),
-        (
-            "VSIM",
-            &["max_dimension", "max_vector_bytes", "max_element_bytes"][..],
-        ),
-        ("VEMB", &["max_element_bytes"][..]),
-        ("VREM", &["max_element_bytes"][..]),
-        ("VISMEMBER", &["max_element_bytes"][..]),
-    ];
+    const ISSUE_418: &str = "https://github.com/arana-db/kiwi/issues/418";
+    const ISSUE_421: &str = "https://github.com/arana-db/kiwi/issues/421";
+    const OPERATIONAL_LIMIT_PREFIX: &str = "Operational-limit difference:";
 
-    for (name, reason_terms) in expected {
-        let command = manifest
-            .commands()
+    fn validate_operational_limits(yaml: &str) -> Result<(), String> {
+        let manifest = parse_valid(yaml);
+        let expected = [
+            (
+                "VADD",
+                &[
+                    "max_dimension",
+                    "max_vector_bytes",
+                    "max_element_bytes",
+                    "raw",
+                ][..],
+            ),
+            (
+                "VSIM",
+                &["max_dimension", "max_vector_bytes", "max_element_bytes"][..],
+            ),
+            ("VEMB", &["max_element_bytes"][..]),
+            ("VREM", &["max_element_bytes"][..]),
+            ("VISMEMBER", &["max_element_bytes"][..]),
+        ];
+        let expected_commands = expected
             .iter()
-            .find(|command| command.command() == name)
-            .unwrap_or_else(|| panic!("{name} must be registered"));
-        assert_eq!(command.classification(), Classification::KnownDifference);
-        assert_eq!(
-            command.modes().get(&Mode::StandaloneCacheOff),
-            Some(&Classification::KnownDifference)
-        );
+            .map(|(name, _)| *name)
+            .collect::<BTreeSet<_>>();
+        let mut observed_commands = BTreeSet::new();
 
-        let difference = command
-            .known_differences()
-            .iter()
-            .find(|difference| difference.issue() == "https://github.com/arana-db/kiwi/issues/421")
-            .unwrap_or_else(|| panic!("{name} must register the Issue #421 limit difference"));
-        assert_eq!(difference.owner(), "cmd-vector");
-        assert_eq!(difference.affected(), "standalone_cache_off; resp2/resp3");
-        assert_eq!(
-            difference.last_verified_ref(),
-            format!("redis-source:{REDIS_COMMIT}")
-        );
-        let reason = difference.reason().to_ascii_lowercase();
-        for term in reason_terms {
-            assert!(
-                reason.contains(term),
-                "{name} Issue #421 reason must mention {term}"
-            );
+        for command in manifest.commands() {
+            let differences = command
+                .known_differences()
+                .iter()
+                .filter(|difference| difference.reason().starts_with(OPERATIONAL_LIMIT_PREFIX))
+                .collect::<Vec<_>>();
+            if differences.len() > 1 {
+                return Err(format!(
+                    "{} must register exactly one operational-limit difference",
+                    command.command()
+                ));
+            }
+            let Some(difference) = differences.first() else {
+                continue;
+            };
+
+            let name = command.command();
+            observed_commands.insert(name);
+            let Some((_, reason_terms)) = expected.iter().find(|(expected, _)| *expected == name)
+            else {
+                return Err(format!("unexpected operational-limit command {name}"));
+            };
+            if command.classification() != Classification::KnownDifference
+                || command.modes().get(&Mode::StandaloneCacheOff)
+                    != Some(&Classification::KnownDifference)
+            {
+                return Err(format!("{name} must remain a known difference"));
+            }
+            if difference.issue() != ISSUE_418 {
+                return Err(format!(
+                    "{name} operational-limit difference must be owned by Issue #418"
+                ));
+            }
+            if difference.owner() != "cmd-vector"
+                || difference.affected() != "standalone_cache_off; resp2/resp3"
+                || difference.last_verified_ref() != format!("redis-source:{REDIS_COMMIT}")
+            {
+                return Err(format!(
+                    "{name} operational-limit governance metadata must remain intact"
+                ));
+            }
+            let reason = difference.reason().to_ascii_lowercase();
+            for term in *reason_terms {
+                if !reason.contains(term) {
+                    return Err(format!(
+                        "{name} operational-limit reason must mention {term}"
+                    ));
+                }
+            }
+            let removal = difference.remove_when().to_ascii_lowercase();
+            for term in ["raw", "resp2", "resp3", "boundary"] {
+                if !removal.contains(term) {
+                    return Err(format!(
+                        "{name} operational-limit removal condition must mention {term}"
+                    ));
+                }
+            }
         }
-        let removal = difference.remove_when().to_ascii_lowercase();
-        for term in ["raw", "resp2", "resp3", "boundary"] {
-            assert!(
-                removal.contains(term),
-                "{name} Issue #421 removal condition must mention {term}"
-            );
+
+        if observed_commands != expected_commands {
+            return Err(format!(
+                "operational-limit commands must be exactly {expected_commands:?}, found {observed_commands:?}"
+            ));
         }
+        if yaml.contains(ISSUE_421) {
+            return Err("the compatibility manifest must not retain Issue #421 ownership".into());
+        }
+        Ok(())
     }
+
+    let yaml = include_str!("../../../tests/compat/redis-8.8.1/manifest.yaml");
+    validate_operational_limits(yaml).unwrap();
+
+    let reason_index = yaml
+        .find("reason: \"Operational-limit difference:")
+        .expect("the repository manifest must contain an operational-limit difference");
+    let issue_index = yaml[..reason_index]
+        .rfind(ISSUE_418)
+        .expect("the first operational-limit difference must be owned by Issue #418");
+    let mut reverted = yaml.to_owned();
+    reverted.replace_range(issue_index..issue_index + ISSUE_418.len(), ISSUE_421);
+    assert!(
+        validate_operational_limits(&reverted).is_err(),
+        "restoring one operational-limit owner to Issue #421 must fail"
+    );
 }
 
 #[test]

--- a/tools/compat/tests/manifest.rs
+++ b/tools/compat/tests/manifest.rs
@@ -542,7 +542,8 @@ fn repository_vector_operational_limits_are_explicitly_governed() {
     }
 
     let yaml = include_str!("../../../tests/compat/redis-8.8.1/manifest.yaml");
-    validate_operational_limits(yaml).unwrap();
+    validate_operational_limits(yaml)
+        .expect("repository operational-limit governance must remain valid");
 
     let reason_index = yaml
         .find("reason: \"Operational-limit difference:")


### PR DESCRIPTION
## Summary

- record PR #422 exact-main acceptance as the authoritative WP8 state
- move active Vector operational-limit ownership from #421 to open #418
- move the rkyv advisory exception ownership from WP8/#421 to open #430
- strengthen the SDD, manifest, and audit governance validators with discriminative failure-path tests

## Verification

- `python -I -B scripts/validate_sdd.py --self-test`
- `python -I -B scripts/validate_sdd.py` (`errors=0`, WP8 `accepted`)
- `cargo test -p kiwi-compat --test manifest` (49 passed)
- `cargo test -p kiwi-compat --test ci_contract` (26 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p kiwi-compat --all-targets -- -D warnings`
- independent review: P0=0, P1=0, P2=0; Test Guard 0 findings

Refs #421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated WP8 closeout records and marked the work package as accepted.
  * Added verification evidence, migration details, and follow-up tracking information.

* **Bug Fixes**
  * Updated governance references for operational-limit differences and security advisory ownership.

* **Tests**
  * Expanded validation for audit governance, manifest ownership, verification evidence, Git history, and CI results.
  * Added checks that reject outdated, duplicate, or incomplete governance metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->