### PR TITLE
fix(storage): report compatibility refusals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2718,6 +2718,7 @@ dependencies = [
  "crc16",
  "foyer",
  "kstd",
+ "libc",
  "log",
  "moka",
  "murmur3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ quote = "1.0"
 syn = { version = "3.0", features = ["extra-traits", "full"] }
 env_logger = "0.11"
 log = "0.4"
+libc = "0.2.186"
 # Kiwi uses the Arana-maintained arana-db/rust-rocksdb fork to provide the
 # TableProperties Collector/Factory FFI required by Storage LogIndex. The
 # maintenance tag names the baseline; Cargo.lock records the resolved commit.

--- a/docs/superpowers/plans/2026-08-19-storage-compatibility-diagnostics.md
+++ b/docs/superpowers/plans/2026-08-19-storage-compatibility-diagnostics.md
@@ -1,0 +1,158 @@
+# Storage 兼容拒绝诊断契约实施计划
+
+> **执行要求：** 使用 `test-driven-development` 先证明真实 `Storage::open` 在旧实现上
+> 缺少诊断字段，再做最小实现；提交/PR/合并前使用
+> `verification-before-completion`。不得修改治理 worktree 或根工作区。
+
+**目标：** 闭合 Issue #342 剩余验收项，使生产 `Storage::open` 的每个格式兼容拒绝
+稳定包含 `current`、`on_disk`、`action` 和原始 `cause`，且不改变任何磁盘格式或迁移
+状态机。
+
+**架构：** 在 Storage admission 边界只包装格式/严格 RocksDB open 错误；一个只读、
+有界 descriptor helper 描述失败时落盘格式；内部 manifest/migration helper 继续返回
+精确 cause。状态发布顺序不变。
+
+**基线：** `main@9a8a64aca12a825912f299450e10fc6043eca610`。
+
+**设计：**
+`docs/superpowers/specs/2026-08-19-storage-compatibility-diagnostics-design.md`。
+
+---
+
+## 文件所有权
+
+- `src/storage/src/storage_manifest.rs`：current/on-disk descriptor 的常量与只读 helper。
+- `src/storage/src/storage.rs`：生产 admission 边界的一次性兼容诊断包装。
+- `src/storage/tests/storage_manifest_v2_test.rs`：future/corrupt/topology/缺失实例的真实
+  `Storage::open` RED/GREEN。
+- `src/storage/tests/storage_migration_test.rs`：unknown legacy/comparator 严格 open 与已知
+  migration 正向回归；仅确有需要时修改。
+- `src/storage/tests/redis_vector_test.rs`：只读确认旧单实例入口语义；不以它代替生产
+  证据。
+- `src/storage/src/storage_migration.rs`：默认不修改；只有 descriptor/action 必须消费
+  已有公开分类且无法在 manifest/storage 层完成时才做外科式改动。
+- 本计划和对应设计文档：批准范围与执行证据。
+
+## 环境基线
+
+- [x] Windows 共享 target 中 `redis_vector_test` 编译成功，但进程启动返回
+  `STATUS_ENTRYPOINT_NOT_FOUND (0xc0000139)`；这不是测试 RED/GREEN 证据。
+- [ ] 后续 Windows 复验使用任务专属 `CARGO_TARGET_DIR`；若 native DLL 仍阻塞，使用
+  WSL/Linux 作为 RocksDB 行为权威，并记录 Windows 环境缺口。不得 clean 共享缓存。
+
+## Task 1：定义权威断言 helper
+
+**文件：** `src/storage/tests/storage_manifest_v2_test.rs`
+
+- [ ] 增加 `assert_storage_compatibility_refusal`，要求错误 Display：
+  - `storage compatibility refusal:` 恰好一次；
+  - `current=`、`on_disk=`、`action=`、`cause=` 各恰好一次且非空；
+  - caller 指定的 on-disk/cause 关键证据存在；
+  - `Storage::insts` 为空且 `is_opened` 为 false。
+- [ ] helper 不接受字段仅出现在 Debug/stack trace；断言真实用户可见 Display。
+
+## Task 2：真实 `Storage::open` RED fixtures
+
+**文件：**
+
+- `src/storage/tests/storage_manifest_v2_test.rs`
+- `src/storage/tests/storage_migration_test.rs`（unknown legacy/comparator fixture 如需）
+
+- [ ] future Root manifest：把合法 root JSON 的 `manifest_version` 改为 99，写到真实
+  root 路径，调用 `Storage::open`，要求 `on_disk` 体现 v99 且 cause 保留 unsupported
+  version。
+- [ ] corrupt Root manifest：写损坏 digest 或非 JSON，要求
+  `on_disk=root-manifest-present-unreadable` 且 cause 保留 digest/JSON 详情。
+- [ ] topology mismatch：合法 Root 的 `db_instance_num=2`，用 `Storage::new(3, ...)`
+  打开，要求 descriptor 和可执行 action。
+- [ ] missing/invalid instance：合法 Root 下缺少实例或 instance manifest，要求 envelope
+  且不重建目录/不发布 Storage。
+- [ ] unregistered legacy CF 或 comparator mismatch：通过现有 legacy fixture/真实
+  RocksDB 创建，要求原始 RocksDB comparator/CF 详情出现在 `cause`，而不是当前只有
+  `RocksDB error` 的丢失文本。
+- [ ] 运行每个精确测试。预期 RED：旧实现只含局部 cause，缺统一字段；comparator
+  fixture 还应证明当前 Display 丢失 RocksDB source 详情。
+
+fixture/setup、文件锁、`STATUS_ENTRYPOINT_NOT_FOUND` 或 cleanup 失败都不是有效 RED。
+
+## Task 3：实现有界只读 on-disk descriptor
+
+**文件：** `src/storage/src/storage_manifest.rs`
+
+- [ ] 从现有 Root/Instance/schema 常量组合唯一 `current` descriptor，不复制版本魔法数。
+- [ ] 增加 crate-private descriptor helper：
+  - 不存在/空目录返回 `empty`；
+  - Root manifest 存在时只读固定上限字节，超过上限或解析失败返回
+    `root-manifest-present-unreadable`；
+  - 在不要求 digest/完整 schema 合法的前提下提取 numeric `manifest_version` 和
+    `storage_schema_version`；
+  - Root manifest 缺失但目录非空返回 `legacy-without-root-manifest`；
+  - metadata/read 失败返回 `unavailable`，不覆盖原 open error。
+- [ ] 用 `symlink_metadata` 拒绝明显 manifest symlink；descriptor 只用于诊断，不能
+  创建目录、打开 RocksDB 或调用 migration。
+- [ ] 单元/集成断言读取上限、unreadable fallback 和版本提取；不要为诊断实现第二套
+  manifest validator。
+
+## Task 4：实现 production admission envelope
+
+**文件：** `src/storage/src/storage.rs`
+
+- [ ] 增加单一 wrapper，把 `InvalidFormat` 与严格 RocksDB open 的兼容拒绝格式化为：
+
+  ```text
+  storage compatibility refusal: current=...; on_disk=...; action=...; cause=...
+  ```
+
+- [ ] 对 RocksDB variant 显式使用内部 source 的 Display，保留 comparator/CF 具体错误；
+  不得只嵌入外层 `RocksDB error`。
+- [ ] action 根据 descriptor/cause 做最小分类；只引用已有 staged migration、匹配版本、
+  离线检查或备份恢复，不发明 CLI。
+- [ ] wrapper 应用于以下每个 `Storage::open` admission step：migration prepare/resume、
+  Root load、instance validation、strict instance open、migration finalize 后的第二次验证/
+  reopen。
+- [ ] 内部 helper 不包装，避免 `current=` 等字段嵌套两次。
+- [ ] 普通 I/O variant 原样返回；背景任务启动后的非兼容错误不进入本 wrapper。
+- [ ] `self.insts`、`db_path`、background/expiration publication 行保持原顺序。
+
+## Task 5：GREEN 与正向不回归
+
+- [ ] 重跑 Task 2 的每个精确测试，预期 GREEN。
+- [ ] 增加/保留正向测试：empty root 创建成功；current v2 reopen 成功；Base-v1 和
+  Vector-v1 已知 staged migration 成功；rollback/finalize 关键状态用例成功。
+- [ ] mutant：分别删除 current、on_disk、action、cause，或只包装第一次 Root load；
+  权威测试必须失败。
+- [ ] comparator mutant 把 Rocks source 退回外层 `RocksDB error`，测试必须失败。
+
+## Task 6：风险匹配验证与 Test Guard
+
+- [ ] 任务专属 Windows target 或 WSL：
+  `cargo test -p storage --test storage_manifest_v2_test`
+- [ ] WSL/Linux：
+  `cargo test -p storage --features test-fault-injection --test storage_migration_test`
+  （至少精确 diagnostic + migration 正向集；资源允许时全文件）。
+- [ ] `cargo test -p storage --test redis_vector_test` 的相关生产入口/manifest 回归；若
+  Windows DLL 阻塞，记录并由 Linux gate覆盖。
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy -p storage --all-targets --features test-fault-injection -- -D warnings`
+- [ ] `git diff --check origin/main...HEAD`
+- [ ] Test Guard 检查 fixtures 真实调用 `Storage::open`、旧实现确实 RED、没有仅测试
+  helper 自己、cleanup 失败不会被吞掉。
+
+## Task 7：独立复审、提交和 PR
+
+- [ ] 规格复审：四字段、真实生产边界、非目标和 #342 验收一致，P0/P1/P2 全零。
+- [ ] 质量复审：错误分类、Rocks source、bounded inspection、状态不发布和 tests/mutants
+  均闭合，P0/P1/P2 全零。
+- [ ] 只提交计划列出的文件；检查 worktree ownership 和 committed diff。
+- [ ] push `codex/storage-diagnostic-contract`，创建独立 PR，使用 `Refs #342`，避免在
+  exact-main 证据前自动关闭。
+- [ ] 等待 exact Head checks 成功，复核 mergeability/threads 后合并。
+
+## Task 8：exact-main 与 #342 关闭
+
+- [ ] 获取诊断 PR merge SHA，等待该 SHA 或其 exact main 后继的 CI push run 成功。
+- [ ] 在 main 上确认生产 `Storage::open` tests 和四字段合同仍存在。
+- [ ] 在 #342 留下九项验收逐项映射、PR、merge SHA、exact-main run、测试命令和典型
+  future/corrupt/topology/comparator 诊断。
+- [ ] 以 completed 关闭 #342 并重新读取 Issue 状态确认。
+- [ ] 不修改 #325、#340、#418、#421 或 #430 的状态（#421 由另一治理计划独立收口）。

--- a/docs/superpowers/plans/2026-08-19-storage-compatibility-diagnostics.md
+++ b/docs/superpowers/plans/2026-08-19-storage-compatibility-diagnostics.md
@@ -21,16 +21,20 @@
 
 ## 文件所有权
 
-- `src/storage/src/storage_manifest.rs`：current/on-disk descriptor 的常量与只读 helper。
-- `src/storage/src/storage.rs`：生产 admission 边界的一次性兼容诊断包装。
+- `src/storage/src/error.rs`：共享 strict Rocks mapper 与 bounded/escaped envelope formatter。
+- `src/storage/src/storage_manifest.rs`：typed current/on-disk descriptor、只读 observer，
+  以及 canonical CF mismatch 的首个 actual/expected detail。
+- `src/storage/src/storage.rs`：生产 admission step 的一次性兼容诊断包装。
+- `src/storage/src/redis.rs`：existing-v2 strict open 的 InvalidArgument 分类。
 - `src/storage/tests/storage_manifest_v2_test.rs`：future/corrupt/topology/缺失实例的真实
   `Storage::open` RED/GREEN。
 - `src/storage/tests/storage_migration_test.rs`：unknown legacy/comparator 严格 open 与已知
   migration 正向回归；仅确有需要时修改。
 - `src/storage/tests/redis_vector_test.rs`：只读确认旧单实例入口语义；不以它代替生产
   证据。
-- `src/storage/src/storage_migration.rs`：默认不修改；只有 descriptor/action 必须消费
-  已有公开分类且无法在 manifest/storage 层完成时才做外科式改动。
+- `src/storage/src/storage_migration.rs`：legacy `open_instance_strict` InvalidArgument 分类。
+- `src/storage/tests/support/legacy_storage.rs`：仅为真实错误 comparator fixture 增加最小
+  构造 helper（如测试内无法清晰完成）。
 - 本计划和对应设计文档：批准范围与执行证据。
 
 ## 环境基线
@@ -59,59 +63,84 @@
 - `src/storage/tests/storage_migration_test.rs`（unknown legacy/comparator fixture 如需）
 
 - [ ] future Root manifest：把合法 root JSON 的 `manifest_version` 改为 99，写到真实
-  root 路径，调用 `Storage::open`，要求 `on_disk` 体现 v99 且 cause 保留 unsupported
-  version。
+  root 路径，刷新 canonical payload digest，调用 `Storage::open`，要求 `on_disk` 体现
+  v99 且 cause 保留 unsupported version；增加 future Instance manifest 的同类 fixture。
 - [ ] corrupt Root manifest：写损坏 digest 或非 JSON，要求
   `on_disk=root-manifest-present-unreadable` 且 cause 保留 digest/JSON 详情。
 - [ ] topology mismatch：合法 Root 的 `db_instance_num=2`，用 `Storage::new(3, ...)`
   打开，要求 descriptor 和可执行 action。
 - [ ] missing/invalid instance：合法 Root 下缺少实例或 instance manifest，要求 envelope
   且不重建目录/不发布 Storage。
-- [ ] unregistered legacy CF 或 comparator mismatch：通过现有 legacy fixture/真实
-  RocksDB 创建，要求原始 RocksDB comparator/CF 详情出现在 `cause`，而不是当前只有
-  `RocksDB error` 的丢失文本。
+- [ ] Root manifest CF contract table：分别改 CF name/role/comparator/key codec/value
+  codec 并刷新 digest，要求首个 mismatch 的 field/current/on-disk 详情。
+- [ ] current-v2 comparator mismatch：合法 Root/Instance v2 manifests 和 canonical CF
+  names，但 `list_data_cf` 持久化默认 comparator；调用真实 `Storage::open`，必须走
+  `redis.rs` strict open。
+- [ ] Base-v1 comparator mismatch：六个 Base CF、无 manifests，同样错误 comparator；
+  调用真实 `Storage::open`，必须走 `open_instance_strict`，且失败前不产生 Root journal、
+  shadow 或 backup。
+- [ ] 合法 v2 DB 的另一个 handle 保持 LOCK/Busy，再调用 `Storage::open`；要求原
+  `Error::Rocks` 且没有 envelope，杀死“包装所有 Rocks kinds” mutant。
 - [ ] 运行每个精确测试。预期 RED：旧实现只含局部 cause，缺统一字段；comparator
   fixture 还应证明当前 Display 丢失 RocksDB source 详情。
 
 fixture/setup、文件锁、`STATUS_ENTRYPOINT_NOT_FOUND` 或 cleanup 失败都不是有效 RED。
 
-## Task 3：实现有界只读 on-disk descriptor
+## Task 3：实现 bounded formatter、descriptor 与 observer
 
-**文件：** `src/storage/src/storage_manifest.rs`
+**文件：**
 
-- [ ] 从现有 Root/Instance/schema 常量组合唯一 `current` descriptor，不复制版本魔法数。
+- `src/storage/src/error.rs`
+- `src/storage/src/storage_manifest.rs`
+
+- [ ] 从现有 Root/Instance/schema/slot 常量组合唯一 `current` descriptor；CF contract
+  复用 storage schema v2，不发明 `cf-schema-current`。
+- [ ] formatter 编码 `%`、`;`、`=`、CR/LF/控制字符，对每个字段固定上限和截断标记；
+  测试含 `; current=` 和换行的值仍只出现一次字段 key。
 - [ ] 增加 crate-private descriptor helper：
   - 不存在/空目录返回 `empty`；
   - Root manifest 存在时只读固定上限字节，超过上限或解析失败返回
     `root-manifest-present-unreadable`；
-  - 在不要求 digest/完整 schema 合法的前提下提取 numeric `manifest_version` 和
-    `storage_schema_version`；
+  - 在不要求 digest/完整 schema 合法的前提下提取 numeric `manifest_version`、
+    `storage_schema_version` 和 bounded migration profile/phase/current instance；
   - Root manifest 缺失但目录非空返回 `legacy-without-root-manifest`；
   - metadata/read 失败返回 `unavailable`，不覆盖原 open error。
-- [ ] 用 `symlink_metadata` 拒绝明显 manifest symlink；descriptor 只用于诊断，不能
-  创建目录、打开 RocksDB 或调用 migration。
+- [ ] Root manifest 必须是 regular file；held handle 最多读取 `MAX+1`。Unix nofollow/
+  nonblock，Windows reparse 拒绝，打开后复核 handle metadata；FIFO/socket/device/
+  directory 不得阻塞。
 - [ ] 单元/集成断言读取上限、unreadable fallback 和版本提取；不要为诊断实现第二套
   manifest validator。
 
-## Task 4：实现 production admission envelope
+## Task 4：实现 strict-open 分类与 production admission envelope
 
-**文件：** `src/storage/src/storage.rs`
+**文件：**
 
-- [ ] 增加单一 wrapper，把 `InvalidFormat` 与严格 RocksDB open 的兼容拒绝格式化为：
+- `src/storage/src/error.rs`
+- `src/storage/src/redis.rs`
+- `src/storage/src/storage_migration.rs`
+- `src/storage/src/storage.rs`
+
+- [ ] shared mapper 仅把 existing-storage strict open 的
+  `rocksdb::ErrorKind::InvalidArgument` 转成带内层 `into_string()` 的 InvalidFormat；
+  其他 ErrorKind 保持原 Rocks error。
+- [ ] `redis.rs` 只在 `allow_manifest_creation=false` 的 existing-v2 open 使用 mapper；
+  新建空实例不重标。
+- [ ] `storage_migration.rs::open_instance_strict` 使用同一 mapper；`DB::list_cf`、iterator、
+  copy 等路径不使用。
+- [ ] 增加单一 wrapper，把五个 admission step 返回的 `InvalidFormat` 格式化为：
 
   ```text
   storage compatibility refusal: current=...; on_disk=...; action=...; cause=...
   ```
 
-- [ ] 对 RocksDB variant 显式使用内部 source 的 Display，保留 comparator/CF 具体错误；
-  不得只嵌入外层 `RocksDB error`。
-- [ ] action 根据 descriptor/cause 做最小分类；只引用已有 staged migration、匹配版本、
-  离线检查或备份恢复，不发明 CLI。
+- [ ] action 根据 typed `AdmissionStep + OnDiskDescriptor` 做最小分类，不解析 cause
+  substring；registered legacy 文案说明当前启动本身执行 staged migration，
+  unregistered/corrupt legacy 要求兼容二进制逻辑导出/空 v2 导入。
 - [ ] wrapper 应用于以下每个 `Storage::open` admission step：migration prepare/resume、
   Root load、instance validation、strict instance open、migration finalize 后的第二次验证/
   reopen。
 - [ ] 内部 helper 不包装，避免 `current=` 等字段嵌套两次。
-- [ ] 普通 I/O variant 原样返回；背景任务启动后的非兼容错误不进入本 wrapper。
+- [ ] 普通 I/O 和未映射 Rocks variant 原样返回；背景任务启动后的非兼容错误不进入。
 - [ ] `self.insts`、`db_path`、background/expiration publication 行保持原顺序。
 
 ## Task 5：GREEN 与正向不回归
@@ -121,7 +150,10 @@ fixture/setup、文件锁、`STATUS_ENTRYPOINT_NOT_FOUND` 或 cleanup 失败都�
   Vector-v1 已知 staged migration 成功；rollback/finalize 关键状态用例成功。
 - [ ] mutant：分别删除 current、on_disk、action、cause，或只包装第一次 Root load；
   权威测试必须失败。
-- [ ] comparator mutant 把 Rocks source 退回外层 `RocksDB error`，测试必须失败。
+- [ ] comparator mutants：退回外层 `RocksDB error`、只修 v2、只修 legacy、包装所有
+  Rocks kinds，分别被两条 comparator test 和 LOCK/Busy test 杀死。
+- [ ] observer/formatter mutants：跟随 symlink、阻塞 FIFO、无读取上限、字段不编码、
+  action 解析 cause substring，权威测试必须失败。
 
 ## Task 6：风险匹配验证与 Test Guard
 
@@ -136,7 +168,8 @@ fixture/setup、文件锁、`STATUS_ENTRYPOINT_NOT_FOUND` 或 cleanup 失败都�
 - [ ] `cargo clippy -p storage --all-targets --features test-fault-injection -- -D warnings`
 - [ ] `git diff --check origin/main...HEAD`
 - [ ] Test Guard 检查 fixtures 真实调用 `Storage::open`、旧实现确实 RED、没有仅测试
-  helper 自己、cleanup 失败不会被吞掉。
+  helper 自己、current-v2/legacy strict open 均真实覆盖、fresh digest 与目录不变性成立、
+  cleanup 失败不会被吞掉。
 
 ## Task 7：独立复审、提交和 PR
 

--- a/docs/superpowers/specs/2026-08-19-storage-compatibility-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-08-19-storage-compatibility-diagnostics-design.md
@@ -1,0 +1,176 @@
+# Storage 兼容拒绝诊断契约设计
+
+## 文档状态
+
+- 日期：2026-08-19
+- 状态：用户已批准，待实施与独立复审
+- 仓库：`arana-db/kiwi`
+- 实施基线：`main@9a8a64aca12a825912f299450e10fc6043eca610`
+- 目标 Issue：[Issue #342](https://github.com/arana-db/kiwi/issues/342)
+- Related implementation：[PR #422](https://github.com/arana-db/kiwi/pull/422)
+
+PR #422 已实现 Root/Instance StorageManifest v2、已知 Base-v1 与 Vector-v1 staged
+migration、恢复/回滚和未来/无效格式的 fail-closed 门禁。Issue #342 的剩余硬性
+验收缺口是：从生产 `Storage::open` 拒绝已有目录时，错误没有统一、稳定地同时给出
+当前格式、落盘格式和可执行处理方式。
+
+本文只补诊断合同，不改变任何可接受格式、迁移状态机、回滚窗口、磁盘字节、目录
+切换或 RocksDB 打开顺序。
+
+## 1. 问题
+
+当前兼容拒绝由 `storage_manifest.rs` 和 `storage_migration.rs` 的多个
+`InvalidFormat`/RocksDB 错误直接向上传播。详细 cause 通常准确，但调用者无法稳定
+解析以下三个运维问题：
+
+```text
+current=<当前二进制支持的存储合同>
+on_disk=<本次被拒绝目录的可观察格式>
+action=<不会破坏原目录的下一步>
+```
+
+现有测试主要断言内部 parser 或 migration helper 的局部 substring；它们不能证明
+server 实际调用的 `Storage::open` 在 RocksDB 对外服务前返回完整诊断，也不能防止
+以后某条新增拒绝路径漏掉字段。
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+- 为 `Storage::open` admission 阶段的每个格式/兼容性拒绝增加统一 envelope，固定
+  `current=...; on_disk=...; action=...; cause=...` 四部分。
+- `current` 来自编译期 StorageManifest/Schema 常量，不能由错误字符串猜测。
+- `on_disk` 来自失败时对目标根目录的只读、有界观察；即使 manifest 损坏、来自未来
+  版本或缺失，也必须返回确定 descriptor，而不是产生第二个错误覆盖原 cause。
+- `action` 只建议仓库真实支持的安全操作：使用匹配版本、运行已有 staged migration、
+  恢复兼容备份或先离线检查；不得承诺不存在的在线自动修复或 CLI。
+- 保留原始 cause 文本，方便定位 manifest、topology、CF、comparator 或 migration
+  phase 的精确拒绝原因。
+- 通过真实 `Storage::open` 回归测试证明拒绝发生在 state publication 之前，目录没有
+  被静默采用。
+
+### 2.2 非目标
+
+- 不新增 StorageManifest 字段、版本或文件。
+- 不改变 Base-v1 / Vector-v1 的已知迁移支持矩阵。
+- 不允许未来版本、未知 CF、损坏 digest、topology mismatch 或非法 migration journal
+  继续打开。
+- 不为所有历史开发版本新增迁移器，也不新增 `adopt`/`repair` 命令。
+- 不把普通运行时 I/O、后台任务或业务数据错误错误标记为格式兼容拒绝。
+- 不修改 `Redis::open` 的单实例内部测试入口来代替生产 `Storage::open` 证据。
+
+## 3. 诊断格式
+
+统一字符串使用单行、稳定 key 顺序：
+
+```text
+storage compatibility refusal: current=<descriptor>; on_disk=<descriptor>; action=<instruction>; cause=<original error>
+```
+
+字段值不得包含换行。`cause` 保持当前错误的 Display 内容。
+
+### 3.1 current descriptor
+
+`current` 至少包含：
+
+- Root manifest version；
+- storage schema version；
+- Instance manifest version；
+- canonical CF schema 身份或版本。
+
+它由现有常量组合，例如：
+
+```text
+root-manifest-v2/storage-schema-v2/instance-manifest-v2/cf-schema-current
+```
+
+不得复制魔法数字；常量变化时诊断和 validator/test fixture 必须同时变化。
+
+### 3.2 on_disk descriptor
+
+失败后只读观察按以下优先级生成：
+
+1. 根目录不存在或为空：`empty`；这种情况通常不属于 compatibility refusal。
+2. Root manifest 存在且可安全提取版本字段：记录
+   `root-manifest-vX/storage-schema-vY`；不要求 manifest 整体验证成功。
+3. Root manifest 存在但不是受支持、可解析的 bounded JSON：
+   `root-manifest-present-unreadable`。
+4. Root manifest 缺失但存在实例/legacy 内容：`legacy-without-root-manifest`。
+5. 目录本身无法安全观察：`unavailable`，并保留原 cause。
+
+观察器必须是 fail-safe：只读、限制读取大小、不跟随用于诊断的 manifest symlink、
+不打开 RocksDB、不写 manifest、不创建目录。观察失败只能降级 descriptor，不能覆盖
+导致 `Storage::open` 失败的原错误。
+
+### 3.3 action
+
+最小稳定 action 按 descriptor/cause 分类：
+
+- 已知 legacy 且 staged migration 可用：明确先用兼容 Kiwi 执行 staged migration，
+  在完成前不要对外服务。
+- future/unsupported version：使用能够读取该版本的 Kiwi，或从兼容备份恢复；不要用
+  当前二进制修改目录。
+- corrupt/unreadable/unknown layout：离线检查并从已验证备份恢复；不要静默初始化。
+- runtime topology mismatch：使用匹配的 `db_instance_num`，或通过受支持的离线迁移
+  产生匹配目录。
+- 其他兼容拒绝：保留目录，依据 cause 选择兼容版本、已有 staged migration 或备份
+  恢复。
+
+文案可以共享 helper，但不能宣称系统拥有实际不存在的自动修复入口。
+
+## 4. 注入边界
+
+诊断只在 `Storage::open` 的 admission 路径注入，覆盖：
+
+1. `prepare_or_resume_migration`；
+2. `load_or_create_root_manifest`；
+3. `validate_existing_instance_manifests`；
+4. instances 尚未发布前的严格 RocksDB/manifest binding open；
+5. runtime finalize migration 后的第二次 root/instance 验证与 reopen。
+
+helper 只包装能够表示格式/兼容性的 `InvalidFormat` 和严格 RocksDB open 拒绝；普通
+I/O 等非兼容错误保持原 error category。`self.insts`、`self.db_path`、background task
+和 expiration manager 的发布顺序不变。
+
+内部 parser/migration helper 保持现有详细错误，避免把 envelope 重复嵌套。只有公开
+生产 admission 边界负责一次包装。
+
+## 5. TDD 与变异证明
+
+至少增加以下真实入口测试，均调用 `Storage::open`：
+
+1. future Root manifest version：旧实现只返回 unsupported cause，新增测试要求四字段；
+2. configured topology 与 on-disk Root 不匹配：要求 current/on_disk/action/cause；
+3. unregistered legacy CF layout 或缺失/非法 legacy manifest：要求 safe action 且打开
+   后 Storage 未发布实例；
+4. 损坏 Root manifest：要求 `on_disk=root-manifest-present-unreadable` 并保留 digest/
+   JSON cause；
+5. 正向 empty/current/known migration fixture 继续成功，证明没有扩大拒绝范围。
+
+RED 必须在基线实现上因缺少字段失败，而不是 fixture、RocksDB lock 或路径清理失败。
+mutant 至少分别删除 `current`、`on_disk`、`action`，以及绕过 production
+`Storage::open` wrapper；每个 mutant 都必须被权威测试拒绝。
+
+## 6. Issue 关闭顺序
+
+1. 按 RED/GREEN 实施最小代码和测试。
+2. 运行 targeted Storage tests、format、Clippy、diff check，并通过独立规格与质量/
+   Test Guard 复审。
+3. 提交、push、创建独立 PR；等待 exact Head checks 成功后合并。
+4. 等待合并后新 main 的 CI 成功，并在 exact-main 重跑最强相关测试或确认对应 CI job。
+5. 在 #342 评论九项验收映射、PR、merge SHA、exact-main run 和诊断示例，然后以
+   completed 关闭。
+
+任何一步未完成都保持 #342 OPEN。不得因为 PR #422 已合并而跳过本诊断 PR 的
+exact-main 证据。
+
+## 7. 验收标准
+
+- 每个生产 `Storage::open` compatibility refusal 都恰好包含一次 `current=`、
+  `on_disk=`、`action=` 和 `cause=`。
+- future、corrupt、unknown legacy、topology mismatch 至少四种真实目录 fixture 通过。
+- 原错误 cause 保留；非兼容 I/O 错误不被错误包装。
+- 已知 migration、rollback/finalize 状态机和磁盘格式无行为变化。
+- 失败打开不会发布 instances、db path 或 background tasks。
+- 独立规格复审与质量/Test Guard 复审均为 P0=0/P1=0/P2=0。
+- PR exact Head 与合并后的 exact main 验证成功后才关闭 #342。

--- a/docs/superpowers/specs/2026-08-19-storage-compatibility-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-08-19-storage-compatibility-diagnostics-design.md
@@ -67,7 +67,11 @@ server 实际调用的 `Storage::open` 在 RocksDB 对外服务前返回完整�
 storage compatibility refusal: current=<descriptor>; on_disk=<descriptor>; action=<instruction>; cause=<original error>
 ```
 
-字段值不得包含换行。`cause` 保持当前错误的 Display 内容。
+字段值必须经过稳定的单行编码：至少编码 `%`、`;`、`=`、CR、LF 和控制字符；每个
+字段有固定最大长度和显式截断标记，防止路径或 RocksDB 文本伪造第二个字段、破坏
+日志行或无限放大。`InvalidFormat` cause 保留原始 message；strict RocksDB open 的
+cause 必须使用内层 `rocksdb::Error::into_string()`，不得使用只显示 `RocksDB error`
+的外层 Kiwi `Error::Rocks`。
 
 ### 3.1 current descriptor
 
@@ -78,13 +82,15 @@ storage compatibility refusal: current=<descriptor>; on_disk=<descriptor>; actio
 - Instance manifest version；
 - canonical CF schema 身份或版本。
 
-它由现有常量组合，例如：
+它由现有常量组合，固定为类似：
 
 ```text
-root-manifest-v2/storage-schema-v2/instance-manifest-v2/cf-schema-current
+root-manifest-v2/storage-schema-v2/instance-manifest-v2/slot-mapping-v1/cf-contract=storage-schema-v2
 ```
 
-不得复制魔法数字；常量变化时诊断和 validator/test fixture 必须同时变化。
+不得复制魔法数字，也不得发明没有持久化常量的 `cf-schema-current`；CF contract 复用
+`CANONICAL_COLUMN_FAMILIES` 和 storage schema v2。常量变化时诊断和 test fixture
+必须同时变化。
 
 ### 3.2 on_disk descriptor
 
@@ -92,22 +98,33 @@ root-manifest-v2/storage-schema-v2/instance-manifest-v2/cf-schema-current
 
 1. 根目录不存在或为空：`empty`；这种情况通常不属于 compatibility refusal。
 2. Root manifest 存在且可安全提取版本字段：记录
-   `root-manifest-vX/storage-schema-vY`；不要求 manifest 整体验证成功。
+   `root-manifest-vX/storage-schema-vY`；如有 migration journal，再附 source profile、
+   phase 和 current instance；不要求 manifest 整体验证成功。
 3. Root manifest 存在但不是受支持、可解析的 bounded JSON：
    `root-manifest-present-unreadable`。
 4. Root manifest 缺失但存在实例/legacy 内容：`legacy-without-root-manifest`。
 5. 目录本身无法安全观察：`unavailable`，并保留原 cause。
 
-观察器必须是 fail-safe：只读、限制读取大小、不跟随用于诊断的 manifest symlink、
-不打开 RocksDB、不写 manifest、不创建目录。观察失败只能降级 descriptor，不能覆盖
-导致 `Storage::open` 失败的原错误。
+对于 strict RocksDB comparator/CF mismatch，descriptor 还附
+`rocksdb-strict-open=invalid-argument`；具体 comparator 名称保存在 bounded cause。
+Root manifest 的 canonical CF contract mismatch 必须在 cause 中给出第一个 mismatch
+的 CF index/name、field、current/expected 和 on-disk/actual，不能继续只报泛化的
+`canonical column-family contract mismatch`。
+
+观察器必须是 fail-safe：只读、held handle、最多读取 `MAX+1` 字节；Root manifest
+必须是 regular file。Unix 使用 nofollow/nonblock 语义，Windows 拒绝 reparse point；
+打开后复核 handle metadata，FIFO/socket/device/directory 均直接降级为 unreadable/
+unavailable。观察器不打开 RocksDB、不写 manifest、不创建目录。观察失败只能降级
+descriptor，不能覆盖导致 `Storage::open` 失败的原错误。
 
 ### 3.3 action
 
 最小稳定 action 按 descriptor/cause 分类：
 
-- 已知 legacy 且 staged migration 可用：明确先用兼容 Kiwi 执行 staged migration，
-  在完成前不要对外服务。
+- registered legacy：保持目录不变并用当前 Kiwi 重试；当前启动本身会在 admission 前
+  执行 staged migration，若仍失败则按 cause 修复精确 registered-profile 问题。
+- unregistered/corrupt legacy：用真正能够打开源格式的二进制做逻辑导出，在空的
+  current-v2 storage 中导入；不得手写 manifest 或静默 adopt。
 - future/unsupported version：使用能够读取该版本的 Kiwi，或从兼容备份恢复；不要用
   当前二进制修改目录。
 - corrupt/unreadable/unknown layout：离线检查并从已验证备份恢复；不要静默初始化。
@@ -128,9 +145,19 @@ root-manifest-v2/storage-schema-v2/instance-manifest-v2/cf-schema-current
 4. instances 尚未发布前的严格 RocksDB/manifest binding open；
 5. runtime finalize migration 后的第二次 root/instance 验证与 reopen。
 
-helper 只包装能够表示格式/兼容性的 `InvalidFormat` 和严格 RocksDB open 拒绝；普通
-I/O 等非兼容错误保持原 error category。`self.insts`、`self.db_path`、background task
-和 expiration manager 的发布顺序不变。
+五个 admission step 返回的所有 `InvalidFormat` 进入统一 envelope，避免靠 cause
+substring 猜测类型。strict RocksDB open 必须先在两个真实调用点分类：
+
+- `redis.rs` 的 existing-v2 instance open：仅当 `allow_manifest_creation=false` 且
+  `ErrorKind::InvalidArgument` 时转换成保留内层 source 的 `InvalidFormat`；
+- `storage_migration.rs::open_instance_strict`：existing legacy 的
+  `ErrorKind::InvalidArgument` 同样转换；
+- `IOError`、`Busy`、`TimedOut`、`Corruption` 等保持原 `Error::Rocks`；`DB::list_cf`、
+  iterator、copy 等非 strict-open Rocks 错误也不转换。
+
+随后 `Storage::open` admission wrapper 只包装 `InvalidFormat`。普通 I/O 等非兼容错误
+保持原 error category。`self.insts`、`self.db_path`、background task 和 expiration
+manager 的发布顺序不变。
 
 内部 parser/migration helper 保持现有详细错误，避免把 envelope 重复嵌套。只有公开
 生产 admission 边界负责一次包装。
@@ -139,17 +166,28 @@ I/O 等非兼容错误保持原 error category。`self.insts`、`self.db_path`�
 
 至少增加以下真实入口测试，均调用 `Storage::open`：
 
-1. future Root manifest version：旧实现只返回 unsupported cause，新增测试要求四字段；
+1. future Root 和 Instance manifest version：修改版本后刷新 canonical digest，再通过
+   `Storage::open` 要求四字段；
 2. configured topology 与 on-disk Root 不匹配：要求 current/on_disk/action/cause；
-3. unregistered legacy CF layout 或缺失/非法 legacy manifest：要求 safe action 且打开
+3. Root canonical CF name/role/comparator/key-codec/value-codec mismatch：逐项刷新 digest，
+   要求 cause 给出首个 actual/expected mismatch；
+4. unregistered legacy CF layout 或缺失/非法 legacy manifest：要求 safe action 且打开
    后 Storage 未发布实例；
-4. 损坏 Root manifest：要求 `on_disk=root-manifest-present-unreadable` 并保留 digest/
+5. 损坏 Root manifest：要求 `on_disk=root-manifest-present-unreadable` 并保留 digest/
    JSON cause；
-5. 正向 empty/current/known migration fixture 继续成功，证明没有扩大拒绝范围。
+6. current-v2 persisted comparator mismatch：合法 v2 manifests + canonical CF names，
+   但 `list_data_cf` 使用错误持久化 comparator，必须覆盖 `redis.rs` strict open；
+7. Base-v1 persisted comparator mismatch：六 CF legacy 且同样错误 comparator，必须在
+   migration journal 写入前覆盖 `open_instance_strict`；
+8. 合法 v2 DB 保持 LOCK/Busy：仍返回原 Rocks error，不能出现 compatibility envelope；
+9. nonregular/symlink/FIFO/超大 manifest descriptor 有界失败；
+10. 正向 empty/current/known migration fixture 继续成功，证明没有扩大拒绝范围。
 
 RED 必须在基线实现上因缺少字段失败，而不是 fixture、RocksDB lock 或路径清理失败。
-mutant 至少分别删除 `current`、`on_disk`、`action`，以及绕过 production
-`Storage::open` wrapper；每个 mutant 都必须被权威测试拒绝。
+mutant 至少分别删除字段、双重包装、绕过任一 admission step、只修 v2 strict open、
+只修 legacy strict open、退回外层 `RocksDB error`、包装所有 Rocks kinds、future fixture
+不刷新 digest、observer 跟随 symlink/阻塞 FIFO/无读取上限、action 解析 cause
+substring，以及字段注入 `; current=`/换行；每个 mutant 都必须被权威测试拒绝。
 
 ## 6. Issue 关闭顺序
 

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -63,6 +63,9 @@ client = { path = "../client" }
 [target.'cfg(windows)'.dependencies]
 windows-sys.workspace = true
 
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
 proptest.workspace = true
 

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -20,7 +20,7 @@
 use std::io;
 
 use common_macro::stack_trace_debug;
-use snafu::{Location, Snafu};
+use snafu::{Location, ResultExt, Snafu};
 
 use crate::storage::BgTask;
 
@@ -173,4 +173,110 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+}
+
+const STRICT_ROCKS_OPEN_CAUSE_PREFIX: &str = "\u{1f}kiwi-strict-rocks-open-invalid-argument\u{1f}";
+const CURRENT_FIELD_LIMIT: usize = 512;
+const ON_DISK_FIELD_LIMIT: usize = 1024;
+const ACTION_FIELD_LIMIT: usize = 1024;
+const CAUSE_FIELD_LIMIT: usize = 4096;
+const TRUNCATION_MARKER: &str = "~truncated~";
+
+pub(crate) fn map_existing_strict_rocks_open<T>(
+    result: std::result::Result<T, rocksdb::Error>,
+) -> Result<T> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(error) if error.kind() == rocksdb::ErrorKind::InvalidArgument => {
+            Err(InvalidFormatSnafu {
+                message: format!("{STRICT_ROCKS_OPEN_CAUSE_PREFIX}{}", error.into_string()),
+            }
+            .build())
+        }
+        Err(error) => Err(error).context(RocksSnafu),
+    }
+}
+
+pub(crate) fn split_strict_rocks_open_cause(message: String) -> (String, bool) {
+    match message.strip_prefix(STRICT_ROCKS_OPEN_CAUSE_PREFIX) {
+        Some(cause) => (cause.to_string(), true),
+        None => (message, false),
+    }
+}
+
+pub(crate) fn format_storage_compatibility_refusal(
+    current: &str,
+    on_disk: &str,
+    action: &str,
+    cause: &str,
+) -> String {
+    format!(
+        "storage compatibility refusal: current={}; on_disk={}; action={}; cause={}",
+        encode_diagnostic_field(current, CURRENT_FIELD_LIMIT),
+        encode_diagnostic_field(on_disk, ON_DISK_FIELD_LIMIT),
+        encode_diagnostic_field(action, ACTION_FIELD_LIMIT),
+        encode_diagnostic_field(cause, CAUSE_FIELD_LIMIT),
+    )
+}
+
+fn encode_diagnostic_field(value: &str, limit: usize) -> String {
+    let mut encoded = String::with_capacity(value.len().min(limit));
+    for character in value.chars() {
+        let mut utf8 = [0_u8; 4];
+        let bytes = character.encode_utf8(&mut utf8).as_bytes();
+        let must_encode =
+            character == '%' || character == ';' || character == '=' || character.is_control();
+        let encoded_len = if must_encode {
+            bytes.len() * 3
+        } else {
+            bytes.len()
+        };
+        if encoded.len() + encoded_len + TRUNCATION_MARKER.len() > limit {
+            encoded.push_str(TRUNCATION_MARKER);
+            return encoded;
+        }
+        if must_encode {
+            for byte in bytes {
+                encode_diagnostic_byte(&mut encoded, *byte);
+            }
+        } else {
+            encoded.push(character);
+        }
+    }
+    encoded
+}
+
+fn encode_diagnostic_byte(encoded: &mut String, byte: u8) {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    encoded.push('%');
+    encoded.push(HEX[(byte >> 4) as usize] as char);
+    encoded.push(HEX[(byte & 0x0f) as usize] as char);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compatibility_formatter_escapes_field_injection_and_bounds_cause() {
+        let formatted = format_storage_compatibility_refusal(
+            "current; current=fake",
+            "disk\non_disk=fake",
+            "act\raction=fake",
+            &"cause%=".repeat(2048),
+        );
+
+        for marker in ["current=", "on_disk=", "action=", "cause="] {
+            assert_eq!(formatted.matches(marker).count(), 1, "{formatted}");
+        }
+        assert!(!formatted.contains('\r') && !formatted.contains('\n'));
+        assert!(formatted.contains("current%3B current%3Dfake"));
+        assert!(formatted.contains("disk%0Aon_disk%3Dfake"));
+        assert!(formatted.contains("act%0Daction%3Dfake"));
+        assert!(formatted.ends_with(TRUNCATION_MARKER));
+        assert!(
+            formatted.len() < 7_000,
+            "bounded formatter grew unexpectedly"
+        );
+    }
 }

--- a/src/storage/src/redis.rs
+++ b/src/storage/src/redis.rs
@@ -47,7 +47,7 @@ use crate::custom_comparator::{
 use crate::data_compaction_filter::DataCompactionFilterFactory;
 use crate::error::Error::RedisErr;
 use crate::error::InvalidFormatSnafu;
-use crate::error::{IoSnafu, OptionNoneSnafu, Result, RocksSnafu};
+use crate::error::{IoSnafu, OptionNoneSnafu, Result, RocksSnafu, map_existing_strict_rocks_open};
 use crate::format_base_value::{DATA_TYPE_TAG, DataType};
 use crate::logindex::{
     FlushTrigger, LogIndexAndSequenceCollector, LogIndexAndSequenceCollectorPurger,
@@ -564,9 +564,12 @@ impl Redis {
             })
             .collect();
 
-        let db = RocksDbOwner::new(
-            DB::open_cf_descriptors(&db_opts, db_path, column_families).context(RocksSnafu)?,
-        );
+        let opened = DB::open_cf_descriptors(&db_opts, db_path, column_families);
+        let db = RocksDbOwner::new(if allow_manifest_creation {
+            opened.context(RocksSnafu)?
+        } else {
+            map_existing_strict_rocks_open(opened)?
+        });
         maybe_fail_redis_open(db_directory)?;
         let _ = db_once_cell.set(db.downgrade());
 

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -25,14 +25,17 @@ use kstd::lock_mgr::LockMgr;
 use snafu::ResultExt;
 use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock, mpsc};
 
-use crate::error::{Error, MpscSnafu, Result};
+use crate::error::{
+    Error, InvalidFormatSnafu, MpscSnafu, Result, format_storage_compatibility_refusal,
+    split_strict_rocks_open_cause,
+};
 use crate::expiration_manager::ExpirationManager;
 use crate::format_base_value::DataType;
 use crate::options::OptionType;
 use crate::slot_indexer::SlotIndexer;
 use crate::storage_manifest::{
-    MigrationPhase, RootStorageManifestV2, load_or_create_root_manifest,
-    validate_existing_instance_manifests,
+    MigrationPhase, OnDiskDescriptor, RootStorageManifestV2, current_storage_descriptor,
+    load_or_create_root_manifest, observe_on_disk_descriptor, validate_existing_instance_manifests,
 };
 use crate::storage_migration::{
     finalize_migration_after_storage_open, prepare_or_resume_migration,
@@ -45,6 +48,78 @@ pub enum TaskType {
     None = 0,
     CleanAll = 1,
     CompactRange = 2,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AdmissionStep {
+    MigrationPrepare,
+    RootManifestLoad,
+    InstanceValidation,
+    StrictInstanceOpen,
+    MigrationFinalize,
+}
+
+fn wrap_storage_compatibility_refusal<T>(
+    result: Result<T>,
+    root: &Path,
+    db_instance_num: usize,
+    step: AdmissionStep,
+) -> Result<T> {
+    match result {
+        Err(Error::InvalidFormat { message, .. }) => {
+            let (cause, strict_rocks_open) = split_strict_rocks_open_cause(message);
+            let on_disk = observe_on_disk_descriptor(root);
+            let action = compatibility_action(step, &on_disk, db_instance_num, strict_rocks_open);
+            Err(InvalidFormatSnafu {
+                message: format_storage_compatibility_refusal(
+                    &current_storage_descriptor(),
+                    &on_disk.render(strict_rocks_open),
+                    action,
+                    &cause,
+                ),
+            }
+            .build())
+        }
+        other => other,
+    }
+}
+
+fn compatibility_action(
+    step: AdmissionStep,
+    on_disk: &OnDiskDescriptor,
+    db_instance_num: usize,
+    strict_rocks_open: bool,
+) -> &'static str {
+    match on_disk {
+        OnDiskDescriptor::RootManifestPresentUnreadable | OnDiskDescriptor::Unavailable => {
+            "keep the directory offline; inspect it and restore from a verified backup"
+        }
+        OnDiskDescriptor::LegacyWithoutRootManifest
+            if step == AdmissionStep::MigrationPrepare && strict_rocks_open =>
+        {
+            "preserve the directory; current Kiwi already attempted staged migration, so fix the registered-profile cause before retrying"
+        }
+        OnDiskDescriptor::LegacyWithoutRootManifest => {
+            "preserve the directory; use a source-compatible binary for logical export, then import into empty current-v2 storage"
+        }
+        OnDiskDescriptor::RootManifest { .. } if on_disk.is_future_version() => {
+            "preserve the directory and use a compatible Kiwi version or restore a compatible backup"
+        }
+        OnDiskDescriptor::RootManifest { .. }
+            if on_disk.has_runtime_topology_mismatch(db_instance_num) =>
+        {
+            "preserve the directory; use the matching db_instance_num or a supported offline migration"
+        }
+        OnDiskDescriptor::RootManifest { .. } if strict_rocks_open => {
+            "preserve the directory and use a compatible Kiwi version or restore a compatible backup"
+        }
+        OnDiskDescriptor::Empty if step == AdmissionStep::MigrationPrepare => {
+            "preserve the directory and retry with the current Kiwi after checking the cause"
+        }
+        _ => {
+            "preserve the directory and follow the cause with a compatible version, staged migration, or verified backup"
+        }
+    }
 }
 
 impl From<u8> for TaskType {
@@ -232,23 +307,43 @@ impl Storage {
         db_path: impl AsRef<Path>,
     ) -> Result<mpsc::Receiver<BgTask>> {
         let db_path = db_path.as_ref();
-        prepare_or_resume_migration(db_path, self.db_instance_num, &options)?;
-        let mut root_load = load_or_create_root_manifest(db_path, self.db_instance_num)?;
-        validate_existing_instance_manifests(
+        wrap_storage_compatibility_refusal(
+            prepare_or_resume_migration(db_path, self.db_instance_num, &options),
             db_path,
-            &root_load.manifest,
-            root_load.created_this_call,
+            self.db_instance_num,
+            AdmissionStep::MigrationPrepare,
+        )?;
+        let mut root_load = wrap_storage_compatibility_refusal(
+            load_or_create_root_manifest(db_path, self.db_instance_num),
+            db_path,
+            self.db_instance_num,
+            AdmissionStep::RootManifestLoad,
+        )?;
+        wrap_storage_compatibility_refusal(
+            validate_existing_instance_manifests(
+                db_path,
+                &root_load.manifest,
+                root_load.created_this_call,
+            ),
+            db_path,
+            self.db_instance_num,
+            AdmissionStep::InstanceValidation,
         )?;
         let mut root_manifest = root_load.manifest;
 
         let (handler, receiver) = BgTaskHandler::new();
         let handler_arc = Arc::new(handler);
-        let mut opened_instances = self.open_instances(
-            Arc::clone(&options),
+        let mut opened_instances = wrap_storage_compatibility_refusal(
+            self.open_instances(
+                Arc::clone(&options),
+                db_path,
+                &root_manifest,
+                root_load.created_this_call,
+                &handler_arc,
+            ),
             db_path,
-            &root_manifest,
-            root_load.created_this_call,
-            &handler_arc,
+            self.db_instance_num,
+            AdmissionStep::StrictInstanceOpen,
         )?;
 
         let requires_runtime_finalize = root_manifest.migration().is_some_and(|transaction| {
@@ -259,20 +354,40 @@ impl Storage {
         });
         if requires_runtime_finalize {
             drop(opened_instances);
-            finalize_migration_after_storage_open(db_path, self.db_instance_num, &options)?;
-            root_load = load_or_create_root_manifest(db_path, self.db_instance_num)?;
-            validate_existing_instance_manifests(
+            wrap_storage_compatibility_refusal(
+                finalize_migration_after_storage_open(db_path, self.db_instance_num, &options),
                 db_path,
-                &root_load.manifest,
-                root_load.created_this_call,
+                self.db_instance_num,
+                AdmissionStep::MigrationFinalize,
+            )?;
+            root_load = wrap_storage_compatibility_refusal(
+                load_or_create_root_manifest(db_path, self.db_instance_num),
+                db_path,
+                self.db_instance_num,
+                AdmissionStep::MigrationFinalize,
+            )?;
+            wrap_storage_compatibility_refusal(
+                validate_existing_instance_manifests(
+                    db_path,
+                    &root_load.manifest,
+                    root_load.created_this_call,
+                ),
+                db_path,
+                self.db_instance_num,
+                AdmissionStep::MigrationFinalize,
             )?;
             root_manifest = root_load.manifest;
-            opened_instances = self.open_instances(
-                Arc::clone(&options),
+            opened_instances = wrap_storage_compatibility_refusal(
+                self.open_instances(
+                    Arc::clone(&options),
+                    db_path,
+                    &root_manifest,
+                    false,
+                    &handler_arc,
+                ),
                 db_path,
-                &root_manifest,
-                false,
-                &handler_arc,
+                self.db_instance_num,
+                AdmissionStep::MigrationFinalize,
             )?;
         }
 

--- a/src/storage/src/storage_manifest.rs
+++ b/src/storage/src/storage_manifest.rs
@@ -276,12 +276,10 @@ fn observe_root_manifest(path: &Path) -> OnDiskDescriptor {
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn open_manifest_for_observation(path: &Path) -> std::io::Result<fs::File> {
-    const O_NONBLOCK: i32 = 0x800;
-    const O_NOFOLLOW: i32 = 0x20000;
     record_diagnostic_manifest_open_attempt();
     OpenOptions::new()
         .read(true)
-        .custom_flags(O_NONBLOCK | O_NOFOLLOW)
+        .custom_flags(libc::O_NONBLOCK | libc::O_NOFOLLOW)
         .open(path)
 }
 
@@ -298,12 +296,10 @@ fn open_manifest_for_observation(path: &Path) -> std::io::Result<fs::File> {
     )
 ))]
 fn open_manifest_for_observation(path: &Path) -> std::io::Result<fs::File> {
-    const O_NONBLOCK: i32 = 0x4;
-    const O_NOFOLLOW: i32 = 0x100;
     record_diagnostic_manifest_open_attempt();
     OpenOptions::new()
         .read(true)
-        .custom_flags(O_NONBLOCK | O_NOFOLLOW)
+        .custom_flags(libc::O_NONBLOCK | libc::O_NOFOLLOW)
         .open(path)
 }
 

--- a/src/storage/src/storage_manifest.rs
+++ b/src/storage/src/storage_manifest.rs
@@ -18,9 +18,14 @@
 //! Durable root and per-instance storage manifests.
 
 use std::fs::{self, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt as _;
+#[cfg(windows)]
+use std::os::windows::fs::{MetadataExt as _, OpenOptionsExt as _};
 
 #[cfg(any(test, feature = "test-fault-injection"))]
 use std::collections::HashSet;
@@ -52,6 +57,299 @@ const ROLLBACK_FLOOR_MAX: u32 = 1;
 const PRODUCER_IDENTITY_PREFIX: &str = "kiwi-storage/v";
 const CURRENT_PRODUCER_IDENTITY: &str = "kiwi-storage/v2";
 const KNOWN_FEATURES: &[&str] = &["vector_set"];
+const DIAGNOSTIC_MANIFEST_MAX_BYTES: u64 = 64 * 1024;
+
+#[cfg(test)]
+thread_local! {
+    static DIAGNOSTIC_ROOT_ENTRY_VISITS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static DIAGNOSTIC_MANIFEST_OPEN_ATTEMPTS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn record_diagnostic_root_entry_visit() {
+    DIAGNOSTIC_ROOT_ENTRY_VISITS.set(DIAGNOSTIC_ROOT_ENTRY_VISITS.get() + 1);
+}
+
+#[cfg(not(test))]
+fn record_diagnostic_root_entry_visit() {}
+
+struct DiagnosticRootEntries {
+    inner: fs::ReadDir,
+}
+
+impl DiagnosticRootEntries {
+    fn new(inner: fs::ReadDir) -> Self {
+        Self { inner }
+    }
+}
+
+impl Iterator for DiagnosticRootEntries {
+    type Item = std::io::Result<fs::DirEntry>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        record_diagnostic_root_entry_visit();
+        self.inner.next()
+    }
+}
+
+#[cfg(test)]
+fn record_diagnostic_manifest_open_attempt() {
+    DIAGNOSTIC_MANIFEST_OPEN_ATTEMPTS.set(DIAGNOSTIC_MANIFEST_OPEN_ATTEMPTS.get() + 1);
+}
+
+#[cfg(not(test))]
+fn record_diagnostic_manifest_open_attempt() {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum OnDiskDescriptor {
+    Empty,
+    RootManifest {
+        manifest_version: u64,
+        storage_schema_version: u64,
+        db_instance_num: Option<u64>,
+        slot_mapping_version: Option<u64>,
+        slot_mapping_digest: Option<String>,
+        migration: Option<MigrationObservation>,
+    },
+    RootManifestPresentUnreadable,
+    LegacyWithoutRootManifest,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct MigrationObservation {
+    source_profile: String,
+    phase: String,
+    current_instance: u64,
+}
+
+#[derive(Deserialize)]
+struct RootManifestObservation {
+    manifest_version: u64,
+    storage_schema_version: u64,
+    #[serde(default)]
+    db_instance_num: Option<u64>,
+    #[serde(default)]
+    slot_mapping_version: Option<u64>,
+    #[serde(default)]
+    slot_mapping_digest: Option<String>,
+    #[serde(default)]
+    migration: Option<MigrationObservation>,
+}
+
+pub(crate) fn current_storage_descriptor() -> String {
+    format!(
+        "root-manifest-v{ROOT_STORAGE_MANIFEST_VERSION}/storage-schema-v{STORAGE_SCHEMA_VERSION_V2}/instance-manifest-v{INSTANCE_STORAGE_MANIFEST_VERSION}/slot-mapping-v{SLOT_MAPPING_VERSION}/cf-contract=storage-schema-v{STORAGE_SCHEMA_VERSION_V2}"
+    )
+}
+
+impl OnDiskDescriptor {
+    pub(crate) fn render(&self, strict_rocks_open: bool) -> String {
+        let mut descriptor = match self {
+            Self::Empty => "empty".to_string(),
+            Self::RootManifest {
+                manifest_version,
+                storage_schema_version,
+                migration,
+                ..
+            } => {
+                let mut value = format!(
+                    "root-manifest-v{manifest_version}/storage-schema-v{storage_schema_version}"
+                );
+                if let Some(migration) = migration {
+                    value.push_str(&format!(
+                        "/migration-source-{}/phase-{}/instance-{}",
+                        migration.source_profile, migration.phase, migration.current_instance
+                    ));
+                }
+                value
+            }
+            Self::RootManifestPresentUnreadable => "root-manifest-present-unreadable".to_string(),
+            Self::LegacyWithoutRootManifest => "legacy-without-root-manifest".to_string(),
+            Self::Unavailable => "unavailable".to_string(),
+        };
+        if strict_rocks_open {
+            descriptor.push_str("/rocksdb-strict-open=invalid-argument");
+        }
+        descriptor
+    }
+
+    pub(crate) fn is_future_version(&self) -> bool {
+        matches!(
+            self,
+            Self::RootManifest {
+                manifest_version,
+                storage_schema_version,
+                ..
+            } if *manifest_version > u64::from(ROOT_STORAGE_MANIFEST_VERSION)
+                || *storage_schema_version > u64::from(STORAGE_SCHEMA_VERSION_V2)
+        )
+    }
+
+    pub(crate) fn has_runtime_topology_mismatch(&self, db_instance_num: usize) -> bool {
+        let Self::RootManifest {
+            db_instance_num: Some(on_disk_count),
+            slot_mapping_version,
+            slot_mapping_digest: on_disk_digest,
+            ..
+        } = self
+        else {
+            return false;
+        };
+        *on_disk_count != db_instance_num as u64
+            || slot_mapping_version
+                .is_some_and(|version| version != u64::from(SLOT_MAPPING_VERSION))
+            || on_disk_digest
+                .as_deref()
+                .is_some_and(|digest| digest != slot_mapping_digest(db_instance_num).as_str())
+    }
+}
+
+pub(crate) fn observe_on_disk_descriptor(root: &Path) -> OnDiskDescriptor {
+    let root_metadata = match fs::symlink_metadata(root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return OnDiskDescriptor::Empty;
+        }
+        Err(_) => return OnDiskDescriptor::Unavailable,
+    };
+    if !root_metadata.file_type().is_dir() {
+        return OnDiskDescriptor::Unavailable;
+    }
+
+    let manifest_path = root.join(ROOT_STORAGE_MANIFEST_FILE);
+    match fs::symlink_metadata(&manifest_path) {
+        Ok(_) => observe_root_manifest(&manifest_path),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let mut entries = match fs::read_dir(root) {
+                Ok(entries) => DiagnosticRootEntries::new(entries),
+                Err(_) => return OnDiskDescriptor::Unavailable,
+            };
+            match entries.next() {
+                None => OnDiskDescriptor::Empty,
+                Some(Ok(_)) => OnDiskDescriptor::LegacyWithoutRootManifest,
+                Some(Err(_)) => OnDiskDescriptor::Unavailable,
+            }
+        }
+        Err(_) => OnDiskDescriptor::Unavailable,
+    }
+}
+
+fn observe_root_manifest(path: &Path) -> OnDiskDescriptor {
+    let file = match open_manifest_for_observation(path) {
+        Ok(file) => file,
+        Err(_) => return OnDiskDescriptor::RootManifestPresentUnreadable,
+    };
+    let held_metadata = match file.metadata() {
+        Ok(metadata) => metadata,
+        Err(_) => return OnDiskDescriptor::RootManifestPresentUnreadable,
+    };
+    if !held_metadata.file_type().is_file()
+        || held_metadata.len() > DIAGNOSTIC_MANIFEST_MAX_BYTES
+        || metadata_is_reparse_point(&held_metadata)
+    {
+        return OnDiskDescriptor::RootManifestPresentUnreadable;
+    }
+
+    let mut bytes = Vec::with_capacity(held_metadata.len() as usize + 1);
+    if file
+        .take(DIAGNOSTIC_MANIFEST_MAX_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .is_err()
+        || bytes.len() as u64 > DIAGNOSTIC_MANIFEST_MAX_BYTES
+    {
+        return OnDiskDescriptor::RootManifestPresentUnreadable;
+    }
+    let observation: RootManifestObservation = match serde_json::from_slice(&bytes) {
+        Ok(observation) => observation,
+        Err(_) => return OnDiskDescriptor::RootManifestPresentUnreadable,
+    };
+    OnDiskDescriptor::RootManifest {
+        manifest_version: observation.manifest_version,
+        storage_schema_version: observation.storage_schema_version,
+        db_instance_num: observation.db_instance_num,
+        slot_mapping_version: observation.slot_mapping_version,
+        slot_mapping_digest: observation.slot_mapping_digest,
+        migration: observation.migration,
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn open_manifest_for_observation(path: &Path) -> std::io::Result<fs::File> {
+    const O_NONBLOCK: i32 = 0x800;
+    const O_NOFOLLOW: i32 = 0x20000;
+    record_diagnostic_manifest_open_attempt();
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(O_NONBLOCK | O_NOFOLLOW)
+        .open(path)
+}
+
+#[cfg(all(
+    unix,
+    not(any(target_os = "linux", target_os = "android")),
+    any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "openbsd",
+        target_os = "netbsd"
+    )
+))]
+fn open_manifest_for_observation(path: &Path) -> std::io::Result<fs::File> {
+    const O_NONBLOCK: i32 = 0x4;
+    const O_NOFOLLOW: i32 = 0x100;
+    record_diagnostic_manifest_open_attempt();
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(O_NONBLOCK | O_NOFOLLOW)
+        .open(path)
+}
+
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "openbsd",
+        target_os = "netbsd"
+    ))
+))]
+fn open_manifest_for_observation(_path: &Path) -> std::io::Result<fs::File> {
+    record_diagnostic_manifest_open_attempt();
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "safe nofollow manifest observation is unavailable on this platform",
+    ))
+}
+
+#[cfg(windows)]
+fn open_manifest_for_observation(path: &Path) -> std::io::Result<fs::File> {
+    use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT;
+
+    record_diagnostic_manifest_open_attempt();
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+}
+
+#[cfg(unix)]
+fn metadata_is_reparse_point(_metadata: &fs::Metadata) -> bool {
+    false
+}
+
+#[cfg(windows)]
+fn metadata_is_reparse_point(metadata: &fs::Metadata) -> bool {
+    use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+
+    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
 
 #[cfg(any(test, feature = "test-fault-injection"))]
 static STORAGE_MANIFEST_PERSIST_FAILURES: LazyLock<ParkingMutex<HashSet<PathBuf>>> =
@@ -346,6 +644,60 @@ struct RootPayload<'a> {
     last_migrated_by: &'a str,
 }
 
+const CF_WIRE_FIELDS: &[&str] = &[
+    "stable_id",
+    "name",
+    "role",
+    "comparator_id",
+    "key_codec_version",
+    "value_codec_version",
+    "snapshot_read_min_version",
+    "snapshot_write_version",
+];
+
+fn first_raw_cf_contract_mismatch(bytes: &[u8]) -> Option<String> {
+    let root: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    let actual = root.get("column_families")?.as_array()?;
+    first_cf_contract_mismatch_in_values(actual)
+}
+
+fn first_typed_cf_contract_mismatch(actual: &[ColumnFamilySpec]) -> Option<String> {
+    let actual = actual
+        .iter()
+        .map(serde_json::to_value)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .ok()?;
+    first_cf_contract_mismatch_in_values(&actual)
+}
+
+fn first_cf_contract_mismatch_in_values(actual: &[serde_json::Value]) -> Option<String> {
+    for (index, expected) in CANONICAL_COLUMN_FAMILIES.iter().enumerate() {
+        let expected_value = serde_json::to_value(expected).ok()?;
+        let actual_value = actual.get(index)?;
+        for field in CF_WIRE_FIELDS {
+            let expected_field = expected_value.get(field);
+            let actual_field = actual_value.get(field);
+            if expected_field != actual_field {
+                return Some(format!(
+                    "root manifest CF index {index} name {} field {field} mismatch: current {} (expected), on-disk {} (actual)",
+                    expected.name,
+                    render_json_field(expected_field),
+                    render_json_field(actual_field)
+                ));
+            }
+        }
+    }
+    None
+}
+
+fn render_json_field(value: Option<&serde_json::Value>) -> String {
+    match value {
+        Some(serde_json::Value::String(value)) => value.clone(),
+        Some(value) => value.to_string(),
+        None => "<missing>".to_string(),
+    }
+}
+
 /// Root authority for storage topology, schema, snapshot compatibility, and migration intent.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -432,7 +784,11 @@ impl RootStorageManifestV2 {
         ensure!(
             self.column_families.len() == CANONICAL_COLUMN_FAMILIES.len(),
             InvalidFormatSnafu {
-                message: "root manifest column-family count mismatch".to_string()
+                message: format!(
+                    "root manifest column-family count mismatch: current/expected {}, on-disk/actual {}",
+                    CANONICAL_COLUMN_FAMILIES.len(),
+                    self.column_families.len()
+                )
             }
         );
         for (actual, expected) in self
@@ -488,12 +844,9 @@ impl RootStorageManifestV2 {
             }
         );
         self.slot_mapping_digest.validate()?;
-        ensure!(
-            self.column_families.as_slice() == CANONICAL_COLUMN_FAMILIES,
-            InvalidFormatSnafu {
-                message: "root manifest canonical column-family contract mismatch".to_string()
-            }
-        );
+        if let Some(message) = first_typed_cf_contract_mismatch(&self.column_families) {
+            return Err(InvalidFormatSnafu { message }.build());
+        }
         ensure!(
             self.snapshot_read_min_version == 1
                 && self.snapshot_read_max_version == 2
@@ -580,7 +933,8 @@ impl RootStorageManifestV2 {
     pub fn from_json_bytes(bytes: &[u8]) -> Result<Self> {
         let mut manifest: Self = serde_json::from_slice(bytes).map_err(|error| {
             InvalidFormatSnafu {
-                message: format!("invalid root storage manifest JSON: {error}"),
+                message: first_raw_cf_contract_mismatch(bytes)
+                    .unwrap_or_else(|| format!("invalid root storage manifest JSON: {error}")),
             }
             .build()
         })?;
@@ -1379,6 +1733,89 @@ mod tests {
     }
 
     #[test]
+    fn diagnostic_observer_rejects_nonregular_root_manifest() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        fs::create_dir(dir.path().join(ROOT_STORAGE_MANIFEST_FILE))
+            .expect("create manifest-shaped directory");
+
+        assert_eq!(
+            observe_on_disk_descriptor(dir.path()),
+            OnDiskDescriptor::RootManifestPresentUnreadable
+        );
+    }
+
+    #[test]
+    fn diagnostic_observer_reads_at_most_one_entry_when_manifest_is_missing() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        for name in ["first", "second", "third", "fourth"] {
+            fs::write(dir.path().join(name), b"legacy").expect("write legacy entry");
+        }
+        DIAGNOSTIC_ROOT_ENTRY_VISITS.set(0);
+
+        assert_eq!(
+            observe_on_disk_descriptor(dir.path()),
+            OnDiskDescriptor::LegacyWithoutRootManifest
+        );
+        assert_eq!(
+            DIAGNOSTIC_ROOT_ENTRY_VISITS.get(),
+            1,
+            "diagnostic observer must not enumerate a large legacy root"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn diagnostic_observer_opens_fifo_with_nonblocking_flag() {
+        use std::process::Command;
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let manifest_path = dir.path().join(ROOT_STORAGE_MANIFEST_FILE);
+        assert!(
+            Command::new("mkfifo")
+                .arg(&manifest_path)
+                .status()
+                .expect("run mkfifo")
+                .success()
+        );
+
+        let root = dir.path().to_path_buf();
+        let (sender, receiver) = mpsc::channel();
+        let observer = std::thread::spawn(move || {
+            DIAGNOSTIC_MANIFEST_OPEN_ATTEMPTS.set(0);
+            let descriptor = observe_on_disk_descriptor(&root);
+            sender
+                .send((descriptor, DIAGNOSTIC_MANIFEST_OPEN_ATTEMPTS.get()))
+                .expect("send observer result");
+        });
+
+        let result = match receiver.recv_timeout(Duration::from_secs(2)) {
+            Ok(result) => result,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                let writer = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(&manifest_path)
+                    .expect("unblock a mutant that omitted O_NONBLOCK");
+                let result = receiver
+                    .recv_timeout(Duration::from_secs(2))
+                    .expect("observer must finish after FIFO is unblocked");
+                drop(writer);
+                observer.join().expect("join blocked observer");
+                panic!("diagnostic observer blocked while opening FIFO: {result:?}");
+            }
+            Err(error) => panic!("observer channel failed: {error}"),
+        };
+        observer.join().expect("join observer");
+        assert_eq!(result.0, OnDiskDescriptor::RootManifestPresentUnreadable);
+        assert_eq!(
+            result.1, 1,
+            "FIFO must reach the O_NOFOLLOW/O_NONBLOCK open path"
+        );
+    }
+
+    #[test]
     fn root_preflight_rejects_orphan_or_unknown_entries() {
         let orphan_root = tempfile::tempdir().expect("temp dir");
         let orphan_manifest = root(orphan_root.path());
@@ -1465,11 +1902,11 @@ mod tests {
 
         let mut reordered = base.clone();
         reordered.column_families.swap(0, 1);
-        assert_root_contract_rejected(reordered, "canonical column-family");
+        assert_root_contract_rejected(reordered, "CF index");
 
         let mut duplicated = base;
         duplicated.column_families[1] = duplicated.column_families[0];
-        assert_root_contract_rejected(duplicated, "canonical column-family");
+        assert_root_contract_rejected(duplicated, "CF index");
     }
 
     #[test]

--- a/src/storage/src/storage_migration.rs
+++ b/src/storage/src/storage_migration.rs
@@ -40,7 +40,9 @@ use crate::custom_comparator::{
     zsets_score_key_compare,
 };
 use crate::durable_fs::{sync_directory, sync_parent_directory};
-use crate::error::{InvalidFormatSnafu, IoSnafu, Result, RocksSnafu};
+use crate::error::{
+    InvalidFormatSnafu, IoSnafu, Result, RocksSnafu, map_existing_strict_rocks_open,
+};
 use crate::storage_manifest::{
     InstanceStorageManifestV2, ManifestDigest, MigrationPhase, MigrationSourceProfile,
     MigrationTransaction, ROOT_STORAGE_MANIFEST_FILE, RootStorageManifestV2, SLOT_MAPPING_VERSION,
@@ -1844,8 +1846,11 @@ fn open_instance_strict(instance: &Path, options: &StorageOptions, names: &[&str
     let mut db_options = options.options.clone();
     db_options.create_if_missing(false);
     db_options.create_missing_column_families(false);
-    DB::open_cf_descriptors(&db_options, instance, descriptors_for(options, names))
-        .context(RocksSnafu)
+    map_existing_strict_rocks_open(DB::open_cf_descriptors(
+        &db_options,
+        instance,
+        descriptors_for(options, names),
+    ))
 }
 
 fn logical_cf_digest(db: &DB, cf_name: &str) -> Result<(u64, [u8; 32])> {

--- a/src/storage/tests/storage_manifest_v2_test.rs
+++ b/src/storage/tests/storage_manifest_v2_test.rs
@@ -18,7 +18,11 @@
 #![allow(clippy::unwrap_used)]
 
 use std::fs;
+use std::path::Path;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use rocksdb::{ColumnFamilyDescriptor, DB, Options};
 
 use storage::checkpoint::expected_column_families;
 use storage::logindex::cf_metadata;
@@ -27,7 +31,7 @@ use storage::{
     CANONICAL_COLUMN_FAMILIES, ColumnFamilyIndex, ColumnFamilyRole, ComparatorId,
     InstanceStorageManifestV2, ManifestDigest, MigrationPhase, MigrationSourceProfile,
     MigrationTransaction, ROOT_STORAGE_MANIFEST_FILE, RootStorageManifestV2, STORAGE_MANIFEST_FILE,
-    StorageOptions, canonical_column_family_names,
+    StorageOptions, canonical_column_family_names, slot_mapping_digest,
 };
 use tempfile::tempdir;
 
@@ -70,6 +74,121 @@ fn replace_once(bytes: &[u8], from: &str, to: &str) -> Vec<u8> {
         "fixture replacement must be unique"
     );
     text.replacen(from, to, 1).into_bytes()
+}
+
+fn refresh_manifest_digest(bytes: &[u8]) -> Vec<u8> {
+    let digest = ManifestDigest::compute_payload(bytes).unwrap();
+    let mut text = std::str::from_utf8(bytes).unwrap().to_string();
+    let marker = "\"digest\":\"";
+    let digest_start = text.rfind(marker).unwrap() + marker.len();
+    let digest_end = text[digest_start..].find('"').unwrap() + digest_start;
+    assert_eq!(
+        digest_end - digest_start,
+        64,
+        "fixture digest must be SHA-256"
+    );
+    text.replace_range(digest_start..digest_end, digest.as_str());
+    text.into_bytes()
+}
+
+fn replace_once_with_fresh_digest(bytes: &[u8], from: &str, to: &str) -> Vec<u8> {
+    refresh_manifest_digest(&replace_once(bytes, from, to))
+}
+
+fn runtime_root_manifest(db_instance_num: u32) -> RootStorageManifestV2 {
+    RootStorageManifestV2::new(
+        ROOT_MANIFEST_ID.parse().unwrap(),
+        db_instance_num,
+        1,
+        slot_mapping_digest(db_instance_num as usize),
+        None,
+    )
+    .unwrap()
+}
+
+async fn create_current_storage(root: &Path, db_instance_num: usize) {
+    let mut storage = Storage::new(db_instance_num, 0);
+    let receiver = storage
+        .open(Arc::new(StorageOptions::default()), root)
+        .unwrap();
+    drop(receiver);
+    storage.shutdown().await;
+    storage.close();
+}
+
+fn assert_storage_compatibility_refusal(
+    error: &storage::error::Error,
+    storage: &Storage,
+    expected_on_disk: &str,
+    expected_action: &str,
+    expected_cause_parts: &[&str],
+) {
+    let display = error.to_string();
+    assert_eq!(
+        display.matches("storage compatibility refusal:").count(),
+        1,
+        "compatibility envelope must appear exactly once: {display}"
+    );
+    for marker in ["current=", "on_disk=", "action=", "cause="] {
+        assert_eq!(
+            display.matches(marker).count(),
+            1,
+            "field {marker} must appear exactly once: {display}"
+        );
+        let start = display.find(marker).unwrap() + marker.len();
+        let end = display[start..]
+            .find("; ")
+            .map_or(display.len(), |offset| start + offset);
+        assert!(end > start, "field {marker} must not be empty: {display}");
+    }
+    let current = display.find("current=").unwrap();
+    let on_disk = display.find("on_disk=").unwrap();
+    let action = display.find("action=").unwrap();
+    let cause = display.find("cause=").unwrap();
+    assert!(
+        current < on_disk && on_disk < action && action < cause,
+        "diagnostic field order must be stable: {display}"
+    );
+    assert!(
+        !display.contains('\r') && !display.contains('\n'),
+        "diagnostic must remain a single line: {display:?}"
+    );
+    assert!(
+        display.contains(expected_on_disk),
+        "missing on-disk evidence {expected_on_disk:?}: {display}"
+    );
+    assert!(
+        display.contains(expected_action),
+        "missing action evidence {expected_action:?}: {display}"
+    );
+    for expected in expected_cause_parts {
+        assert!(
+            display.contains(expected),
+            "missing cause evidence {expected:?}: {display}"
+        );
+    }
+    assert!(storage.insts.is_empty(), "failed open published instances");
+    assert!(storage.db_path().is_none(), "failed open published db_path");
+    assert!(!storage.is_opened.load(Ordering::SeqCst));
+}
+
+fn create_v2_with_wrong_persisted_list_comparator(root_path: &Path) {
+    let instance_path = root_path.join("0");
+    fs::create_dir_all(&instance_path).unwrap();
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+    let descriptors = canonical_column_family_names()
+        .into_iter()
+        .map(|name| ColumnFamilyDescriptor::new(name, Options::default()));
+    let db = DB::open_cf_descriptors(&options, &instance_path, descriptors).unwrap();
+    drop(db);
+
+    let root = runtime_root_manifest(1);
+    root.write_to_dir_atomically(root_path).unwrap();
+    instance_manifest(0, &root)
+        .write_to_dir_atomically(&instance_path)
+        .unwrap();
 }
 
 #[test]
@@ -186,6 +305,303 @@ fn root_manifest_rejects_unknown_version_corrupt_digest_and_noncanonical_encodin
     );
 }
 
+#[tokio::test]
+async fn storage_open_reports_future_root_manifest_diagnostic_with_fresh_digest() {
+    let temp = tempdir().unwrap();
+    create_current_storage(temp.path(), 1).await;
+    let manifest_path = temp.path().join(ROOT_STORAGE_MANIFEST_FILE);
+    let original = fs::read(&manifest_path).unwrap();
+    let future = replace_once_with_fresh_digest(
+        &original,
+        "\"manifest_version\":2",
+        "\"manifest_version\":99",
+    );
+    fs::write(&manifest_path, &future).unwrap();
+
+    let mut storage = Storage::new(1, 0);
+    let error = storage
+        .open(Arc::new(StorageOptions::default()), temp.path())
+        .unwrap_err();
+    assert_storage_compatibility_refusal(
+        &error,
+        &storage,
+        "root-manifest-v99",
+        "compatible",
+        &["unsupported root storage manifest version 99"],
+    );
+    assert_eq!(fs::read(&manifest_path).unwrap(), future);
+}
+
+#[tokio::test]
+async fn storage_open_reports_future_instance_manifest_diagnostic_with_fresh_digest() {
+    let temp = tempdir().unwrap();
+    create_current_storage(temp.path(), 1).await;
+    let manifest_path = temp.path().join("0").join(STORAGE_MANIFEST_FILE);
+    let original = fs::read(&manifest_path).unwrap();
+    let future = replace_once_with_fresh_digest(
+        &original,
+        "\"manifest_version\":2",
+        "\"manifest_version\":99",
+    );
+    fs::write(&manifest_path, &future).unwrap();
+
+    let mut storage = Storage::new(1, 0);
+    let error = storage
+        .open(Arc::new(StorageOptions::default()), temp.path())
+        .unwrap_err();
+    assert_storage_compatibility_refusal(
+        &error,
+        &storage,
+        "root-manifest-v2",
+        "preserve",
+        &["unsupported instance storage manifest version 99"],
+    );
+    assert_eq!(fs::read(&manifest_path).unwrap(), future);
+}
+
+#[tokio::test]
+async fn storage_open_reports_each_root_cf_contract_mismatch() {
+    let cases = [
+        (
+            "\"name\":\"list_data_cf\"",
+            "\"name\":\"wrong_list_data_cf\"",
+            ["name", "list_data_cf", "wrong_list_data_cf"],
+        ),
+        (
+            "\"name\":\"list_data_cf\",\"role\":\"list_data\"",
+            "\"name\":\"list_data_cf\",\"role\":\"hash_data\"",
+            ["role", "list_data", "hash_data"],
+        ),
+        (
+            "\"role\":\"list_data\",\"comparator_id\":\"lists_data_key\"",
+            "\"role\":\"list_data\",\"comparator_id\":\"bytewise\"",
+            ["comparator_id", "lists_data_key", "bytewise"],
+        ),
+        (
+            "\"comparator_id\":\"lists_data_key\",\"key_codec_version\":1",
+            "\"comparator_id\":\"lists_data_key\",\"key_codec_version\":99",
+            ["key_codec_version", "current 1", "on-disk 99"],
+        ),
+        (
+            "\"name\":\"list_data_cf\",\"role\":\"list_data\",\"comparator_id\":\"lists_data_key\",\"key_codec_version\":1,\"value_codec_version\":1",
+            "\"name\":\"list_data_cf\",\"role\":\"list_data\",\"comparator_id\":\"lists_data_key\",\"key_codec_version\":1,\"value_codec_version\":99",
+            ["value_codec_version", "current 1", "on-disk 99"],
+        ),
+    ];
+
+    for (from, to, cause_parts) in cases {
+        let temp = tempdir().unwrap();
+        create_current_storage(temp.path(), 1).await;
+        let manifest_path = temp.path().join(ROOT_STORAGE_MANIFEST_FILE);
+        let original = fs::read(&manifest_path).unwrap();
+        let incompatible = replace_once_with_fresh_digest(&original, from, to);
+        fs::write(&manifest_path, &incompatible).unwrap();
+
+        let mut storage = Storage::new(1, 0);
+        let error = storage
+            .open(Arc::new(StorageOptions::default()), temp.path())
+            .unwrap_err();
+        assert_storage_compatibility_refusal(
+            &error,
+            &storage,
+            "root-manifest-v2",
+            "preserve",
+            &cause_parts,
+        );
+        assert_eq!(fs::read(&manifest_path).unwrap(), incompatible);
+    }
+}
+
+#[tokio::test]
+async fn storage_open_reports_current_v2_persisted_comparator_mismatch() {
+    let temp = tempdir().unwrap();
+    create_v2_with_wrong_persisted_list_comparator(temp.path());
+    let root_before = fs::read(temp.path().join(ROOT_STORAGE_MANIFEST_FILE)).unwrap();
+    let instance_before = fs::read(temp.path().join("0").join(STORAGE_MANIFEST_FILE)).unwrap();
+
+    let mut storage = Storage::new(1, 0);
+    let error = storage
+        .open(Arc::new(StorageOptions::default()), temp.path())
+        .unwrap_err();
+    assert_storage_compatibility_refusal(
+        &error,
+        &storage,
+        "rocksdb-strict-open%3Dinvalid-argument",
+        "compatible",
+        &["comparator", "floyd.ListsDataKeyComparator"],
+    );
+    assert!(!error.to_string().ends_with("cause=RocksDB error"));
+    assert_eq!(
+        fs::read(temp.path().join(ROOT_STORAGE_MANIFEST_FILE)).unwrap(),
+        root_before
+    );
+    assert_eq!(
+        fs::read(temp.path().join("0").join(STORAGE_MANIFEST_FILE)).unwrap(),
+        instance_before
+    );
+}
+
+#[tokio::test]
+async fn storage_open_does_not_relabel_rocksdb_lock_error() {
+    let temp = tempdir().unwrap();
+    let options = Arc::new(StorageOptions::default());
+    let mut owner = Storage::new(1, 0);
+    let owner_receiver = owner.open(Arc::clone(&options), temp.path()).unwrap();
+
+    let mut contender = Storage::new(1, 0);
+    let error = contender.open(options, temp.path()).unwrap_err();
+    assert!(matches!(&error, storage::error::Error::Rocks { .. }));
+    assert!(
+        !error.to_string().contains("storage compatibility refusal:"),
+        "LOCK/Busy must retain its Rocks category: {error}"
+    );
+    assert!(contender.insts.is_empty());
+    assert!(contender.db_path().is_none());
+    assert!(!contender.is_opened.load(Ordering::SeqCst));
+
+    drop(owner_receiver);
+    owner.close();
+}
+
+#[tokio::test]
+async fn storage_open_reports_oversized_root_manifest_as_bounded_unreadable() {
+    let temp = tempdir().unwrap();
+    let manifest_path = temp.path().join(ROOT_STORAGE_MANIFEST_FILE);
+    let mut oversized = br#"{"manifest_version":99,"storage_schema_version":2}"#.to_vec();
+    oversized.resize(1024 * 1024, b' ');
+    fs::write(&manifest_path, &oversized).unwrap();
+
+    let mut storage = Storage::new(1, 0);
+    let error = storage
+        .open(Arc::new(StorageOptions::default()), temp.path())
+        .unwrap_err();
+    assert_storage_compatibility_refusal(
+        &error,
+        &storage,
+        "root-manifest-present-unreadable",
+        "offline",
+        &["root storage manifest"],
+    );
+    assert_eq!(fs::metadata(&manifest_path).unwrap().len(), 1024 * 1024);
+}
+
+#[tokio::test]
+async fn storage_open_reports_regular_corrupt_root_manifest_as_unreadable() {
+    let temp = tempdir().unwrap();
+    let manifest_path = temp.path().join(ROOT_STORAGE_MANIFEST_FILE);
+    let corrupt = br#"{"manifest_version":"#.to_vec();
+    fs::write(&manifest_path, &corrupt).unwrap();
+
+    let mut storage = Storage::new(1, 0);
+    let error = storage
+        .open(Arc::new(StorageOptions::default()), temp.path())
+        .unwrap_err();
+    assert_storage_compatibility_refusal(
+        &error,
+        &storage,
+        "root-manifest-present-unreadable",
+        "offline",
+        &["invalid root storage manifest JSON", "EOF"],
+    );
+    assert_eq!(fs::read(&manifest_path).unwrap(), corrupt);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn storage_open_observer_does_not_follow_root_manifest_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir().unwrap();
+    let external = tempdir().unwrap();
+    let target = external.path().join("future-root.json");
+    let current = runtime_root_manifest(1).to_json_bytes().unwrap();
+    let future = replace_once_with_fresh_digest(
+        &current,
+        "\"manifest_version\":2",
+        "\"manifest_version\":99",
+    );
+    fs::write(&target, &future).unwrap();
+    symlink(&target, temp.path().join(ROOT_STORAGE_MANIFEST_FILE)).unwrap();
+
+    let mut storage = Storage::new(1, 0);
+    let error = storage
+        .open(Arc::new(StorageOptions::default()), temp.path())
+        .unwrap_err();
+    assert_storage_compatibility_refusal(
+        &error,
+        &storage,
+        "root-manifest-present-unreadable",
+        "offline",
+        &["unsupported root storage manifest version 99"],
+    );
+    assert_eq!(fs::read(&target).unwrap(), future);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn storage_open_observer_does_not_block_reopening_root_manifest_fifo() {
+    use std::os::unix::fs::FileTypeExt;
+    use std::process::Command;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    let temp = tempdir().unwrap();
+    let manifest_path = temp.path().join(ROOT_STORAGE_MANIFEST_FILE);
+    assert!(
+        Command::new("mkfifo")
+            .arg(&manifest_path)
+            .status()
+            .unwrap()
+            .success()
+    );
+    let writer_path = manifest_path.clone();
+    let writer = thread::spawn(move || fs::write(writer_path, b"not-json").unwrap());
+    let root = temp.path().to_path_buf();
+    let (sender, receiver) = mpsc::channel();
+    let opener = thread::spawn(move || {
+        let mut storage = Storage::new(1, 0);
+        let error = storage
+            .open(Arc::new(StorageOptions::default()), &root)
+            .unwrap_err();
+        assert_storage_compatibility_refusal(
+            &error,
+            &storage,
+            "root-manifest-present-unreadable",
+            "offline",
+            &["invalid root storage manifest JSON"],
+        );
+        sender.send(()).unwrap();
+    });
+
+    match receiver.recv_timeout(Duration::from_secs(2)) {
+        Ok(()) => {}
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            let unblocker = fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&manifest_path)
+                .expect("unblock a mutant that omitted O_NONBLOCK");
+            receiver
+                .recv_timeout(Duration::from_secs(2))
+                .expect("Storage::open must finish after FIFO is unblocked");
+            drop(unblocker);
+            opener.join().expect("join blocked Storage::open");
+            writer.join().expect("join initial FIFO writer");
+            panic!("Storage::open observer blocked while reopening the FIFO");
+        }
+        Err(error) => panic!("Storage::open observer channel failed: {error}"),
+    }
+    opener.join().expect("join Storage::open");
+    writer.join().expect("join initial FIFO writer");
+    assert!(
+        fs::symlink_metadata(&manifest_path)
+            .unwrap()
+            .file_type()
+            .is_fifo()
+    );
+}
+
 #[test]
 fn instance_manifest_rejects_wrong_instance_id_or_root_digest() {
     let root = root_manifest(2);
@@ -271,9 +687,12 @@ async fn existing_root_missing_instance_directory_fails_closed_without_recreatio
 
     let mut reopened = Storage::new(2, 0);
     let error = reopened.open(options, temp.path()).unwrap_err();
-    assert!(
-        error.to_string().contains("instance") && error.to_string().contains("missing"),
-        "unexpected error: {error}"
+    assert_storage_compatibility_refusal(
+        &error,
+        &reopened,
+        "root-manifest-v2",
+        "preserve",
+        &["instance", "missing"],
     );
     assert!(
         !missing.exists(),
@@ -300,9 +719,12 @@ async fn existing_root_without_any_instance_directories_fails_closed() {
     let error = storage
         .open(Arc::new(StorageOptions::default()), temp.path())
         .unwrap_err();
-    assert!(
-        error.to_string().contains("instance") && error.to_string().contains("missing"),
-        "unexpected error: {error}"
+    assert_storage_compatibility_refusal(
+        &error,
+        &storage,
+        "root-manifest-v2",
+        "preserve",
+        &["instance", "missing"],
     );
     assert!(!temp.path().join("0").exists());
     assert!(!temp.path().join("1").exists());
@@ -441,9 +863,12 @@ fn storage_open_rejects_instance_count_or_slot_mapping_mismatch() {
     let count_error = wrong_count
         .open(Arc::clone(&options), count_temp.path())
         .unwrap_err();
-    assert!(
-        count_error.to_string().contains("db_instance_num"),
-        "unexpected error: {count_error}"
+    assert_storage_compatibility_refusal(
+        &count_error,
+        &wrong_count,
+        "root-manifest-v2",
+        "db_instance_num",
+        &["db_instance_num"],
     );
     assert!(wrong_count.insts.is_empty());
     assert!(
@@ -466,9 +891,12 @@ fn storage_open_rejects_instance_count_or_slot_mapping_mismatch() {
         .unwrap();
     let mut storage = Storage::new(2, 0);
     let mapping_error = storage.open(options, mapping_temp.path()).unwrap_err();
-    assert!(
-        mapping_error.to_string().contains("slot mapping"),
-        "unexpected error: {mapping_error}"
+    assert_storage_compatibility_refusal(
+        &mapping_error,
+        &storage,
+        "root-manifest-v2",
+        "db_instance_num",
+        &["slot mapping"],
     );
     assert!(storage.insts.is_empty());
     assert!(!storage.is_opened.load(std::sync::atomic::Ordering::SeqCst));

--- a/src/storage/tests/storage_migration_test.rs
+++ b/src/storage/tests/storage_migration_test.rs
@@ -360,7 +360,16 @@ fn storage_open_reports_base_v1_persisted_comparator_mismatch_before_journal() {
 #[test]
 fn storage_open_escapes_field_injection_from_legacy_path() {
     let temp = tempfile::tempdir().expect("field injection root");
-    let injected_name = "bad; current=fake\ncause=fake";
+    #[cfg(unix)]
+    let (injected_name, escaped_name) = (
+        "bad; current=fake\ncause=fake",
+        "%3B current%3Dfake%0Acause%3Dfake",
+    );
+    #[cfg(not(unix))]
+    let (injected_name, escaped_name) = (
+        "bad; current=fake%cause=fake",
+        "%3B current%3Dfake%25cause%3Dfake",
+    );
     std::fs::write(temp.path().join(injected_name), b"unexpected").expect("write unexpected entry");
 
     let runtime = tokio::runtime::Runtime::new().expect("runtime");
@@ -374,7 +383,7 @@ fn storage_open_escapes_field_injection_from_legacy_path() {
         &storage,
         "legacy-without-root-manifest",
         "logical export",
-        &["%3B current%3Dfake%0Acause%3Dfake"],
+        &[escaped_name],
     );
     assert!(temp.path().join(injected_name).is_file());
 }

--- a/src/storage/tests/storage_migration_test.rs
+++ b/src/storage/tests/storage_migration_test.rs
@@ -32,7 +32,10 @@ use storage::{
 };
 use uuid::Uuid;
 
-use support::legacy_storage::{VECTOR_CF_NAMES, create_legacy_root, list_cf, read_sentinel};
+use support::legacy_storage::{
+    VECTOR_CF_NAMES, create_base_v1_root_with_wrong_list_comparator, create_legacy_root, list_cf,
+    read_sentinel,
+};
 use support::vector_v1_storage::{
     create_vector_v1_root, rewrite_first_member_incarnation, vector_member_key,
     vector_member_value, vector_meta_key, vector_meta_value,
@@ -57,6 +60,49 @@ fn open_storage(root: &std::path::Path, instance_count: usize) -> Result<(), Str
     drop(receiver);
     storage.close();
     Ok(())
+}
+
+fn assert_storage_compatibility_refusal(
+    error: &storage::error::Error,
+    storage: &storage::storage::Storage,
+    expected_on_disk: &str,
+    expected_action: &str,
+    expected_cause_parts: &[&str],
+) {
+    let display = error.to_string();
+    assert_eq!(
+        display.matches("storage compatibility refusal:").count(),
+        1,
+        "compatibility envelope must appear exactly once: {display}"
+    );
+    for marker in ["current=", "on_disk=", "action=", "cause="] {
+        assert_eq!(
+            display.matches(marker).count(),
+            1,
+            "field {marker} must appear exactly once: {display}"
+        );
+    }
+    assert!(
+        !display.contains('\r') && !display.contains('\n'),
+        "diagnostic must remain one line: {display:?}"
+    );
+    assert!(
+        display.contains(expected_on_disk),
+        "unexpected error: {display}"
+    );
+    assert!(
+        display.contains(expected_action),
+        "unexpected error: {display}"
+    );
+    for expected in expected_cause_parts {
+        assert!(
+            display.contains(expected),
+            "missing cause evidence {expected:?}: {display}"
+        );
+    }
+    assert!(storage.insts.is_empty());
+    assert!(storage.db_path().is_none());
+    assert!(!storage.is_opened.load(std::sync::atomic::Ordering::SeqCst));
 }
 
 #[test]
@@ -230,6 +276,107 @@ fn unknown_cf_partial_manifest_or_mixed_v1_v2_fails_before_shadow_creation() {
     });
     assert!(classify_storage_root(partial.path(), 1, &options).is_err());
     assert!(!partial.path().join(ROOT_STORAGE_MANIFEST_FILE).exists());
+}
+
+#[test]
+fn storage_open_reports_unregistered_legacy_cf_before_journal_creation() {
+    let temp = tempfile::tempdir().expect("unknown legacy root");
+    create_legacy_root(temp.path(), 1, false);
+    {
+        let instance = temp.path().join("0");
+        let mut db_options = Options::default();
+        db_options.create_if_missing(false);
+        db_options.create_missing_column_families(false);
+        let db = DB::open_cf_descriptors(
+            &db_options,
+            &instance,
+            support::legacy_storage::descriptors(&support::legacy_storage::BASE_CF_NAMES),
+        )
+        .expect("open Base-v1 fixture");
+        db.create_cf("unknown_cf", &Options::default())
+            .expect("create unknown CF");
+    }
+    let cf_before = list_cf(&temp.path().join("0"));
+
+    let runtime = tokio::runtime::Runtime::new().expect("runtime");
+    let _runtime_guard = runtime.enter();
+    let mut storage = storage::storage::Storage::new(1, 0);
+    let error = storage
+        .open(Arc::new(StorageOptions::default()), temp.path())
+        .expect_err("unregistered legacy CF must fail production admission");
+    assert_storage_compatibility_refusal(
+        &error,
+        &storage,
+        "legacy-without-root-manifest",
+        "logical export",
+        &["unregistered legacy column-family layout", "unknown_cf"],
+    );
+    assert_eq!(list_cf(&temp.path().join("0")), cf_before);
+    assert!(!temp.path().join(ROOT_STORAGE_MANIFEST_FILE).exists());
+    assert!(
+        std::fs::read_dir(temp.path())
+            .expect("read legacy root")
+            .all(|entry| {
+                let name = entry.expect("root entry").file_name();
+                let name = name.to_string_lossy();
+                !name.starts_with(".kiwi-shadow-") && !name.starts_with(".kiwi-backup-")
+            })
+    );
+}
+
+#[test]
+fn storage_open_reports_base_v1_persisted_comparator_mismatch_before_journal() {
+    let temp = tempfile::tempdir().expect("wrong comparator legacy root");
+    create_base_v1_root_with_wrong_list_comparator(temp.path());
+    let cf_before = list_cf(&temp.path().join("0"));
+
+    let runtime = tokio::runtime::Runtime::new().expect("runtime");
+    let _runtime_guard = runtime.enter();
+    let mut storage = storage::storage::Storage::new(1, 0);
+    let error = storage
+        .open(Arc::new(StorageOptions::default()), temp.path())
+        .expect_err("wrong persisted legacy comparator must fail before migration journal");
+    assert_storage_compatibility_refusal(
+        &error,
+        &storage,
+        "rocksdb-strict-open%3Dinvalid-argument",
+        "current Kiwi already attempted staged migration",
+        &["comparator", "floyd.ListsDataKeyComparator"],
+    );
+    assert!(!error.to_string().ends_with("cause=RocksDB error"));
+    assert_eq!(list_cf(&temp.path().join("0")), cf_before);
+    assert!(!temp.path().join(ROOT_STORAGE_MANIFEST_FILE).exists());
+    assert!(
+        std::fs::read_dir(temp.path())
+            .expect("read legacy root")
+            .all(|entry| {
+                let name = entry.expect("root entry").file_name();
+                let name = name.to_string_lossy();
+                !name.starts_with(".kiwi-shadow-") && !name.starts_with(".kiwi-backup-")
+            })
+    );
+}
+
+#[test]
+fn storage_open_escapes_field_injection_from_legacy_path() {
+    let temp = tempfile::tempdir().expect("field injection root");
+    let injected_name = "bad; current=fake\ncause=fake";
+    std::fs::write(temp.path().join(injected_name), b"unexpected").expect("write unexpected entry");
+
+    let runtime = tokio::runtime::Runtime::new().expect("runtime");
+    let _runtime_guard = runtime.enter();
+    let mut storage = storage::storage::Storage::new(1, 0);
+    let error = storage
+        .open(Arc::new(StorageOptions::default()), temp.path())
+        .expect_err("unexpected legacy path must fail production admission");
+    assert_storage_compatibility_refusal(
+        &error,
+        &storage,
+        "legacy-without-root-manifest",
+        "logical export",
+        &["%3B current%3Dfake%0Acause%3Dfake"],
+    );
+    assert!(temp.path().join(injected_name).is_file());
 }
 
 #[test]
@@ -476,6 +623,18 @@ fn run_fault_retry(
     let _guard = fail_next_storage_migration(temp.path(), fault);
     let error = open_storage(temp.path(), 2).expect_err("migration fault must stop admission");
     assert!(error.contains("injected storage migration failure"));
+    assert_eq!(
+        error.matches("storage compatibility refusal:").count(),
+        1,
+        "production migration fault must cross the admission envelope exactly once: {error}"
+    );
+    for marker in ["current=", "on_disk=", "action=", "cause="] {
+        assert_eq!(
+            error.matches(marker).count(),
+            1,
+            "production migration fault is missing {marker}: {error}"
+        );
+    }
 
     let interrupted = RootStorageManifestV2::read_from_dir(temp.path()).expect("journal");
     let transaction = interrupted.migration().expect("migration transaction");
@@ -1451,7 +1610,13 @@ async fn live_open_rejects_missing_vector_cf_instead_of_creating_it() {
     let error = storage
         .open(Arc::new(StorageOptions::default()), temp.path())
         .expect_err("live open must not add the missing Vector CF");
-    assert!(error.to_string().contains("RocksDB") || error.to_string().contains("column family"));
+    assert_storage_compatibility_refusal(
+        &error,
+        &storage,
+        "rocksdb-strict-open%3Dinvalid-argument",
+        "compatible",
+        &["Column family", "vector_data_cf"],
+    );
     let mut expected: Vec<String> = support::legacy_storage::BASE_CF_NAMES
         .iter()
         .map(|name| (*name).to_string())

--- a/src/storage/tests/support/legacy_storage.rs
+++ b/src/storage/tests/support/legacy_storage.rs
@@ -104,6 +104,27 @@ pub fn create_legacy_root(root: &Path, instance_count: usize, vector: bool) {
     }
 }
 
+pub fn create_base_v1_root_with_wrong_list_comparator(root: &Path) {
+    std::fs::create_dir_all(root).expect("create legacy root");
+    let instance = root.join("0");
+    let descriptors = BASE_CF_NAMES.iter().map(|name| {
+        let options = if *name == "list_data_cf" {
+            Options::default()
+        } else {
+            cf_options(name)
+        };
+        ColumnFamilyDescriptor::new(*name, options)
+    });
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+    let db = DB::open_cf_descriptors(&options, &instance, descriptors)
+        .expect("create Base-v1 RocksDB with wrong persisted list comparator");
+    let default = db.cf_handle("default").expect("default CF");
+    db.put_cf(&default, b"string:alpha", b"value-0")
+        .expect("write Base-v1 sentinel");
+}
+
 pub fn list_cf(instance: &Path) -> Vec<String> {
     let mut names = DB::list_cf(&Options::default(), instance).expect("list column families");
     names.sort();


### PR DESCRIPTION
## Summary

- add a bounded four-field `Storage::open` compatibility-refusal envelope with `current`, `on_disk`, `action`, and original `cause`
- preserve detailed RocksDB comparator/CF errors only at the two existing strict-open admission points while leaving LOCK/Busy/I/O and other Rocks errors unchanged
- observe root manifests through bounded held handles with nofollow/nonblock/reparse protections and one-entry root classification
- report the first canonical CF mismatch and distinguish registered staged migration from unknown legacy recovery actions
- add real RocksDB and filesystem regression coverage for future/corrupt manifests, comparator drift, unknown legacy layouts, symlink/FIFO/oversize inputs, field injection, and non-publication on failure

## Verification

- `cargo test -p storage --test storage_manifest_v2_test` (21 passed)
- `cargo test -p storage --features test-fault-injection --test storage_migration_test` (45 passed)
- `cargo clippy -p storage --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- independent review: P0=0, P1=0, P2=0; Test Guard PASS

Refs #342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added structured storage compatibility diagnostics showing current format, detected on-disk format, cause, and recommended action.
  - Added safe detection for legacy, future, corrupted, unreadable, and incompatible storage layouts.
  - Added clearer reporting for column-family and comparator mismatches.

- **Bug Fixes**
  - Preserved original storage errors while providing actionable compatibility details.
  - Prevented diagnostic inspection from modifying storage or creating partial state.
  - Improved handling of malformed, oversized, linked, and non-regular manifest files.

- **Documentation**
  - Added implementation and design documentation for storage compatibility diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->